### PR TITLE
Significant Rebalances

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -28976,10 +28976,6 @@
 /area/f13/brotherhood)
 "bAN" = (
 /obj/structure/bodycontainer/crematorium,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
@@ -29469,10 +29465,6 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "bBO" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
 /obj/item/detective_scanner,
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -29481,7 +29473,7 @@
 	},
 /area/f13/brotherhood)
 "bBP" = (
-/obj/structure/table,
+/obj/item/wallframe/light_fixture/small,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
@@ -29778,9 +29770,6 @@
 /area/f13/brotherhood)
 "bCB" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /turf/open/floor/f13{
@@ -29959,8 +29948,10 @@
 	},
 /area/f13/brotherhood)
 "bCZ" = (
-/obj/machinery/sleeper,
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/brotherhood)
 "bDa" = (
 /obj/structure/table/glass,
@@ -29995,11 +29986,15 @@
 	},
 /area/f13/brotherhood)
 "bDh" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/smes,
+/turf/open/floor/plating,
 /area/f13/brotherhood)
 "bDi" = (
 /obj/docking_port/stationary/bosaway,
@@ -30190,13 +30185,8 @@
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
 "bDM" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
-	},
+/obj/item/wallframe/light_fixture,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/brotherhood)
 "bDN" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
@@ -30363,15 +30353,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/brotherhood)
 "bEm" = (
-/obj/machinery/chem_dispenser,
+/obj/structure/table,
+/obj/item/wallframe/light_fixture,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
 /area/f13/brotherhood)
 "bEn" = (
-/obj/machinery/chem_master,
-/turf/open/floor/plasteel/f13{
-	icon_state = "whitebluechess"
+/obj/structure/table,
+/obj/item/wallframe/light_fixture/small,
+/obj/item/wallframe/light_fixture/small,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
 /area/f13/brotherhood)
 "bEo" = (
@@ -30441,14 +30435,8 @@
 /turf/open/floor/plating,
 /area/f13/brotherhood)
 "bEA" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/brotherhood)
 "bEB" = (
 /obj/machinery/power/apc{
@@ -30656,9 +30644,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "bFd" = (
-/obj/structure/closet/crate/rcd,
-/obj/item/construction/rld,
-/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/f13{
+	icon_state = "whitebluechess"
+	},
 /area/f13/brotherhood)
 "bFe" = (
 /obj/machinery/light{
@@ -30752,7 +30741,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "bFr" = (
-/obj/machinery/computer/operating,
+/obj/structure/frame/computer,
+/obj/item/circuitboard/computer/operating,
 /turf/open/floor/plasteel/f13{
 	icon_state = "whitebluechess"
 	},
@@ -31133,10 +31123,6 @@
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/brotherhood)
-"bGB" = (
-/mob/living/simple_animal/hostile/spawner/scorpion,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "bGF" = (
 /obj/structure/simple_door/metal/fence{
 	dir = 8;
@@ -65673,7 +65659,7 @@ aae
 aae
 aae
 aaa
-aaB
+aaY
 aaB
 aae
 aae
@@ -66702,7 +66688,7 @@ aak
 aak
 aaA
 aaB
-aaB
+aaY
 aaA
 aaa
 aae
@@ -67216,7 +67202,7 @@ aak
 aae
 aaa
 aaB
-bGB
+aaB
 aae
 aae
 aae
@@ -70556,7 +70542,7 @@ aae
 aae
 aae
 aaA
-aaB
+aaY
 aaB
 aaA
 aae
@@ -164624,9 +164610,9 @@ bAD
 bAD
 bAD
 bAD
+bBE
 bBF
-bBF
-bBF
+bDm
 bAD
 bAD
 bAD
@@ -169002,7 +168988,7 @@ bAD
 bAD
 bAD
 bAD
-bEA
+bDh
 bEO
 bFa
 bFk
@@ -169259,7 +169245,7 @@ bDJ
 bDT
 bEg
 bAD
-bEA
+bDh
 bEO
 bFb
 bFl
@@ -171574,7 +171560,7 @@ bDz
 bDz
 bDz
 bER
-bFd
+bDz
 bFq
 bAD
 bBF
@@ -172849,13 +172835,13 @@ bCz
 bAM
 bCL
 bAD
-bCZ
-bDh
+bEA
+bBa
+bDM
 bBa
 bBa
 bBa
-bBa
-bDh
+bDM
 bEu
 bEE
 bDC
@@ -173363,7 +173349,7 @@ bAD
 bAD
 bAD
 bAD
-bCZ
+bEA
 bBa
 bBa
 bBa
@@ -173870,15 +173856,15 @@ bAM
 bAM
 bAM
 bAD
-bBP
+bEn
 bAM
 bAM
 bAM
 bBD
 bBa
+bDM
 bBa
 bBa
-bBb
 bBa
 bBa
 bBa
@@ -174397,7 +174383,7 @@ bDr
 bDC
 bDC
 bDC
-bEm
+bFd
 bAD
 bEG
 bAM
@@ -174636,7 +174622,7 @@ aaa
 aae
 bAD
 bAO
-bAM
+bBP
 bAM
 bAM
 bBq
@@ -174654,7 +174640,7 @@ bDr
 bDC
 bDC
 bEb
-bEn
+bFd
 bAD
 bCh
 bAM
@@ -174909,8 +174895,8 @@ bDd
 bAD
 bDs
 bDr
-bDM
-bDr
+bCZ
+bEm
 bDr
 bAD
 bBU

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -623,8 +623,8 @@
 
 	var/loot6 = list(
 				/obj/item/gun/ballistic/shotgun/remington,
-				/obj/item/ammo_box/a308,
-				/obj/item/ammo_box/a308
+				/obj/item/ammo_box/a762,
+				/obj/item/ammo_box/a762
 				)
 
 	var/loot7 = list(
@@ -678,8 +678,8 @@
 
 	var/loot3 = list(
 				/obj/item/gun/ballistic/shotgun/remington/scoped,
-				/obj/item/ammo_box/a308,
-				/obj/item/ammo_box/a308
+				/obj/item/ammo_box/a762,
+				/obj/item/ammo_box/a762
 				)
 
 	var/loot4 = list(
@@ -958,8 +958,7 @@
 
 	loot = list(
 				/obj/item/ammo_box/magazine/m45,
-				/obj/item/ammo_box/a762,
-        		/obj/item/ammo_box/a308,
+        		/obj/item/ammo_box/a762,
 				/obj/item/ammo_box/magazine/m10mm_adv,
 				/obj/item/ammo_box/magazine/m556/rifle,
 				/obj/item/ammo_box/c38,

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -20,7 +20,7 @@
 	name = "\improper Goliath" //the Goliath
 	desc = "A metal gauntlet with a piston-powered ram on top. This one has been painted in the colors of Caesar's Legion, and features a brutal metal spike to increase penetration and damage."
 	icon_state = "goliath"
-	force = 40 //you are Strongly Encouraged not to get hit by this.
+	force = 60 //you are Strongly Encouraged not to get hit by this.
 	armour_penetration = 80 //what is armor?
 	throwforce = 20
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -923,8 +923,8 @@
 	icon_state = "sledgehammer0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	force_unwielded = 20
-	force_wielded = 45
+	force_unwielded = 12//Likely not able to hit too hard with those noodle arms, bro.
+	force_wielded = 62
 	throwforce = 20
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
@@ -955,7 +955,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	force_unwielded = 25
-	force_wielded = 60
+	force_wielded = 72
 
 /obj/item/twohanded/sledgehammer/supersledge/update_icon()
 	icon_state = "supersledge[wielded]"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -598,16 +598,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
-/datum/crafting_recipe/a556sport
-	name = "5.56 match ammo box"
-	result = /obj/item/ammo_box/a556/sport
-	reqs = list(/obj/item/stack/sheet/metal = 15,
-				/datum/reagent/blackpowder = 40)
-	tools = list(TOOL_WORKBENCH)
-	time = 10
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
 /datum/crafting_recipe/c9mm
 	name = "9mm FMJ ammo box"
 	result = /obj/item/ammo_box/c9mm
@@ -668,16 +658,6 @@
 	traits = list(TRAIT_GUNSMITH_TWO)
 	tools = list(TOOL_WORKBENCH, TOOL_GUNTIER2)
 	time = 10
-	category = CAT_WEAPONRY
-	subcategory = CAT_AMMO
-
-/datum/crafting_recipe/a308
-	name = ".308 ammo box"
-	result = /obj/item/ammo_box/a308box
-	reqs = list(/obj/item/stack/sheet/metal = 7,
-				/datum/reagent/blackpowder = 40)
-	traits = list(TRAIT_GUNSMITH_ONE)
-	tools = list(TOOL_WORKBENCH, TOOL_GUNTIER1)
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 

--- a/code/modules/fallout/mob/simple_animal/mobs/supermutant.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/supermutant.dm
@@ -90,7 +90,7 @@
 	minimum_distance = 6
 	projectiletype = /obj/item/projectile/bullet/F13/c308mmBullet
 	projectilesound = 'sound/f13weapons/hunting_rifle.ogg'
-	loot = list(/obj/item/ammo_box/a308)
+	loot = list(/obj/item/ammo_box/a762)
 
 /mob/living/simple_animal/hostile/supermutant/rangedmutant/death(gibbed)
 	icon = 'icons/fallout/mobs/supermutant_dead.dmi'

--- a/code/modules/fallout/obj/trash_stack.dm
+++ b/code/modules/fallout/obj/trash_stack.dm
@@ -78,7 +78,7 @@
 		/obj/item/ammo_box/magazine/m556/rifle, /obj/item/ammo_box/magazine/greasegun,
 		/obj/item/ammo_box/m44,/obj/item/ammo_box/magazine/m45,
 		/obj/item/reagent_containers/pill/patch/healingpowder, /obj/item/ammo_box/a762,
-		/obj/item/ammo_box/a308, /obj/item/ammo_box/a762/doublestacked,
+		/obj/item/ammo_box/a762/doublestacked,
 		/obj/item/ammo_box/c9mm, /obj/item/ammo_box/c10mm,
 		/obj/item/ammo_box/a556, /obj/item/ammo_box/c45,
 		/obj/item/storage/pill_bottle/chem_tin/mentats, /obj/item/storage/pill_bottle/chem_tin/fixer,

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -330,7 +330,7 @@ Corporal
 	suit_store = /obj/item/gun/ballistic/shotgun/remington/scoped
 	head = /obj/item/clothing/head/beret/ncr_scout
 	backpack_contents = list(
-		/obj/item/ammo_box/a308=3,
+		/obj/item/ammo_box/a762=3,
 		/obj/item/twohanded/binocs=1
 		)
 /*
@@ -473,7 +473,7 @@ Trooper
 	name = "Ranged Trooper"
 	suit_store = /obj/item/gun/ballistic/shotgun/remington
 	backpack_contents = list(
-		/obj/item/ammo_box/a308=3
+		/obj/item/ammo_box/a762=3
 		)
 
 /*

--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -16,8 +16,3 @@
 	name = "1.95x129mm hollow-point bullet casing"
 	desc = "A 1.95x129mm bullet casing designed to cause more damage to unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/mm195x129_hp
-
-/obj/item/ammo_casing/mm195x129/incen
-	name = "1.95x129mm incendiary bullet casing"
-	desc = "A 1.95x129mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames."
-	projectile_type = /obj/item/projectile/bullet/incendiary/mm195x129

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -10,11 +10,6 @@
 	desc = "A .45-70 jacketed hollow point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c4570/jhp
 
-/obj/item/ammo_casing/c4570/swc
-	name = ".45-70 SWC bullet casing"
-	desc = "A .45-70 semi-wadcutter bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c4570/swc
-
 // .44 magnum
 /obj/item/ammo_casing/m44
 	name = ".44 magnum FMJ bullet casing"
@@ -26,11 +21,6 @@
 	name = ".44 magnum JHP bullet casing"
 	desc = "A .44 magnum jacketed hollow point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/m44/jhp
-
-/obj/item/ammo_casing/m44/swc
-	name = ".44 magnum SWC bullet casing"
-	desc = "A .44 magnum semi-wadcutter bullet casing."
-	projectile_type = /obj/item/projectile/bullet/m44/swc
 
 // .357 magnum, .38 special
 /obj/item/ammo_casing/a357
@@ -44,11 +34,6 @@
 	desc = "A .357 magnum jacketed hollow point bullet casing."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/a357/jhp
-
-/obj/item/ammo_casing/a357/swc
-	name = ".357 magnum SWC bullet casing"
-	desc = "A .357 magnum semi-wadcutter bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a357/swc
 
 /obj/item/ammo_casing/a357/c38
 	name = ".38 Spl. bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -24,11 +24,6 @@
 	desc = "A 5.56x45mm jacketed hollow point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/a556/jhp
 
-/obj/item/ammo_casing/a556/sport
-	name = "5.56x45 match bullet casing"
-	desc = "A 5.56x45mm hand-loaded match grade bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a556/sport
-
 // 7.62x51, .308 Winchester
 /obj/item/ammo_casing/a762
 	name = "7.62x51 FMJ bullet casing"
@@ -46,11 +41,6 @@
 	name = "7.62x51 JHP bullet casing"
 	desc = "A 7.62x51 jacketed hollow point bullet casing."
 	projectile_type = /obj/item/projectile/bullet/a762/jhp
-
-/obj/item/ammo_casing/a762/sport
-	name = ".308 Winchester bullet casing"
-	desc = "A .308 Winchester sporting bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a762/sport
 
 // 2mm EC
 /obj/item/ammo_casing/c2mm
@@ -74,12 +64,6 @@
 /obj/item/ammo_casing/F13/m308/armourpiercing
 	projectile_type = /obj/item/projectile/bullet/F13/c308mmBullet/armourpiercing
 
-/obj/item/ammo_casing/F13/m308/toxic
-	projectile_type = /obj/item/projectile/bullet/F13/c308mmBullet/toxic
-
-/obj/item/ammo_casing/F13/m308/fire
-	projectile_type = /obj/item/projectile/bullet/F13/c308mmBullet/fire
-
 /obj/item/ammo_casing/F13/a556
 	desc = "A 5.56 bullet casing."
 	caliber = "223mm"
@@ -92,10 +76,4 @@
 
 /obj/item/ammo_casing/F13/a556/armourpiercing
 	projectile_type = /obj/item/projectile/bullet/F13/c556Bullet/armourpiercing
-
-/obj/item/ammo_casing/F13/a556/toxic
-	projectile_type = /obj/item/projectile/bullet/F13/c556Bullet/toxic
-
-/obj/item/ammo_casing/F13/a556/fire
-	projectile_type = /obj/item/projectile/bullet/F13/c556Bullet/fire
 

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -10,8 +10,3 @@
 	name = "4.6x30mm armor-piercing bullet casing"
 	desc = "A 4.6x30mm armor-piercing bullet casing."
 	projectile_type = /obj/item/projectile/bullet/c46x30mm_ap
-
-/obj/item/ammo_casing/c46x30mm/inc
-	name = "4.6x30mm incendiary bullet casing"
-	desc = "A 4.6x30mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c46x30mm

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -130,10 +130,6 @@
 	name = "ammo box (.357 Magnum JHP)"
 	ammo_type = /obj/item/ammo_casing/a357/jhp
 
-/obj/item/ammo_box/a357box/swc
-	name = "ammo box (.357 Magnum SWC)"
-	ammo_type = /obj/item/ammo_casing/a357/swc
-
 /obj/item/ammo_box/box38
 	name = "ammo box (.38 Spl)"
 	icon_state = "38box"
@@ -193,10 +189,6 @@
 	name = "ammo box (5.56 AP)"
 	ammo_type = /obj/item/ammo_casing/a556/ap
 
-/obj/item/ammo_box/a556/sport
-	name = "ammo box (5.56 match)"
-	ammo_type = /obj/item/ammo_casing/a556/sport
-
 //.45 ACP
 /obj/item/ammo_box/c45
 	name = "ammo box (.45 FMJ)"
@@ -223,19 +215,7 @@
 	name = "ammo box (.44 Magnum JHP)"
 	ammo_type = /obj/item/ammo_casing/m44/jhp
 
-/obj/item/ammo_box/m44box/swc
-	name = "ammo box (.44 Magnum SWC)"
-	ammo_type = /obj/item/ammo_casing/m44/swc
-
 //7.62x51, .308 Winchester
-/obj/item/ammo_box/a308box
-	name = "ammo box (.308)"
-	icon_state = "308box"
-	ammo_type = /obj/item/ammo_casing/a762/sport
-	max_ammo = 30
-	materials = list(MAT_METAL = 15000)
-	w_class = WEIGHT_CLASS_NORMAL
-
 /obj/item/ammo_box/a762box
 	name = "ammo box (7.62x51 FMJ)"
 	icon_state = "762box"
@@ -264,10 +244,6 @@
 /obj/item/ammo_box/c4570box/jhp
 	name = "ammo box (.45-70 JHP)"
 	ammo_type = /obj/item/ammo_casing/c4570/jhp
-
-/obj/item/ammo_box/c4570box/swc
-	name = "ammo box (.45-70 SWC)"
-	ammo_type = /obj/item/ammo_casing/c4570/swc
 
 //.50 MG and .50 AE
 /obj/item/ammo_box/a50MGbox
@@ -324,16 +300,6 @@
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 5000)
 	w_class = WEIGHT_CLASS_SMALL
-
-/obj/item/ammo_box/a308
-	name = "stripper clip (.308)"
-	desc = "A stripper clip."
-	icon_state = "308"
-	ammo_type = /obj/item/ammo_casing/a762/sport
-	max_ammo = 5
-	multiple_sprites = 1
-	materials = list(MAT_METAL = 7000)
-	w_class = WEIGHT_CLASS_SMALL
 /*
 /obj/item/ammo_box/magazine/m308/heap
 	name = "rifle magazine (.308) (+Heap!)"
@@ -353,10 +319,10 @@
 */
 
 /obj/item/ammo_box/a762/doublestacked
-	name = "double stack stripper clip (.308)"
+	name = "double stack stripper clip (7.62)"
 	desc = "A stripper clip."
 	icon_state = "762a"
-	ammo_type = /obj/item/ammo_casing/a762/sport
+	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 10
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 10000)

--- a/code/modules/projectiles/boxes_magazines/external/lmg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/lmg.dm
@@ -13,10 +13,6 @@
 	name = "box magazine (Armor Penetrating 1.95x129mm)"
 	ammo_type = /obj/item/ammo_casing/mm195x129/ap
 
-/obj/item/ammo_box/magazine/mm195x129/incen
-	name = "box magazine (Incendiary 1.95x129mm)"
-	ammo_type = /obj/item/ammo_casing/mm195x129/incen
-
 /obj/item/ammo_box/magazine/mm195x129/update_icon()
 	..()
 	icon_state = "a762-[round(ammo_count(),10)]"

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -18,15 +18,6 @@
 	..()
 	icon_state = "46x30mmtA-[round(ammo_count(),4)]"
 
-/obj/item/ammo_box/magazine/wt550m9/wtic
-	name = "submachine gun magazine (Incindiary 4.6x30mm)"
-	icon_state = "46x30mmtI-20"
-	ammo_type = /obj/item/ammo_casing/c46x30mm/inc
-
-/obj/item/ammo_box/magazine/wt550m9/wtic/update_icon()
-	..()
-	icon_state = "46x30mmtI-[round(ammo_count(),4)]"
-
 /obj/item/ammo_box/magazine/uzim9mm
 	name = "smg magazine (9mm)"
 	icon_state = "uzi9mm-32"

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -15,7 +15,7 @@
 
 //Fallout 13
 /obj/item/ammo_box/magazine/internal/boltaction/remington
-	ammo_type = /obj/item/ammo_casing/a762/sport
+	ammo_type = /obj/item/ammo_casing/a762
 	caliber = "a762"
 	max_ammo = 5
 	multiload = 1

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -639,28 +639,16 @@
 	name = "bullet"
 //Bullets library: 9mm
 /obj/item/projectile/bullet/F13/c9mmBullet
-	damage = 14
+	damage = 8
 
 /obj/item/projectile/bullet/F13/c9mmBullet/heap
-	damage = 26
+	damage = 12
 	armour_penetration = -22
 
 /obj/item/projectile/bullet/F13/c9mmBullet/armourpiercing
-	damage = 12
-	armour_penetration = 25
+	damage = 6
+	armour_penetration = 15
 
-/obj/item/projectile/bullet/F13/c9mmBullet/toxic
-	damage = 15
-	damage_type = TOX
-
-/obj/item/projectile/bullet/F13/c9mmBullet/fire
-	damage = 7
-
-/obj/item/projectile/bullet/F13/c9mmBullet/fire/on_hit(atom/target, blocked = 0)
-	if(..(target, blocked))
-		var/mob/living/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
 
 /obj/item/projectile/bullet/F13/spear
 	damage = 40
@@ -669,111 +657,58 @@
 
 //Bullets library: 10mm
 /obj/item/projectile/bullet/F13/c10mmBullet
-	damage = 16
+	damage = 12
 
 /obj/item/projectile/bullet/F13/c10mmBullet/heap
-	damage = 32
+	damage = 16
 	armour_penetration = -28
 
 /obj/item/projectile/bullet/F13/c10mmBullet/armourpiercing
-	damage = 14
-	armour_penetration = 22
-
-/obj/item/projectile/bullet/F13/c10mmBullet/toxic
-	damage = 14
-	damage_type = TOX
-
-/obj/item/projectile/bullet/F13/c10mmBullet/fire
 	damage = 8
+	armour_penetration = 25
 
-/obj/item/projectile/bullet/F13/c10mmBullet/fire/on_hit(atom/target, blocked = 0)
-	if(..(target, blocked))
-		var/mob/living/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
 
 //Bullets library: 5.56
 /obj/item/projectile/bullet/F13/c556Bullet
-	damage = 22
+	damage = 14
 
 /obj/item/projectile/bullet/F13/c556Bullet/heap
-	damage = 36
+	damage = 18
 	armour_penetration = -28
 
 /obj/item/projectile/bullet/F13/c556Bullet/armourpiercing
-	damage = 18
-	armour_penetration = 22
+	damage = 12
+	armour_penetration = 35
 
-/obj/item/projectile/bullet/F13/c556Bullet/toxic
-	damage = 20
-	damage_type = TOX
-
-/obj/item/projectile/bullet/F13/c556Bullet/fire
-	damage = 11
-
-/obj/item/projectile/bullet/F13/c556Bullet/fire/on_hit(atom/target, blocked = 0)
-	if(..(target, blocked))
-		var/mob/living/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
 
 //Bullets library: .44
 /obj/item/projectile/bullet/F13/c44mmBullet
-	damage = 34
+	damage = 24
 
 /obj/item/projectile/bullet/F13/c44mmBullet/heap
-	damage = 52
+	damage = 32
 	armour_penetration = -45
 
 /obj/item/projectile/bullet/F13/c44mmBullet/armourpiercing
-	damage = 24
-	armour_penetration = 28
+	damage = 12//much less damage
+	armour_penetration = 42//much more pen
 
-/obj/item/projectile/bullet/F13/c44mmBullet/toxic
-	damage = 24
-	damage_type = TOX
-
-/obj/item/projectile/bullet/F13/c44mmBullet/fire
-	damage = 20
-
-/obj/item/projectile/bullet/F13/c44mmBullet/fire/on_hit(atom/target, blocked = 0)
-	if(..(target, blocked))
-		var/mob/living/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
 
 //Bullets library: .308
 /obj/item/projectile/bullet/F13/c308mmBullet
-	damage = 46
-
-/obj/item/projectile/bullet/F13/c308mmBullet/toxic
-	damage = 30
-	damage_type = TOX
+	damage = 28
 
 /obj/item/projectile/bullet/F13/c308mmBullet/heap
-	damage = 60
+	damage = 32
 	armour_penetration = -44
 
 /obj/item/projectile/bullet/F13/c308mmBullet/armourpiercing
-	damage = 32
-	armour_penetration = 30
-
-/obj/item/projectile/bullet/F13/c308mmBullet/fire
 	damage = 18
+	armour_penetration = 35
 
-/obj/item/projectile/bullet/F13/c308mmBullet/fire/on_hit(atom/target, blocked = 0)
-	if(..(target, blocked))
-		var/mob/living/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
-
-//Bullets library: .223
+//Bullets library: .223 //YET AGAIN, IS THIS EVEN USED?
 /obj/item/projectile/bullet/F13/c223Bullet
-	damage = 56
-
-/obj/item/projectile/bullet/F13/c223Bullet/toxic
-	damage = 48
-	damage_type = TOX
+	damage = 32
 
 /obj/item/projectile/bullet/F13/c223Bullet/heap
 	damage = 88
@@ -783,15 +718,7 @@
 	damage = 44
 	armour_penetration = 32
 
-/obj/item/projectile/bullet/F13/c223Bullet/fire
-	damage = 28
 
-/obj/item/projectile/bullet/F13/c223Bullet/fire/on_hit(atom/target, blocked = 0)
-	if(..(target, blocked))
-		var/mob/living/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
-
-
+//Bullets library: .38
 /obj/item/projectile/bullet/F13/c38mmBullet
-	damage = 4
+	damage = 6

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -185,20 +185,21 @@
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"
-	damage = 28
-	armour_penetration = 15
+	damage = 16
+	armour_penetration = 10
 
 /obj/item/projectile/beam/laser/pistol //AEP7
 	name = "laser beam"
-	damage = 22
-	armour_penetration = 10
+	damage = 12
+	armour_penetration = 5
 
 /obj/item/projectile/beam/laser/pistol/wattz //Wattz pistol
-	damage = 18
+	damage = 14
+	armour_penetration = 2//lol
 
 /obj/item/projectile/beam/laser/pistol/wattz/magneto //upgraded Wattz
 	name = "penetrating laser beam"
-	damage = 20
+	damage = 18
 	armour_penetration = 15
 
 /obj/item/projectile/beam/laser/solar //Solar Scorcher
@@ -208,20 +209,20 @@
 
 /obj/item/projectile/beam/laser/tribeam //Tribeam laser, fires 3 shots, will melt you
 	name = "tribeam laser"
-	damage = 22
-	armour_penetration = 12
+	damage = 15
+	armour_penetration = 10
 
 /obj/item/projectile/plasma //Plasma rifle
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 38
+	damage = 28
 	armour_penetration = 25
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
 	is_reflectable = TRUE
 
-/obj/item/projectile/plasma/repeater //Plasma repeater
+/obj/item/projectile/plasma/repeater //Is this even used?
 	name = "plasma stream"
 	icon_state = "plasma_clot"
 	damage_type = BURN
@@ -232,16 +233,16 @@
 	is_reflectable = FALSE
 
 /obj/item/projectile/plasma/pistol //Plasma pistol
-	damage = 28
+	damage = 19
 	armour_penetration = 20
 
 /obj/item/projectile/plasma/pistol/glock //Glock (upgraded plasma pistol)
-	damage = 28
-	armour_penetration = 15
+	damage = 22
+	armour_penetration = 24
 
 /obj/item/projectile/plasma/scatter //Multiplas, fires 3 shots, will melt you
-	damage = 26
-	armour_penetration = 30
+	damage = 18//less damage, given multiple projectiles.
+	armour_penetration = 15//less pen.
 
 /obj/item/projectile/plasma/alien
 	name = "alien projectile"

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -26,20 +26,16 @@
 
 /obj/item/projectile/bullet/mm195x129
 	name = "1.95x129mm bullet"
-	damage = 26
-	armour_penetration = 20
+	damage = 12
+	armour_penetration = 24
 
 /obj/item/projectile/bullet/mm195x129_ap
 	name = "1.95x129mm armor-piercing bullet"
-	damage = 26
-	armour_penetration = 20
+	damage = 8
+	armour_penetration = 35
 
 /obj/item/projectile/bullet/mm195x129_hp
 	name = "1.95x129mm hollow-point bullet"
-	damage = 34
-	armour_penetration = -9
+	damage = 24
+	armour_penetration = -19
 
-/obj/item/projectile/bullet/incendiary/mm195x129
-	name = "1.95x129mm incendiary bullet"
-	damage = 25
-	fire_stacks = 3

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -1,53 +1,53 @@
 //.22 LR
 /obj/item/projectile/bullet/c22
-	damage = 15
-	armour_penetration = 0
+	damage = 8
+	armour_penetration = -5
 
 //.45 ACP
 /obj/item/projectile/bullet/c45
-	damage = 35
+	damage = 16
 	armour_penetration = 0
 
 /obj/item/projectile/bullet/c45/jhp
-	damage = 40
+	damage = 24
 	armour_penetration = -20
 
 //9x19mm
 /obj/item/projectile/bullet/c9mm
-	damage = 30
+	damage = 12
 	armour_penetration = 0
 
 /obj/item/projectile/bullet/c9mm/ap
-	damage = 25
-	armour_penetration = 20
+	damage = 6
+	armour_penetration = 24
 
 /obj/item/projectile/bullet/c9mm/jhp
-	damage = 35
+	damage = 18
 	armour_penetration = -20
 
 //10mm
 /obj/item/projectile/bullet/c10mm
-	damage = 35
+	damage = 14
 	armour_penetration = 0
 
 /obj/item/projectile/bullet/c10mm/ap
-	damage = 30
-	armour_penetration = 20
+	damage = 8
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/c10mm/hp
-	damage = 40
+	damage = 24
 	armour_penetration = -20
 
 // Needler
 /obj/item/projectile/bullet/needle
     name = "needle"
     icon_state = "cbbolt"
-    damage = 40
+    damage = 25
     armour_penetration = 15
 
 /obj/item/projectile/bullet/needle/ap
     name = "armour piercing needle"
-    damage = 30
+    damage = 15
     armour_penetration = 35
 
 /*

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -1,46 +1,34 @@
 //.45-70 Gov't
 /obj/item/projectile/bullet/c4570
-	damage = 50
-	armour_penetration = 10
+	damage = 24
+	armour_penetration = 16
 
 /obj/item/projectile/bullet/c4570/jhp
-	damage = 55
+	damage = 32
 	armour_penetration = -10
-
-/obj/item/projectile/bullet/c4570/swc
-	damage = 55
-	armour_penetration = 10
 
 // .357 Magnum, .38 Special
 /obj/item/projectile/bullet/a357
-	damage = 30
+	damage = 18
 	armour_penetration = 5
 
 /obj/item/projectile/bullet/a357/jhp
-	damage = 35
+	damage = 24
 	armour_penetration = -15
 
-/obj/item/projectile/bullet/a357/swc
-	damage = 35
-	armour_penetration = 15
-
 /obj/item/projectile/bullet/a38
-	damage = 25
+	damage = 16
 
 // .44 Magnum
 /obj/item/projectile/bullet/m44
-	damage = 35
+	damage = 22
 	armour_penetration = 5
 
 /obj/item/projectile/bullet/m44/jhp
-	damage = 40
+	damage = 32
 	armour_penetration = -15
-
-/obj/item/projectile/bullet/m44/swc
-	damage = 40
-	armour_penetration = 5
 
 // .50 Action Express
 /obj/item/projectile/bullet/a50AE
-	damage = 55
+	damage = 38
 	armour_penetration = 20

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -1,19 +1,15 @@
 //7.62x51 NATO / .308 Winchester
 /obj/item/projectile/bullet/a762
-	damage = 40
-	armour_penetration = 20
+	damage = 32
+	armour_penetration = 18
 
 /obj/item/projectile/bullet/a762/ap
-	damage = 35
-	armour_penetration = 40
+	damage = 24
+	armour_penetration = 45
 
 /obj/item/projectile/bullet/a762/jhp
 	damage = 45
-	armour_penetration = 0
-
-/obj/item/projectile/bullet/a762/sport //.308 Winchester
-	damage = 40
-	armour_penetration = 30
+	armour_penetration = -15
 
 //5.56x45mm
 /obj/item/projectile/bullet/a556
@@ -22,15 +18,11 @@
 
 /obj/item/projectile/bullet/a556/ap
 	damage = 25
-	armour_penetration = 30
+	armour_penetration = 45
 
 /obj/item/projectile/bullet/a556/jhp
 	damage = 45
 	armour_penetration = -5
-
-/obj/item/projectile/bullet/a556/sport
-	damage = 30
-	armour_penetration = 10
 
 //2mm Electromagnetic
 /obj/item/projectile/bullet/c2mm

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
-	armour_penetration = 10
+	damage = 50
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -1,14 +1,9 @@
 /obj/item/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
-	damage = 25
+	damage = 12
 	armour_penetration = 15
 
 /obj/item/projectile/bullet/c46x30mm_ap
 	name = "4.6x30mm armor-piercing bullet"
-	damage = 0
+	damage = 6
 	armour_penetration = 40
-
-/obj/item/projectile/bullet/incendiary/c46x30mm
-	name = "4.6x30mm incendiary bullet"
-	damage = 10
-	fire_stacks = 1

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -41,11 +41,11 @@
 
 /obj/item/projectile/bullet/a50MG
 	damage = 60
-	armour_penetration = 60
+	armour_penetration = 65
 
 /obj/item/projectile/bullet/a50MG/incendiary
-	damage = 40
-	armour_penetration = 20
+	damage = 32
+	armour_penetration = -20
 	var/fire_stacks = 4
 
 /obj/item/projectile/bullet/a50MG/incendiary/on_hit(atom/target, blocked = FALSE)
@@ -56,12 +56,12 @@
 		M.IgniteMob()
 
 
-	/obj/item/projectile/bullet/a50MG/AP
+/obj/item/projectile/bullet/a50MG/AP
 	damage = 35
-	armour_penetration = 95
+	armour_penetration = 95//gang gang
 
 /obj/item/projectile/bullet/a50MG/explosive
-	damage = 30
+	damage = 24
 	armour_penetration = 0
 
 /obj/item/projectile/bullet/a50MG/explosive/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -145,13 +145,13 @@
 	id = "epinephrine"
 	results = list("epinephrine" = 6)
 	required_reagents = list("phenol" = 1, "acetone" = 1, "diethylamine" = 1, "oxygen" = 1, "chlorine" = 1, "hydrogen" = 1)
-/*
+
 /datum/chemical_reaction/strange_reagent
 	name = "Strange Reagent"
 	id = "strange_reagent"
 	results = list("strange_reagent" = 3)
 	required_reagents = list("omnizine" = 1, "holywater" = 1, "FEV_solution" = 1)
-*/
+
 
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -44,13 +44,13 @@
 	id = "lipolicide"
 	results = list("lipolicide" = 3)
 	required_reagents = list("mercury" = 1, "diethylamine" = 1, "ephedrine" = 1)
-/*
+
 /datum/chemical_reaction/FEV_solution
 	name = "Unstable FEV solution"
 	id = "FEV_solution"
 	results = list("FEV_solution" = 5)
 	required_reagents = list("radium" = 1, "phosphorus" = 1, "chlorine" = 1, "virusfood" = 2)
-*/
+
 /datum/chemical_reaction/lexorin
 	name = "Lexorin"
 	id = "lexorin"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -798,14 +798,6 @@
 	build_path = /obj/item/ammo_box/a762
 	category = list("initial", "Security")
 
-/datum/design/a308
-	name = "Stripper Clip (.308)"
-	id = "a308"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 7000)
-	build_path = /obj/item/ammo_box/a308
-	category = list("initial", "Security")
-
 /datum/design/doublestacked
 	name = "Rangemaster Stripper Clip (7.62mm)"
 	id = "doublestacked"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -532,12 +532,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			to puncture even the most durable armor."
 	item = /obj/item/ammo_box/magazine/mm195x129/ap
 
-/datum/uplink_item/ammo/machinegun/incen
-	name = "1.95x129mm (Incendiary) Box Magazine"
-	desc = "A 50-round magazine of 1.95x129mm ammunition for use in the L6 SAW; tipped with a special flammable \
-			mixture that'll ignite anyone struck by the bullet. Some men just want to watch the world burn."
-	item = /obj/item/ammo_box/magazine/mm195x129/incen
-
 /datum/uplink_item/ammo/sniper
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
- - -
Nerfs:
 - BoS now have to construct some significant pieces of their bunker in order to be fully functional. They must also actually go and obtain materials, due to this.
 - Nearly every ammo type has had a significant reduction in damage, armor penetration and other such utility values.
 - Various ammo types removed. Generally those that deal 'toxins' and some incendiary rounds from small arms.
- - -
Buffs:
 - Powerfist's cousin given a much needed buff to damage, so it's not just a reskin with slightly better armor pen.
 - Sledges made sledges again. 'Nuff said.
- - -
Other:
 - FEV and "Strange Reagent" can once again be made.
