### PR TITLE
Removes Ability to Select Genitals as a Preference

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -331,10 +331,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			else if(use_skintones || mutant_colors)
 				dat += "</td>"
 
-			dat += "<a href='?_src_=prefs;preference=has_penis'>Has Penis: [has_penis ? "Yes" : "No"]</A><br>"
-			dat += "<a href='?_src_=prefs;preference=has_vagina'>Has Vagina: [has_vagina ? "Yes" : "No"]</A><br>"
-			dat += "<a href='?_src_=prefs;preference=has_breasts'>Has Breasts: [has_breasts ? "Yes" : "No"]</A><br>"
-
 			if(HAIR in pref_species.species_traits)
 
 				dat += APPEARANCE_CATEGORY_COLUMN

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1664,22 +1664,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					facial_hair_style = random_facial_hair_style(gender)
 					hair_style = random_hair_style(gender)
 
-				if("has_penis")
-					if(has_penis == 1)
-						has_penis = 0
-					else
-						has_penis = 1
-				if("has_vagina")
-					if(has_vagina == 1)
-						has_vagina = 0
-					else
-						has_vagina = 1
-				if("has_breasts")
-					if(has_breasts == 1)
-						has_breasts = 0
-					else
-						has_breasts = 1
-
 				if("hotkeys")
 					hotkeys = !hotkeys
 					if(hotkeys)
@@ -1813,9 +1797,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	character.gender = gender
 	character.age = age
-	character.has_penis = has_penis
-	character.has_vagina = has_vagina
-	character.has_breasts = has_breasts
 
 	character.eye_color = eye_color
 	var/obj/item/organ/eyes/organ_eyes = character.getorgan(/obj/item/organ/eyes)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -67,9 +67,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/facial_hair_style = "Shaved"	//Face hair type
 	var/facial_hair_color = "000"		//Facial hair color
 	var/skin_tone = "caucasian1"		//Skin color
-	var/has_penis = 0						//Do they have a penis? (for ERP verbs and surgery)
-	var/has_vagina = 0						//Do they have a vagina? (for ERP verbs and surgery)
-	var/has_breasts = 0						//Do they have breasts? (for ERP verbs and surgery)
 	var/eye_color = "000"				//Eye color
 	var/datum/species/pref_species = new /datum/species/human()	//Mutant race
 	var/list/features = list("mcolor" = "FFF", "tail_lizard" = "Smooth", "tail_human" = "None", "snout" = "Round", "horns" = "None", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs", "moth_wings" = "Plain")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -218,9 +218,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["body_is_always_random"] >> be_random_body
 	S["gender"]				>> gender
 	S["age"]				>> age
-	S["has_penis"]			>> has_penis
-	S["has_vagina"]			>> has_vagina
-	S["has_breasts"]		>> has_breasts
 	S["hair_color"]			>> hair_color
 	S["facial_hair_color"]	>> facial_hair_color
 	S["eye_color"]			>> eye_color
@@ -426,9 +423,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["body_is_always_random"] , be_random_body)
 	WRITE_FILE(S["gender"]				, gender)
 	WRITE_FILE(S["age"]				, age)
-	WRITE_FILE(S["has_penis"]		 , has_penis)
-	WRITE_FILE(S["has_vagina"]		 , has_vagina)
-	WRITE_FILE(S["has_breasts"]		, has_breasts)
 	WRITE_FILE(S["hair_color"]			, hair_color)
 	WRITE_FILE(S["facial_hair_color"]	, facial_hair_color)
 	WRITE_FILE(S["eye_color"]			, eye_color)

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -260,6 +260,16 @@
 	if(visualsOnly)
 		return
 
+	if(H.gender == MALE)
+		H.has_penis = TRUE
+		H.has_vagina = FALSE
+		H.has_breasts = FALSE
+
+	if(H.gender == FEMALE)
+		H.has_vagina = TRUE
+		H.has_breasts = TRUE
+		H.has_penis = FALSE
+
 	var/datum/job/J = SSjob.GetJobType(jobtype)
 	if(!J)
 		J = SSjob.GetJob(H.job)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the pesky ability to pick your genitals.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This solves the problem in which the same 7 foot wang futa ERPer would show up and instantly be able to shit on everything the server stands for with it's disturbing fetish ERP.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested it in a private game, seems to work alright. Will post screenshots.
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/43885371/82810186-31dad580-9ed1-11ea-9c5a-c25e17ea8590.png)
![image](https://user-images.githubusercontent.com/43885371/82810367-9e55d480-9ed1-11ea-8806-45143dec0a45.png)

## Changelog (necessary)
:cl:
tweak: Genitals are now based on your gender
del: You can no longer mix and match your genitals
/:cl:
