### PR TITLE
Dungeon Reworks

### DIFF
--- a/_maps/map_files/Pahrump/Dungeons.dmm
+++ b/_maps/map_files/Pahrump/Dungeons.dmm
@@ -110,9 +110,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "at" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/plating/tunnel,
-/area/f13/radiation)
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/bunker)
 "au" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/blood/old,
@@ -256,7 +259,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "aS" = (
-/mob/living/simple_animal/hostile/supermutant,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "aT" = (
@@ -279,12 +282,8 @@
 	},
 /area/f13/bunker)
 "aW" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
-	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "aX" = (
 /turf/closed/wall/f13/tunnel,
@@ -549,6 +548,7 @@
 	},
 /area/f13/bunker)
 "bD" = (
+/mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "bE" = (
@@ -669,6 +669,7 @@
 	icon_state = "shower";
 	tag = "icon-shower (EAST)"
 	},
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
@@ -892,9 +893,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "cn" = (
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/bunker)
+/mob/living/simple_animal/hostile/handy/sentrybot,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "co" = (
 /obj/structure/rack,
 /obj/item/storage/belt/medical,
@@ -1276,11 +1277,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/spider/stickyweb,
+/obj/machinery/porta_turret/syndicate/wasteland,
 /turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+	icon_state = "plating";
+	tag = "icon-plating"
 	},
 /area/f13/bunker)
 "dn" = (
@@ -1519,8 +1519,8 @@
 	},
 /area/f13/bunker)
 "dU" = (
-/obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/hatch,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -1666,9 +1666,11 @@
 	},
 /area/f13/bunker)
 "eo" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "ep" = (
@@ -1794,7 +1796,7 @@
 /area/f13/bunker)
 "eE" = (
 /obj/machinery/door/airlock,
-/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -1882,7 +1884,13 @@
 	},
 /area/f13/bunker)
 "eQ" = (
-/mob/living/simple_animal/hostile/chinese,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -1901,10 +1909,11 @@
 	},
 /area/f13/bunker)
 "eS" = (
-/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/remains/human,
+/obj/item/flashlight/flare/torch,
 /turf/open/floor/plasteel/barber{
-	icon_state = "plating";
-	tag = "icon-plating"
+	icon_state = "platingdmg2";
+	tag = "icon-platingdmg2"
 	},
 /area/f13/bunker)
 "eT" = (
@@ -1916,11 +1925,8 @@
 	},
 /area/f13/bunker)
 "eU" = (
-/obj/effect/decal/waste{
-	icon_state = "goo5";
-	tag = "icon-goo5"
-	},
-/mob/living/simple_animal/hostile/supermutant,
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/barber{
 	icon_state = "plating";
 	tag = "icon-plating"
@@ -2065,13 +2071,11 @@
 	},
 /area/f13/bunker)
 "fn" = (
-/obj/structure/chair/f13chair2{
-	dir = 8;
-	icon_state = "f13chair2"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "fo" = (
@@ -2156,6 +2160,7 @@
 /area/f13/bunker)
 "fx" = (
 /obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plating/f13/inside/mountain,
 /area/f13/underground/cave)
 "fy" = (
@@ -2381,13 +2386,16 @@
 	},
 /area/f13/bunker)
 "gc" = (
-/obj/structure/chair/f13chair2{
-	dir = 4;
-	icon_state = "f13chair2"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "gd" = (
@@ -2497,9 +2505,11 @@
 	},
 /area/f13/bunker)
 "gq" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "whitebluerustychess"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "gr" = (
@@ -2559,9 +2569,18 @@
 	},
 /area/f13/bunker)
 "gy" = (
-/mob/living/simple_animal/hostile/chinese,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "gz" = (
@@ -2659,9 +2678,11 @@
 	},
 /area/f13/bunker)
 "gN" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
 "gO" = (
@@ -2691,9 +2712,11 @@
 	},
 /area/f13/bunker)
 "gR" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
 "gS" = (
@@ -2723,12 +2746,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "gV" = (
-/obj/effect/decal/remains/human,
-/obj/item/flashlight/flare/torch,
-/mob/living/simple_animal/hostile/radscorpion,
+/obj/effect/decal/waste{
+	icon_state = "goo5";
+	tag = "icon-goo5"
+	},
 /turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg2";
-	tag = "icon-platingdmg2"
+	icon_state = "plating";
+	tag = "icon-plating"
 	},
 /area/f13/bunker)
 "gW" = (
@@ -2880,7 +2904,7 @@
 	},
 /area/f13/bunker)
 "hr" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /turf/open/floor/plasteel/barber{
 	icon = 'icons/turf/f13floors2.dmi';
 	icon_state = "bluerustychess2";
@@ -2924,9 +2948,12 @@
 	},
 /area/f13/bunker)
 "hw" = (
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/floor/plating/tunnel,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/bunker)
 "hx" = (
 /obj/machinery/chem_heater,
@@ -3089,9 +3116,13 @@
 	},
 /area/f13/bunker)
 "hR" = (
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/bunker)
 "hS" = (
 /obj/structure/cable{
@@ -3133,6 +3164,7 @@
 /area/f13/bunker)
 "hX" = (
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
@@ -3144,9 +3176,14 @@
 /area/f13/bunker)
 "hZ" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowdirtyfull"
 	},
@@ -3182,9 +3219,12 @@
 	},
 /area/f13/bunker)
 "ie" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/plating/tunnel{
-	icon_state = "tunnelchess"
+/obj/machinery/light,
+/mob/living/simple_animal/hostile/supermutant,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/bunker)
 "if" = (
@@ -3201,8 +3241,12 @@
 	},
 /area/f13/bunker)
 "ig" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/indestructible/ground/outside/sidewalk,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
 /area/f13/bunker)
 "ih" = (
 /obj/structure/cable{
@@ -3236,15 +3280,15 @@
 	},
 /area/f13/bunker)
 "ik" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/mob/living/simple_animal/hostile/ghoul/glowing{
+	maxHealth = 280;
+	melee_damage_lower = 25;
+	melee_damage_upper = 40;
+	name = "Security Chief";
+	resize = 1.2
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/hostile/chinese,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "il" = (
@@ -3288,27 +3332,18 @@
 	},
 /area/f13/bunker)
 "io" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "ip" = (
-/obj/effect/decal/hammerandsickle,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "iq" = (
@@ -3412,8 +3447,11 @@
 	},
 /area/f13/bunker)
 "iz" = (
-/obj/machinery/light,
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -3478,6 +3516,7 @@
 	icon = 'icons/obj/doors/airlocks/station/security.dmi';
 	name = "Vault 223 Security"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -3504,10 +3543,10 @@
 	},
 /area/f13/bunker)
 "iL" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -3860,9 +3899,19 @@
 	},
 /area/f13/bunker)
 "jy" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/command.dmi';
+	name = "Vault 223 Overseer Office"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "jz" = (
@@ -3994,9 +4043,7 @@
 	},
 /area/f13/bunker)
 "jO" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -4005,6 +4052,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/porta_turret/syndicate/wasteland,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -4016,11 +4064,12 @@
 	},
 /area/f13/bunker)
 "jR" = (
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating/f13/inside/mountain{
 	icon_state = "mountain2"
 	},
-/area/f13/bunker)
+/area/f13/underground/cave)
 "jS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4132,6 +4181,7 @@
 	icon = 'icons/obj/doors/airlocks/station/security.dmi';
 	name = "Vault 223 Security"
 	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -4195,7 +4245,7 @@
 	},
 /area/f13/bunker)
 "kn" = (
-/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -4314,6 +4364,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -4382,17 +4433,14 @@
 	},
 /area/f13/bunker)
 "kI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "stalin";
+	name = "Overseer Office shutters"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution/stand_clear,
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "kJ" = (
@@ -4421,13 +4469,8 @@
 	},
 /area/f13/bunker)
 "kM" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -4511,12 +4554,10 @@
 	},
 /area/f13/bunker)
 "kX" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/security.dmi';
-	name = "Vault 223 armory"
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+	icon_state = "plating"
 	},
 /area/f13/bunker)
 "kY" = (
@@ -4536,9 +4577,9 @@
 	},
 /area/f13/bunker)
 "la" = (
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/cable,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "lb" = (
@@ -4580,10 +4621,9 @@
 	},
 /area/f13/bunker)
 "lf" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker)
 "lg" = (
@@ -4602,9 +4642,8 @@
 	},
 /area/f13/bunker)
 "li" = (
-/obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -4624,6 +4663,7 @@
 	},
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi';
+	locked = 1;
 	name = "Vault 223 Enginieering"
 	},
 /turf/open/floor/plasteel/f13{
@@ -4636,9 +4676,12 @@
 	},
 /area/f13/bunker)
 "lm" = (
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/command.dmi';
+	name = "Vault 223 Overseer storage"
+	},
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/bunker)
 "ln" = (
@@ -4681,10 +4724,11 @@
 	},
 /area/f13/bunker)
 "lr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/security.dmi';
+	name = "Vault 223 armory"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13{
 	icon_state = "redrustyfull"
 	},
@@ -4822,16 +4866,10 @@
 	},
 /area/f13/bunker)
 "lH" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+/obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -4840,7 +4878,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -4858,6 +4896,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/mob/living/simple_animal/hostile/spawner/ghoul/larger,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -4950,9 +4989,9 @@
 	},
 /area/f13/bunker)
 "lW" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner,
-/obj/effect/decal/cleanable/greenglow,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13{
 	icon_state = "plating"
 	},
@@ -4984,10 +5023,13 @@
 	},
 /area/f13/bunker)
 "ma" = (
-/obj/structure/window/reinforced/spawner,
-/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/waste,
 /turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "mb" = (
@@ -5054,10 +5096,10 @@
 	},
 /area/f13/bunker)
 "mj" = (
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "mk" = (
@@ -5093,10 +5135,10 @@
 /area/f13/bunker)
 "mq" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
+/obj/effect/decal/waste,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -5129,18 +5171,11 @@
 /area/f13/bunker)
 "mu" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/machinery/porta_turret/syndicate/wasteland,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "mv" = (
@@ -5237,23 +5272,18 @@
 	},
 /area/f13/bunker)
 "mD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/machinery/porta_turret/syndicate/wasteland,
 /turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "mE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4;
-	icon_state = "warningline"
-	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/machinery/porta_turret/syndicate/wasteland,
 /turf/open/floor/plasteel/f13{
-	icon_state = "redrustyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "mF" = (
@@ -5332,10 +5362,13 @@
 	},
 /area/f13/bunker)
 "mO" = (
+/obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -5446,9 +5479,9 @@
 	},
 /area/f13/bunker)
 "nb" = (
-/mob/living/simple_animal/hostile/chinese,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "nc" = (
@@ -5461,9 +5494,9 @@
 	},
 /area/f13/bunker)
 "nd" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "ne" = (
@@ -5477,10 +5510,9 @@
 	},
 /area/f13/bunker)
 "nf" = (
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "ng" = (
@@ -5497,7 +5529,7 @@
 	},
 /area/f13/bunker)
 "ni" = (
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -5509,10 +5541,12 @@
 	},
 /area/f13/bunker)
 "nk" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "nl" = (
@@ -5556,9 +5590,12 @@
 	},
 /area/f13/bunker)
 "nq" = (
-/obj/effect/spawner/lootdrop/trash,
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "redrustyfull"
+	},
 /area/f13/bunker)
 "nr" = (
 /obj/structure/closet/crate/bin,
@@ -5599,12 +5636,9 @@
 	},
 /area/f13/bunker)
 "nw" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/mob/living/simple_animal/hostile/chinese/ranged,
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
+	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
 "nx" = (
@@ -5650,14 +5684,10 @@
 	},
 /area/f13/bunker)
 "nC" = (
-/obj/machinery/light,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/mob/living/simple_animal/hostile/chinese/ranged/assault,
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -5693,38 +5723,24 @@
 	},
 /area/f13/bunker)
 "nH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/chinese,
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/f13{
-	icon_state = "showroomfloor"
+	icon_state = "redrustyfull"
 	},
 /area/f13/bunker)
 "nI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/mob/living/simple_animal/pet/dog/eyebot{
+	name = "Steve"
 	},
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/command.dmi';
-	name = "Vault 223 Overseer Office"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "stalin";
-	name = "Overseer Office shutters"
-	},
-/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "floorrusty"
 	},
 /area/f13/bunker)
 "nJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "stalin";
-	name = "Overseer Office shutters"
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/barricade/wooden/crude,
+/mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -5761,6 +5777,7 @@
 /area/f13/tunnel)
 "nO" = (
 /obj/machinery/light,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -5956,9 +5973,12 @@
 	},
 /area/f13/bunker)
 "oi" = (
-/mob/living/simple_animal/hostile/chinese/ranged,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/eyebot,
 /turf/open/floor/plasteel/f13{
-	icon_state = "yellowdirtyfull"
+	icon_state = "floorgrime"
 	},
 /area/f13/bunker)
 "oj" = (
@@ -5976,17 +5996,19 @@
 	},
 /area/f13/bunker)
 "ol" = (
-/obj/structure/cable,
-/obj/structure/barricade/wooden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "floorrusty"
 	},
 /area/f13/bunker)
 "om" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/wooden,
+/mob/living/simple_animal/hostile/ghoul,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "floorrusty"
 	},
 /area/f13/bunker)
 "on" = (
@@ -6105,13 +6127,15 @@
 	},
 /area/f13/bunker)
 "oB" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/command.dmi';
-	name = "Vault 223 Overseer storage"
+/mob/living/simple_animal/hostile/ghoul/glowing{
+	maxHealth = 280;
+	melee_damage_lower = 25;
+	melee_damage_upper = 40;
+	name = "Chief Medical Officer";
+	resize = 1.2
 	},
-/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
 "oC" = (
@@ -6122,9 +6146,9 @@
 	},
 /area/f13/bunker)
 "oD" = (
-/mob/living/simple_animal/hostile/handy/sentrybot,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorrusty"
+	icon_state = "showroomfloor"
 	},
 /area/f13/bunker)
 "oE" = (
@@ -6435,9 +6459,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "pq" = (
-/obj/effect/decal/remains/human,
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plating/tunnel,
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtyfull"
+	},
 /area/f13/bunker)
 "pr" = (
 /obj/effect/decal/waste,
@@ -6456,12 +6481,9 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/bunker)
 "pu" = (
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/hostile/supermutant,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
 	},
 /area/f13/bunker)
 "pv" = (
@@ -6506,11 +6528,9 @@
 	},
 /area/f13/bunker)
 "pA" = (
-/obj/item/storage/pill_bottle/chem_tin/radx,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/f13/inside/mountain{
+	icon_state = "mountain2"
 	},
 /area/f13/bunker)
 "pB" = (
@@ -6586,6 +6606,49 @@
 	tag = "icon-bluerustychess2"
 	},
 /area/f13/bunker)
+"pI" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/bunker)
+"pJ" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon_state = "plating";
+	tag = "icon-plating"
+	},
+/area/f13/bunker)
+"pK" = (
+/obj/machinery/door/airlock/hatch{
+	locked = 1
+	},
+/turf/open/floor/plasteel/barber{
+	icon_state = "platingdmg1";
+	tag = "icon-platingdmg1"
+	},
+/area/f13/bunker)
+"pL" = (
+/obj/machinery/porta_turret/syndicate/wasteland,
+/turf/open/floor/plasteel/barber{
+	icon_state = "plating";
+	tag = "icon-plating"
+	},
+/area/f13/bunker)
+"pM" = (
+/mob/living/simple_animal/hostile/centaur,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/bunker)
 "pN" = (
 /obj/item/radio/intercom{
 	dir = 8
@@ -6608,20 +6671,136 @@
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"pP" = (
+/obj/machinery/light/small,
+/mob/living/simple_animal/hostile/supermutant/rangedmutant,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/bunker)
+"pQ" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"pR" = (
+/obj/structure/window/reinforced/spawner,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
+"pS" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"pT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"pU" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
+"pV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/bunker)
 "pW" = (
 /obj/machinery/vending/nukacolavend,
 /turf/open/floor/f13{
 	icon_state = "darkdirty"
 	},
 /area/f13/bunker)
+"pX" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/bunker)
 "pY" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"pZ" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/bunker)
+"qa" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/cave)
+"qb" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/cave)
 "qc" = (
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
+	},
+/area/f13/bunker)
+"qd" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/bunker)
+"qe" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/bunker)
 "qi" = (
@@ -7475,13 +7654,6 @@
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
 	tag = "icon-housewood2"
-	},
-/area/f13/bunker)
-"zo" = (
-/mob/living/simple_animal/hostile/radscorpion,
-/turf/open/floor/plasteel/barber{
-	icon_state = "platingdmg3";
-	tag = "icon-platingdmg3"
 	},
 /area/f13/bunker)
 "zr" = (
@@ -9307,14 +9479,6 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/f13{
 	icon_state = "bar"
-	},
-/area/f13/bunker)
-"QM" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/floor/plasteel/barber{
-	icon = 'icons/turf/f13floors2.dmi';
-	icon_state = "bluerustychess2";
-	tag = "icon-bluerustychess2"
 	},
 /area/f13/bunker)
 "QO" = (
@@ -14317,7 +14481,7 @@ jZ
 jd
 jZ
 jZ
-ig
+jZ
 aX
 aa
 aa
@@ -14565,13 +14729,13 @@ aa
 aX
 jZ
 jZ
-ws
+jZ
 jZ
 jZ
 zt
 ws
 jZ
-ws
+jZ
 jZ
 jZ
 ph
@@ -15354,7 +15518,7 @@ HD
 Li
 Ng
 Pu
-aV
+hr
 aV
 HD
 WB
@@ -15618,7 +15782,7 @@ bx
 aV
 aV
 aV
-dF
+pP
 HD
 aa
 aa
@@ -15869,7 +16033,7 @@ EO
 JO
 HD
 bx
-bu
+aV
 HD
 aV
 Sn
@@ -16119,14 +16283,14 @@ aa
 aa
 HD
 Kc
-QM
+aV
 aU
 HD
 HD
 HD
 HD
 aV
-bu
+aV
 fH
 aV
 gk
@@ -16367,8 +16531,8 @@ aa
 aa
 aa
 aX
-fH
-fH
+pI
+pI
 aX
 aa
 aa
@@ -16633,7 +16797,7 @@ aa
 aa
 HD
 Qj
-aV
+pM
 fV
 bv
 Ep
@@ -16644,7 +16808,7 @@ bu
 HD
 bx
 fV
-QM
+aV
 aV
 dF
 HD
@@ -16893,7 +17057,7 @@ Gh
 aV
 aV
 dL
-aV
+pM
 aV
 HD
 aV
@@ -17138,8 +17302,8 @@ aa
 aa
 aa
 aX
-hr
-hr
+aV
+aV
 aX
 HD
 HD
@@ -17154,7 +17318,7 @@ HD
 fH
 HD
 aV
-bu
+aV
 HD
 HD
 HD
@@ -17914,7 +18078,7 @@ aV
 aX
 HD
 lt
-bu
+aV
 zh
 HD
 ce
@@ -18423,18 +18587,18 @@ aa
 HD
 HD
 HD
-fH
-fH
+pI
+pI
 HD
 HD
 lt
 fV
 EC
 HD
-bv
 aV
+pL
 aV
-fH
+pI
 aV
 HD
 aa
@@ -18681,11 +18845,11 @@ HD
 Vg
 bX
 aV
-bu
+aV
 Lf
 HD
 zb
-bu
+aV
 ns
 HD
 bG
@@ -19193,14 +19357,14 @@ aa
 aa
 HD
 aV
-bu
+aV
 PU
 fV
 LW
 HD
 bH
 fV
-aW
+aV
 HD
 PU
 aV
@@ -19455,12 +19619,12 @@ aV
 dq
 aV
 fH
-aW
 aV
+pM
 dq
-fH
+pI
 aV
-aW
+aV
 aV
 HD
 aa
@@ -19970,7 +20134,7 @@ bH
 aV
 HD
 HD
-fH
+pI
 HD
 HD
 aV
@@ -20221,7 +20385,7 @@ fv
 aV
 HD
 bx
-bu
+aV
 Tq
 bt
 bX
@@ -20485,7 +20649,7 @@ EZ
 xx
 Tq
 dq
-aW
+aV
 aV
 aV
 aV
@@ -20732,7 +20896,7 @@ aa
 aa
 HD
 nZ
-bu
+aV
 HD
 eO
 aV
@@ -20741,11 +20905,11 @@ dq
 aV
 HD
 HD
-fH
+pI
 HD
 HD
 HD
-fH
+pI
 HD
 HD
 HD
@@ -21000,7 +21164,7 @@ HD
 bE
 RU
 LG
-aV
+qe
 bH
 aV
 bH
@@ -21258,10 +21422,10 @@ RU
 aV
 aV
 aV
-aW
 aV
 aV
 aV
+qe
 Gj
 dl
 dl
@@ -21511,9 +21675,9 @@ aA
 aA
 aA
 HD
+qe
 aV
 aV
-aW
 aV
 aV
 aV
@@ -21768,7 +21932,7 @@ aA
 aA
 aA
 HD
-bx
+qd
 aV
 Tq
 RU
@@ -22026,10 +22190,10 @@ HD
 HD
 HD
 HD
-rI
+pJ
 HD
 HD
-aV
+qe
 dq
 aV
 aV
@@ -22288,8 +22452,8 @@ Dv
 HD
 aV
 aV
-aW
 aV
+ig
 SM
 SM
 SM
@@ -22534,7 +22698,7 @@ FR
 gF
 HD
 Hv
-eU
+gV
 ji
 RW
 RW
@@ -22544,7 +22708,7 @@ ut
 HD
 HD
 aV
-aW
+aV
 aV
 HD
 HD
@@ -22791,12 +22955,12 @@ Tb
 aD
 RW
 wG
-lD
+Hv
 La
 oN
 Hg
 ji
-gV
+eS
 Hv
 RW
 HD
@@ -23047,7 +23211,7 @@ aa
 Su
 Ar
 HD
-RW
+eU
 DS
 Ar
 Bo
@@ -23314,7 +23478,7 @@ HD
 ut
 HD
 HD
-aV
+qe
 aV
 dq
 HD
@@ -23571,9 +23735,9 @@ Ih
 Ku
 gF
 HD
-RU
-aV
-sA
+dn
+dn
+cl
 HD
 aa
 aa
@@ -23825,12 +23989,12 @@ Ar
 Hv
 jG
 RW
-eS
+Hv
 RN
-ut
+pJ
 bO
 dm
-bv
+aV
 HD
 aa
 aa
@@ -24085,7 +24249,7 @@ TS
 RW
 RW
 HD
-oU
+pK
 HD
 HD
 HD
@@ -24601,7 +24765,7 @@ nr
 HD
 oC
 RW
-zo
+Ar
 HD
 HD
 HD
@@ -56106,7 +56270,7 @@ fu
 fl
 fu
 fu
-fx
+qa
 fl
 aa
 aa
@@ -56375,7 +56539,7 @@ HD
 kB
 kZ
 lv
-kB
+mq
 HD
 HD
 aa
@@ -56624,12 +56788,12 @@ fu
 fl
 fl
 fu
-ei
-ei
-ei
+fu
+fu
+jR
 HD
-jk
-jk
+kn
+kn
 jk
 jk
 jk
@@ -56879,15 +57043,15 @@ hi
 fl
 fl
 fl
-ei
+fu
 fu
 iJ
 fl
 fu
-jR
+pA
 jk
+lf
 jk
-la
 jk
 jk
 mm
@@ -57134,11 +57298,11 @@ aa
 aa
 aa
 fl
-fx
+qb
 ei
 ei
-ei
-ei
+fu
+fu
 ei
 aa
 HD
@@ -57146,7 +57310,7 @@ kk
 jk
 jk
 jk
-jk
+lf
 mn
 HD
 aa
@@ -57404,7 +57568,7 @@ kC
 jk
 jk
 jk
-mq
+pT
 HD
 aa
 aa
@@ -57917,7 +58081,7 @@ km
 kD
 jk
 jk
-jk
+lf
 mr
 ko
 HD
@@ -58170,7 +58334,7 @@ HD
 HD
 HD
 HD
-jk
+lf
 jk
 lc
 lc
@@ -58424,14 +58588,14 @@ aa
 aa
 HD
 iI
-jk
-jk
+lf
+kn
 hz
 jk
 kH
 ld
 lx
-lW
+pQ
 mt
 jk
 hz
@@ -58680,13 +58844,13 @@ aa
 aa
 aa
 HD
-iK
+iL
 jl
 jz
 HD
 jk
 kH
-lf
+li
 ly
 lX
 mt
@@ -58694,7 +58858,7 @@ jk
 HD
 iK
 jz
-jk
+kn
 HD
 aa
 aa
@@ -58937,16 +59101,16 @@ aa
 aa
 aa
 HD
-iL
+pU
 jk
 jB
 jS
 jl
-kI
+gc
 lg
 lz
 lZ
-mu
+gy
 jl
 jS
 jl
@@ -59194,21 +59358,21 @@ aa
 aa
 aa
 HD
-iK
-jl
+iL
+pV
 jC
 HD
 jk
 kK
 lh
 lC
-ma
+pR
 mv
 jk
 HD
 jk
 jk
-jk
+lf
 HD
 aa
 aa
@@ -59452,19 +59616,19 @@ aa
 aa
 HD
 iM
-jk
-jk
+kn
+kn
 hz
-jk
+kn
 kK
-li
+lW
 lF
 md
 mv
 jk
 hz
 nt
-jk
+kn
 nP
 HD
 aa
@@ -59712,13 +59876,13 @@ HD
 HD
 jm
 HD
-kn
+kM
 kL
 lj
 lG
 me
 kL
-jk
+lf
 HD
 HD
 HD
@@ -59970,9 +60134,9 @@ ez
 ez
 HD
 ko
-kM
+pS
 jz
-la
+jk
 mf
 mw
 ko
@@ -60229,7 +60393,7 @@ HD
 HD
 HD
 ee
-ht
+ma
 il
 HD
 HD
@@ -60473,10 +60637,10 @@ fq
 fB
 fC
 Zp
-fC
+om
 fC
 fB
-fC
+om
 HD
 HD
 iO
@@ -60742,9 +60906,9 @@ jp
 jF
 HD
 HD
-ef
 lH
-fe
+pZ
+oc
 HD
 HD
 HD
@@ -60985,10 +61149,10 @@ aa
 HD
 fA
 gi
-gy
 fC
 fC
-gy
+fC
+fC
 hP
 fC
 HD
@@ -61250,22 +61414,22 @@ hQ
 fC
 HD
 HD
-ez
+pX
 jp
 jF
 jW
 HD
 ff
 dZ
-lI
+ee
 dZ
 HD
 mJ
 mJ
-mJ
+oD
 HD
 mJ
-mJ
+oB
 op
 oH
 HD
@@ -61498,13 +61662,13 @@ aa
 aa
 HD
 fC
-gD
+ol
 fC
 fC
 fC
 gm
 hP
-fC
+om
 HD
 HD
 HD
@@ -61515,14 +61679,14 @@ HD
 HD
 dZ
 ee
-dZ
+nf
 HD
 mJ
-nb
+mJ
 nv
 HD
 mJ
-nb
+mJ
 mJ
 oI
 HD
@@ -61765,9 +61929,9 @@ HD
 HD
 HD
 iV
+nd
 dZ
-dZ
-dZ
+nf
 iV
 HD
 dZ
@@ -62018,7 +62182,7 @@ fD
 fC
 fC
 hP
-gy
+fC
 fC
 HD
 eh
@@ -62029,7 +62193,7 @@ eh
 HD
 dZ
 ee
-eo
+dZ
 HD
 mJ
 nc
@@ -62271,7 +62435,7 @@ HD
 fD
 fC
 fC
-gR
+fC
 fC
 fC
 hV
@@ -62289,8 +62453,8 @@ ee
 dZ
 HD
 mJ
-mJ
-nw
+oD
+gN
 nG
 mJ
 mJ
@@ -62541,7 +62705,7 @@ dZ
 dZ
 eh
 HD
-dZ
+nd
 ee
 dZ
 HD
@@ -62549,8 +62713,8 @@ mL
 mJ
 ny
 mJ
-nd
 mJ
+oD
 or
 HD
 aa
@@ -62795,7 +62959,7 @@ HD
 eh
 dZ
 dZ
-dZ
+nd
 eh
 HD
 eV
@@ -62803,9 +62967,9 @@ ee
 dZ
 HD
 mN
-nd
+mJ
 ny
-nH
+gR
 mJ
 mJ
 os
@@ -63045,7 +63209,7 @@ gG
 gU
 gU
 HD
-dZ
+io
 ee
 dZ
 HD
@@ -63302,13 +63466,13 @@ dR
 dR
 hj
 HD
-dZ
-ee
+io
+lI
 ic
 dZ
 dZ
 dZ
-eQ
+dZ
 dZ
 dZ
 dZ
@@ -63560,8 +63724,8 @@ dR
 hk
 HD
 dZ
-ik
-em
+eQ
+ip
 em
 em
 em
@@ -63818,8 +63982,8 @@ HD
 HD
 ej
 ee
-dZ
-dZ
+io
+io
 ic
 dZ
 dZ
@@ -63833,7 +63997,7 @@ ht
 eV
 dZ
 dZ
-eQ
+dZ
 dZ
 ht
 dZ
@@ -64839,7 +65003,7 @@ aa
 aa
 HD
 fN
-gq
+fO
 gJ
 gJ
 hn
@@ -64854,16 +65018,16 @@ jI
 ka
 HD
 kQ
-lm
+pq
 hF
 hF
 hF
 hF
-nf
-ll
+iE
+pu
 mh
 hF
-oi
+hF
 ou
 HD
 aa
@@ -65874,7 +66038,7 @@ hc
 hz
 dZ
 ee
-eo
+dZ
 hz
 dZ
 dZ
@@ -65882,12 +66046,12 @@ jJ
 jt
 HD
 hF
-lm
 hF
 hF
 hF
 hF
-lm
+hF
+hF
 hF
 HD
 aa
@@ -66125,7 +66289,7 @@ aa
 HD
 fU
 fO
-gq
+fO
 fO
 ho
 HD
@@ -66478,7 +66642,7 @@ aa
 ac
 ad
 ah
-at
+al
 ar
 bn
 ad
@@ -66992,7 +67156,7 @@ aa
 ac
 ad
 am
-at
+cn
 ak
 aE
 aF
@@ -67000,8 +67164,8 @@ aQ
 ar
 ad
 bf
-hw
-ie
+bq
+at
 aI
 aI
 zU
@@ -67414,9 +67578,9 @@ gM
 hf
 hq
 HD
-dZ
-ee
-dZ
+io
+lI
+io
 HD
 HD
 HD
@@ -67660,7 +67824,7 @@ aa
 aa
 HD
 eN
-dZ
+nd
 dZ
 dZ
 dZ
@@ -67671,9 +67835,9 @@ ez
 eI
 ez
 HD
-dZ
-ee
-ic
+io
+mD
+mj
 et
 HD
 HD
@@ -67763,7 +67927,7 @@ aa
 ac
 ab
 al
-at
+al
 ad
 ad
 bc
@@ -67919,12 +68083,12 @@ HD
 eP
 dZ
 ej
-eQ
 dZ
+nd
 fh
 HD
 gt
-gN
+ez
 ez
 HD
 HD
@@ -68461,7 +68625,7 @@ HD
 HD
 HD
 nX
-eV
+dZ
 ic
 dZ
 dZ
@@ -68695,12 +68859,12 @@ dZ
 dZ
 dZ
 dZ
-eo
+dZ
 dZ
 dZ
 hF
 hY
-io
+fn
 hY
 hF
 dZ
@@ -68709,16 +68873,16 @@ dZ
 dZ
 ej
 dZ
-eo
+dZ
 ic
 dZ
+io
+io
 dZ
-dZ
-ni
 ed
-nI
+jy
 nY
-eV
+dZ
 oy
 oJ
 ej
@@ -68952,16 +69116,16 @@ em
 em
 em
 em
-em
-em
-em
-hG
-hZ
 ip
+nC
+em
+hG
+eo
 hZ
+eo
 hG
 em
-jw
+iz
 em
 em
 em
@@ -68969,13 +69133,13 @@ em
 em
 em
 em
+ip
+mu
 em
 mO
-em
-nC
-nJ
+kI
 oa
-ol
+la
 oz
 oK
 fh
@@ -69056,9 +69220,9 @@ aa
 aa
 aa
 aI
-hR
+aW
 bF
-nq
+cv
 aI
 aa
 aa
@@ -69204,17 +69368,17 @@ eC
 dZ
 ee
 dZ
-eQ
+dZ
 dZ
 dZ
 ep
 ej
-eo
-dZ
+io
+io
 dZ
 hF
 hY
-io
+fn
 hY
 iE
 dZ
@@ -69223,16 +69387,16 @@ jM
 dZ
 dZ
 dZ
-eo
+dZ
 ep
 ej
-dZ
-dZ
-nk
+io
+io
+ic
 ef
-nI
+jy
 oc
-eV
+dZ
 oA
 oM
 dZ
@@ -69455,10 +69619,10 @@ dQ
 dW
 HD
 ej
-eo
+nd
 dZ
 HD
-eQ
+dZ
 ee
 dZ
 HD
@@ -69470,7 +69634,7 @@ HD
 HD
 ht
 hH
-hF
+nw
 in
 hF
 hY
@@ -69489,7 +69653,7 @@ HD
 HD
 HD
 od
-om
+ic
 ej
 dZ
 dZ
@@ -69721,7 +69885,7 @@ dZ
 eC
 dZ
 fm
-gc
+ge
 dZ
 HD
 HD
@@ -69976,10 +70140,10 @@ ej
 ee
 dZ
 eC
-dZ
+nb
 ev
 ev
-dZ
+nd
 HD
 HD
 dV
@@ -70004,7 +70168,7 @@ aa
 aa
 HD
 HD
-oB
+lm
 HD
 HD
 aa
@@ -70229,12 +70393,12 @@ HD
 HD
 HD
 HD
-eo
+dZ
 ee
 fh
 HD
 dZ
-fn
+ex
 ex
 dZ
 HD
@@ -70261,7 +70425,7 @@ aa
 aa
 HD
 fC
-fC
+nI
 oP
 HD
 aa
@@ -70347,7 +70511,7 @@ aV
 aV
 bj
 ca
-cn
+ct
 cw
 aN
 cm
@@ -70488,7 +70652,7 @@ eu
 eC
 ev
 ee
-eo
+dZ
 eE
 dZ
 dZ
@@ -70499,8 +70663,8 @@ dR
 dR
 HD
 dZ
-ee
-dZ
+lI
+io
 HD
 HD
 HD
@@ -70518,7 +70682,7 @@ aa
 aa
 HD
 fC
-oD
+fC
 fC
 HD
 aa
@@ -70749,15 +70913,15 @@ ev
 HD
 dZ
 dZ
-dZ
+nd
 dZ
 HD
 fb
 dS
 HD
 dZ
-ee
-dZ
+lI
+mE
 HD
 HD
 HD
@@ -71000,7 +71164,7 @@ dZ
 ej
 dZ
 HD
-dZ
+ni
 fd
 eV
 HD
@@ -71012,9 +71176,9 @@ HD
 HD
 HD
 HD
-eo
+dZ
 ir
-iz
+fh
 HD
 jf
 jx
@@ -71025,7 +71189,7 @@ HD
 lq
 lP
 hY
-mD
+mR
 mR
 HD
 aa
@@ -71253,13 +71417,13 @@ HD
 dQ
 dW
 HD
-dZ
+nd
 dZ
 dZ
 eE
-dZ
+ej
 ee
-dZ
+ni
 HD
 HD
 HD
@@ -71278,11 +71442,11 @@ hY
 hY
 hY
 ku
-kX
 lr
+gq
 lP
-mj
-hY
+hE
+ik
 mS
 HD
 aa
@@ -71376,9 +71540,9 @@ aV
 bj
 aV
 aV
-bu
 aV
 aV
+hr
 ac
 SM
 dl
@@ -71515,7 +71679,7 @@ dZ
 ev
 HD
 dZ
-ee
+oi
 dZ
 eC
 dZ
@@ -71539,7 +71703,7 @@ HD
 lq
 lP
 hY
-mE
+mU
 mU
 HD
 aa
@@ -71624,7 +71788,7 @@ aa
 aa
 aa
 pp
-aS
+aN
 ac
 bw
 bI
@@ -71633,7 +71797,7 @@ bU
 bY
 cc
 aV
-bu
+aV
 aV
 cL
 ac
@@ -71778,7 +71942,7 @@ eC
 dZ
 ev
 gf
-dZ
+nd
 HD
 HD
 dV
@@ -71881,7 +72045,7 @@ aa
 aa
 aa
 aN
-pq
+aS
 bj
 aV
 aV
@@ -72028,7 +72192,7 @@ HD
 HD
 HD
 HD
-dZ
+ni
 ee
 fh
 HD
@@ -72045,8 +72209,8 @@ it
 dZ
 HD
 jg
-jy
 jO
+nq
 kf
 hG
 hG
@@ -72279,7 +72443,7 @@ aa
 aa
 aa
 HD
-dZ
+ni
 dZ
 dZ
 er
@@ -72288,7 +72452,7 @@ dZ
 dZ
 ee
 dZ
-eD
+eE
 dZ
 dZ
 dZ
@@ -72302,7 +72466,7 @@ iu
 iA
 iH
 hG
-hG
+nk
 jP
 HD
 kv
@@ -72313,7 +72477,7 @@ HD
 HD
 mW
 hY
-hY
+nH
 nK
 hY
 HD
@@ -72394,7 +72558,7 @@ aa
 aa
 aa
 aN
-aS
+aN
 bd
 ac
 aV
@@ -72404,7 +72568,7 @@ bX
 ac
 ce
 aV
-bu
+aV
 cE
 cM
 ac
@@ -72537,7 +72701,7 @@ aa
 aa
 HD
 dZ
-ed
+nJ
 em
 em
 em
@@ -72547,7 +72711,7 @@ fe
 ej
 HD
 dZ
-dZ
+nf
 dZ
 dZ
 HD
@@ -72559,9 +72723,9 @@ dZ
 ej
 HD
 jg
-jy
-hY
-hz
+jO
+jO
+kX
 kw
 kY
 hY
@@ -72650,17 +72814,17 @@ aa
 aa
 aa
 bq
-aS
+aN
 aN
 pr
 ac
 by
-bu
+aV
 bI
 aV
 bj
 cf
-bu
+aV
 bM
 cF
 cN
@@ -72670,7 +72834,7 @@ aV
 aV
 aV
 aV
-cO
+ie
 ac
 aX
 aX
@@ -72795,13 +72959,13 @@ aa
 HD
 dZ
 ee
+ej
+ni
 dZ
 dZ
 dZ
 dZ
-dZ
-dZ
-dZ
+ni
 HD
 eu
 fp
@@ -72818,7 +72982,7 @@ HD
 hY
 hY
 hY
-hz
+kX
 ky
 hY
 hY
@@ -73076,9 +73240,9 @@ hY
 hY
 hY
 HD
-hz
-hz
-hz
+kX
+kX
+kX
 HD
 HD
 HD
@@ -73169,12 +73333,12 @@ ac
 ac
 ac
 bz
-bu
+aV
 aV
 aV
 bZ
 cg
-aV
+hr
 aV
 aV
 aV
@@ -73307,7 +73471,7 @@ HD
 HD
 HD
 HD
-dZ
+ni
 ee
 dZ
 HD
@@ -73343,7 +73507,7 @@ hY
 hE
 hY
 hY
-hY
+nH
 kg
 hY
 HD
@@ -73422,7 +73586,7 @@ aa
 aa
 bB
 aV
-aW
+aV
 aV
 ac
 bA
@@ -73433,7 +73597,7 @@ bj
 aV
 aV
 aV
-bu
+aV
 aV
 py
 aV
@@ -73564,7 +73728,7 @@ HD
 dN
 dO
 dT
-dZ
+ej
 ef
 em
 es
@@ -73591,7 +73755,7 @@ hY
 hY
 hY
 hY
-hY
+nH
 hY
 hY
 hY
@@ -73678,8 +73842,8 @@ aa
 aa
 aa
 aV
-aW
-aW
+aV
+aV
 aV
 bj
 aV
@@ -73694,10 +73858,10 @@ cG
 cO
 ac
 bx
-cr
-cy
-cy
-cG
+hw
+hw
+hw
+hw
 aV
 ac
 aa
@@ -73947,14 +74111,14 @@ bj
 aV
 aV
 bI
-pu
+sA
 aV
 py
 sA
-aV
+hw
 pH
-pA
-dq
+hR
+hw
 aV
 ac
 aa
@@ -74198,11 +74362,11 @@ ac
 ac
 bC
 aV
-bu
+aV
 aV
 bZ
 bV
-aV
+bu
 aV
 aV
 aV
@@ -74718,7 +74882,7 @@ ac
 ci
 aV
 bI
-bu
+aV
 bR
 ac
 ac
@@ -74975,7 +75139,7 @@ ac
 cj
 bM
 aV
-bu
+aV
 aV
 ac
 aa

--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -2424,7 +2424,6 @@
 	},
 /area/f13/wasteland)
 "agI" = (
-/obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 10;
 	icon_state = "rubble";
@@ -8906,11 +8905,8 @@
 	},
 /area/f13/wasteland)
 "axs" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3";
-	tag = "icon-horizontaltopbordertop3"
-	},
+/obj/structure/bus_door,
+/turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
 "axt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9060,10 +9056,9 @@
 	},
 /area/f13/wasteland)
 "axP" = (
-/obj/item/ammo_casing/shotgun/buckshot,
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
-	tag = "icon-horizontaltopborderbottom0"
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
 "axQ" = (
@@ -12219,9 +12214,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "aGf" = (
-/obj/effect/decal/cleanable/cum,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/wasteland)
 "aGg" = (
 /obj/structure/fence{
 	dir = 4;
@@ -13715,6 +13709,14 @@
 	tag = "icon-outermaincornerouter"
 	},
 /area/f13/wasteland)
+"aKm" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerpavement";
+	tag = "icon-outerpavement (EAST)"
+	},
+/area/f13/wasteland)
 "aKn" = (
 /obj/structure/simple_door/house{
 	tag = "icon-room";
@@ -13777,7 +13779,7 @@
 	dir = 8;
 	icon_state = "dirt"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "aKw" = (
 /obj/structure/fence{
 	dir = 4;
@@ -13956,6 +13958,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"aKZ" = (
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "aLa" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -13979,36 +13984,35 @@
 /area/f13/building)
 "aLd" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/draculass,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
 /area/f13/building)
 "aLe" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/pirate,
-/turf/open/floor/f13{
-	icon_state = "bar"
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	tag = "icon-innermaincornerouter (EAST)";
+	icon_state = "innermaincornerouter";
+	dir = 4
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "aLf" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/suit_jacket/female,
-/turf/open/floor/f13{
-	icon_state = "bar"
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	tag = "icon-innermaincornerouter (WEST)";
+	icon_state = "innermaincornerouter";
+	dir = 8
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "aLg" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/geisha,
-/turf/open/floor/f13{
-	icon_state = "bar"
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33";
+	tag = "icon-wasteland33"
 	},
-/area/f13/building)
+/area/f13/wasteland)
 "aLh" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/outside/dirt,
@@ -14171,16 +14175,12 @@
 	},
 /area/f13/building)
 "aLC" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench";
-	tag = "icon-bench (WEST)"
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
 	},
-/obj/effect/decal/cleanable/cum,
-/turf/open/floor/f13{
-	icon_state = "bar"
-	},
-/area/f13/building)
+/area/f13/wasteland)
 "aLD" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical";
@@ -14207,12 +14207,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aLH" = (
+/obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt (SOUTHWEST)";
-	icon_state = "dirt";
-	dir = 10
+	icon_state = "dirt"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "aLI" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
@@ -14221,11 +14220,9 @@
 	},
 /area/f13/wasteland)
 "aLJ" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/city)
+/obj/machinery/light/kebab_sign,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "aLK" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/city)
@@ -14337,13 +14334,17 @@
 	},
 /area/f13/wasteland)
 "aMa" = (
-/obj/machinery/light/kebab_sign,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"aMb" = (
 /obj/effect/landmark/start/f13/settler,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/wasteland)
+"aMb" = (
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/dirt{
+	tag = "icon-dirt (NORTH)";
+	icon_state = "dirt";
+	dir = 1
+	},
+/area/f13/wasteland)
 "aMc" = (
 /obj/item/clothing/head/f13/police,
 /obj/item/clothing/under/f13/police,
@@ -14483,7 +14484,7 @@
 /area/f13/building)
 "aMw" = (
 /obj/structure/table,
-/obj/item/lighter,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13,
 /area/f13/building)
 "aMx" = (
@@ -14718,12 +14719,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "aNe" = (
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt (NORTHWEST)";
-	icon_state = "dirt";
-	dir = 9
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "ruins12"
 	},
-/area/f13/city)
+/area/space)
 "aNf" = (
 /obj/structure/tires/two,
 /turf/open/floor/f13/wood{
@@ -14746,12 +14745,8 @@
 /area/f13/village)
 "aNi" = (
 /obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt (NORTH)";
-	icon_state = "dirt";
-	dir = 1
-	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "aNj" = (
 /obj/structure/chair,
 /obj/effect/spawner/lootdrop/trash,
@@ -14882,6 +14877,10 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"aNB" = (
+/mob/living/simple_animal/hostile/handy/assaultron,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aNC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/pill/patch/jet,
@@ -15051,6 +15050,7 @@
 /area/f13/building)
 "aOa" = (
 /obj/structure/table/glass,
+/obj/item/lighter,
 /turf/open/floor/f13,
 /area/f13/building)
 "aOb" = (
@@ -15092,9 +15092,15 @@
 	},
 /area/f13/village)
 "aOh" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	tag = "icon-dirt (NORTHWEST)";
+	icon_state = "dirt";
+	dir = 9
+	},
+/area/f13/wasteland)
 "aOi" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/f13/eyebot,
@@ -15391,6 +15397,15 @@
 /obj/effect/spawner/lootdrop/ammo,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"aOY" = (
+/obj/machinery/autolathe/ammobench,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"aOZ" = (
+/obj/machinery/light,
+/obj/machinery/workbench,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "aPa" = (
 /obj/structure/chair{
 	dir = 8
@@ -15425,26 +15440,46 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
+"aPe" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/obj/item/stack/sheet/plastic,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"aPf" = (
+/obj/structure/rack,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "aPg" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2";
-	tag = "icon-horizontaltopbordertop2"
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	tag = "icon-tree_3"
 	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "aPh" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop3";
-	tag = "icon-horizontaltopbordertop3"
-	},
-/area/f13/wasteland)
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aPi" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2";
-	tag = "icon-horizontaltopbordertop2"
-	},
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "aPj" = (
 /obj/structure/barricade/wooden,
@@ -15528,24 +15563,20 @@
 "aPv" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2left";
-	tag = "icon-horizontaltopborderbottom2left (WEST)"
+	tag = "icon-horizontalbottombordertopright";
+	icon_state = "horizontalbottombordertopright"
 	},
 /area/f13/wasteland)
 "aPw" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontaltopborderbottom2right";
-	tag = "icon-horizontaltopborderbottom2right (WEST)"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/wood/f13,
+/area/f13/building)
 "aPx" = (
 /obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
-	tag = "icon-horizontaltopborderbottom0"
+/turf/open/indestructible/ground/outside/sidewalk{
+	tag = "icon-horizontaltopbordertopright";
+	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland)
 "aPy" = (
@@ -15750,22 +15781,21 @@
 "aQa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
+	tag = "icon-horizontaltopborderbottomright";
+	icon_state = "horizontaltopborderbottomright"
 	},
 /area/f13/wasteland)
 "aQb" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left";
-	tag = "icon-horizontalinnermain2left (WEST)"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/wood/f13,
+/area/f13/building)
 "aQc" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop2";
-	tag = "icon-horizontalbottombordertop2"
+	dir = 8;
+	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right (WEST)"
 	},
 /area/f13/wasteland)
 "aQd" = (
@@ -15846,12 +15876,15 @@
 	},
 /area/f13/wasteland)
 "aQo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/dirt{
 	tag = "icon-dirt (NORTHEAST)";
 	icon_state = "dirt";
 	dir = 5
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "aQp" = (
 /obj/structure/bonfire,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15943,13 +15976,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aQC" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight";
-	tag = "icon-metal_fence3"
+/obj/structure/guillotine,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "transition3"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/area/f13/wasteland)
 "aQD" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15957,6 +15988,20 @@
 	tag = "icon-horizontaloutermainleft"
 	},
 /area/f13/wasteland)
+"aQE" = (
+/obj/structure/rack,
+/obj/item/stack/crafting/goodparts/five,
+/obj/item/stack/crafting/goodparts/five,
+/obj/item/stack/crafting/metalparts/five,
+/obj/item/stack/crafting/metalparts/five,
+/obj/item/stack/crafting/metalparts/five,
+/obj/item/stack/crafting/metalparts/five,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"aQF" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "aQG" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -15964,6 +16009,11 @@
 	tag = "icon-outermaincornerinner"
 	},
 /area/f13/wasteland)
+"aQH" = (
+/obj/structure/rack,
+/obj/item/stack/crafting/electronicparts/five,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "aQI" = (
 /obj/structure/table/wood/settler,
 /obj/machinery/light/small{
@@ -16745,25 +16795,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aTa" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt (NORTHWEST)";
-	icon_state = "dirt";
-	dir = 9
+	icon_state = "dirtcorner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "aTb" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt (NORTHEAST)";
-	icon_state = "dirt";
-	dir = 5
-	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aTc" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/desert,
@@ -16854,8 +16896,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aTr" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood/f13,
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/f13/armor/costumes,
+/obj/item/clothing/under/schoolgirl/green,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aTs" = (
 /obj/structure/chair/wood/worn{
@@ -17076,6 +17121,20 @@
 /obj/item/shovel,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"aTY" = (
+/obj/structure/rack,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/ncr/high,
+/obj/item/stack/f13Cash/random/denarius/high,
+/obj/item/stack/f13Cash/random/bottle_cap/high,
+/obj/item/stack/f13Cash/random/bottle_cap/high,
+/obj/item/stack/f13Cash/random/bottle_cap/high,
+/obj/item/stack/f13Cash/random/bottle_cap/high,
+/obj/item/stack/f13Cash/random/aureus/high,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "aTZ" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17471,18 +17530,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aVl" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
-	},
-/area/f13/city)
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aVm" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
+/obj/structure/simple_door/metal/fence{
 	dir = 8;
-	icon_state = "dirtcorner"
+	icon_state = "fence"
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aVn" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/female/tribal,
@@ -17581,10 +17642,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "aVD" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/costumes,
-/obj/item/clothing/under/schoolgirl/green,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13,
 /area/f13/building)
 "aVE" = (
 /obj/structure/bed,
@@ -17618,12 +17678,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "aVJ" = (
-/obj/structure/flora/tree/tall{
-	tag = "icon-tree_2";
-	icon_state = "tree_2"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "aVK" = (
 /obj/structure/fence{
 	dir = 4;
@@ -17719,6 +17776,19 @@
 "aVV" = (
 /turf/open/floor/f13/wood,
 /area/f13/radiation)
+"aVW" = (
+/obj/machinery/button/door{
+	id = "Store_Shutters";
+	name = "window shutters";
+	pixel_y = 8
+	},
+/obj/structure/table/wood,
+/obj/machinery/button/door{
+	id = "shop_counter_windows";
+	name = "counter shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "aVX" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -18423,11 +18493,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aYa" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/storage/backpack{
+	tag = "icon-satchel";
+	icon_state = "satchel"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aYb" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -18526,9 +18602,9 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/village)
 "aYr" = (
-/obj/structure/sink/well,
+/obj/structure/chair,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/area/f13/wasteland)
 "aYs" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/dirt{
@@ -21592,9 +21668,12 @@
 	},
 /area/f13/wasteland)
 "bgd" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "bge" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal";
@@ -21758,6 +21837,15 @@
 	dir = 10
 	},
 /area/f13/wasteland)
+"bgz" = (
+/obj/structure/table/wood,
+/obj/item/gun/ballistic/shotgun/hunting,
+/obj/machinery/door/poddoor/shutters{
+	id = "shop_counter_windows";
+	name = "interior shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "bgA" = (
 /turf/open/indestructible/ground/outside/dirt{
 	tag = "icon-dirt (EAST)";
@@ -21841,6 +21929,15 @@
 	dir = 1
 	},
 /area/f13/wasteland)
+"bgM" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/mining,
+/obj/machinery/door/poddoor/shutters{
+	id = "shop_counter_windows";
+	name = "interior shutters"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "bgN" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/outside/dirt{
@@ -21997,6 +22094,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building)
+"bhi" = (
+/obj/machinery/door/airlock/wood{
+	req_access = 34;
+	req_access_txt = "34";
+	req_one_access = 34;
+	req_one_access_txt = "34"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "bhj" = (
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22314,16 +22420,11 @@
 /area/f13/city)
 "bhX" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/storage/backpack{
-	tag = "icon-satchel";
-	icon_state = "satchel"
-	},
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
-	icon_state = "dirt"
+	icon_state = "dirtcorner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "bhY" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/random/bottle_cap/med,
@@ -22446,6 +22547,19 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"bip" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
+"biq" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/obj/effect/decal/waste,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"bir" = (
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
 "bis" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/light/small{
@@ -22617,9 +22731,13 @@
 	},
 /area/f13/farm)
 "biN" = (
-/obj/structure/chair,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "biO" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -22669,6 +22787,10 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
+"biV" = (
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "biW" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/dirt{
@@ -22699,17 +22821,22 @@
 /obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bja" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
 "bjb" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bjc" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+	dir = 1;
+	icon_state = "dirtcorner"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "bjd" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
@@ -22722,6 +22849,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"bjf" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/caves)
+"bjg" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "bjh" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -22779,12 +22914,15 @@
 	},
 /area/f13/building)
 "bjq" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibmid3";
+	pixel_x = -10;
+	pixel_y = -2;
+	tag = "icon-gibmid3"
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/tunnel)
 "bjr" = (
 /obj/machinery/trading_machine/weapon,
 /turf/open/floor/f13/wood,
@@ -22813,12 +22951,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bjw" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/obj/structure/chair{
+	tag = "icon-chair (WEST)";
+	icon_state = "chair";
+	dir = 8
 	},
-/area/f13/city)
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "bjx" = (
 /turf/open/floor/f13/wood,
 /area/f13/city)
@@ -22865,21 +23006,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bjE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/city)
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bjF" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
+/turf/open/indestructible/ground/outside/desert{
+	tag = "icon-wasteland33";
+	icon_state = "wasteland33"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "bjG" = (
 /obj/effect/decal/remains/human,
 /obj/item/reagent_containers/pill/patch/healingpowder,
@@ -23023,6 +23158,35 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/city)
+"bjY" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"bjZ" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/tunnel,
+/area/f13/tunnel)
+"bka" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner"
+	},
+/area/f13/wasteland)
+"bkb" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	dir = 1;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (NORTH)"
+	},
+/area/f13/wasteland)
+"bkc" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland)
 "bkd" = (
 /obj/structure/simple_door/house{
 	tag = "icon-roomopening";
@@ -23090,23 +23254,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bkl" = (
-/obj/structure/chair{
-	tag = "icon-chair (WEST)";
-	icon_state = "chair";
-	dir = 8
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "ruins3"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/city)
+/area/space)
 "bkm" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
-"bkn" = (
-/obj/structure/fence/corner{
-	icon_state = "corner";
-	dir = 1
-	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
 "bko" = (
@@ -23194,12 +23346,8 @@
 	},
 /area/f13/village)
 "bkz" = (
-/obj/structure/flora/tree/tall{
-	tag = "icon-tree_3";
-	icon_state = "tree_3"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
+/turf/closed/wall/f13/wood/house,
+/area/space)
 "bkA" = (
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
@@ -23305,13 +23453,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"bkU" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+"bkS" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/sidewalk{
+	tag = "icon-horizontalbottomborderbottomright";
+	icon_state = "horizontalbottomborderbottomright"
 	},
-/area/f13/city)
+/area/f13/wasteland)
 "bkV" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -23340,12 +23488,6 @@
 /obj/item/storage/pill_bottle/chem_tin/mentats,
 /obj/item/storage/pill_bottle/chem_tin/mentats,
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"bkZ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt";
-	icon_state = "dirt"
-	},
 /area/f13/city)
 "bla" = (
 /obj/item/shovel,
@@ -23422,10 +23564,6 @@
 "blo" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"blp" = (
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "blq" = (
 /obj/structure/chair/wood/fancy{
@@ -23506,12 +23644,6 @@
 /obj/item/clothing/under/f13/settler,
 /obj/item/clothing/head/f13/town,
 /obj/item/clothing/suit/armor/f13/town,
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"blF" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar,
-/obj/item/reagent_containers/food/condiment/pack/ketchup,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "blG" = (
@@ -23619,12 +23751,6 @@
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
-"bma" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "bmb" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/settler,
@@ -23708,11 +23834,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
-"bmn" = (
-/obj/structure/table/wood,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "bmo" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -23806,12 +23927,6 @@
 /obj/item/seeds/xander,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/city)
-"bmD" = (
-/turf/open/indestructible/ground/outside/desert{
-	tag = "icon-wasteland32";
-	icon_state = "wasteland32"
-	},
-/area/f13/city)
 "bmF" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/city)
@@ -23835,19 +23950,6 @@
 /obj/structure/window/fulltile/house,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"bmJ" = (
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirtcorner";
-	icon_state = "dirtcorner"
-	},
-/area/f13/city)
-"bmK" = (
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirt (SOUTHEAST)";
-	icon_state = "dirt";
-	dir = 6
-	},
-/area/f13/city)
 "bmL" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/f13/wood,
@@ -23858,13 +23960,6 @@
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"bmN" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	tag = "icon-dirtcorner";
-	icon_state = "dirtcorner"
-	},
 /area/f13/city)
 "bmO" = (
 /obj/machinery/reagentgrinder,
@@ -23893,13 +23988,6 @@
 /obj/structure/closet/cabinet,
 /obj/item/storage/pill_bottle/stimulant,
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"bmT" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
 /area/f13/city)
 "bmU" = (
 /obj/structure/window/fulltile/wood,
@@ -24018,16 +24106,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/city)
-"bnj" = (
-/obj/structure/fence{
-	dir = 4;
-	icon_state = "straight";
-	tag = "icon-metal_fence3"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "bnk" = (
 /obj/structure/toilet{
 	pixel_y = 0
@@ -24071,16 +24149,6 @@
 "bnr" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
-/area/f13/city)
-"bns" = (
-/obj/structure/fence/corner{
-	icon_state = "corner";
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
 /area/f13/city)
 "bnt" = (
 /obj/structure/table/wood,
@@ -24161,13 +24229,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"bnH" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "bnI" = (
 /obj/structure/simple_door/house{
 	tag = "icon-roomopening";
@@ -24241,12 +24302,6 @@
 /obj/machinery/light,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
-	},
-/area/f13/city)
-"bnP" = (
-/turf/open/indestructible/ground/outside/desert{
-	tag = "icon-wasteland33";
-	icon_state = "wasteland33"
 	},
 /area/f13/city)
 "bnQ" = (
@@ -24365,27 +24420,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/clinic)
-"boi" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/city)
-"boj" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8;
-	icon_state = "fence"
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt"
-	},
-/area/f13/city)
-"bok" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/city)
 "bol" = (
 /turf/open/floor/f13{
 	tag = "icon-bluedirtychess2";
@@ -26770,37 +26804,6 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"bvi" = (
-/obj/structure/window/fulltile/house{
-	tag = "icon-housewindowvertical (NORTHEAST)";
-	icon_state = "housewindowvertical"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "Store_Shutters";
-	name = "storm shutters"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "Store_Shutters";
-	name = "storm shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"bvj" = (
-/obj/structure/simple_door/house,
-/obj/machinery/door/poddoor/shutters{
-	id = "Store_Shutters";
-	name = "storm shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
-"bvk" = (
-/obj/structure/table/wood,
-/obj/machinery/button/door{
-	id = "Store_Shutters";
-	name = "window shutters"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "bvl" = (
 /turf/closed/indestructible/fakeglass,
 /area/f13/tunnel)
@@ -27924,10 +27927,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
-"bBs" = (
-/mob/living/simple_animal/hostile/alien,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "bBt" = (
 /obj/item/pickaxe,
 /obj/item/clothing/head/hardhat,
@@ -28537,10 +28536,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
-"bCQ" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
-/turf/open/floor/plating/tunnel,
-/area/f13/tunnel)
 "bCR" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -28613,10 +28608,6 @@
 "bDe" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
-"bDf" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bDg" = (
 /obj/machinery/light,
 /turf/open/floor/f13{
@@ -28635,14 +28626,6 @@
 /obj/docking_port/stationary/bosaway,
 /turf/closed/wall/f13/tunnel,
 /area/f13/tunnel)
-"bDj" = (
-/mob/living/simple_animal/hostile/alien,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bDk" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bDl" = (
 /obj/machinery/light{
 	dir = 8;
@@ -28694,10 +28677,6 @@
 	icon_state = "whitebluechess"
 	},
 /area/f13/brotherhood)
-"bDt" = (
-/mob/living/simple_animal/hostile/handy/sentrybot,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bDu" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -29712,33 +29691,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"bGG" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/road{
-	tag = "icon-verticalinnermain1";
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland)
-"bGI" = (
-/obj/structure/fence{
-	icon_state = "straight";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	tag = "icon-verticalleftborderright2";
-	icon_state = "verticalleftborderright2"
-	},
-/area/f13/wasteland)
-"bGJ" = (
-/obj/structure/fence{
-	icon_state = "straight";
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/road{
-	tag = "icon-verticalrightborderleft2";
-	icon_state = "verticalrightborderleft2"
-	},
-/area/f13/wasteland)
 "bGK" = (
 /obj/structure/chair{
 	dir = 1
@@ -29784,28 +29736,6 @@
 	icon_state = "dark"
 	},
 /area/f13/brotherhood)
-"bGU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bGV" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille/indestructable,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bGW" = (
-/obj/machinery/porta_turret/syndicate,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bGX" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bGY" = (
 /obj/docking_port/stationary/bosaway/three,
 /turf/closed/wall/f13/tunnel,
@@ -29813,23 +29743,6 @@
 "bGZ" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
-"bHa" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bHb" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bHc" = (
-/turf/closed/indestructible/rock,
 /area/f13/tunnel)
 "bHd" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -29947,10 +29860,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bHx" = (
-/obj/machinery/light,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bHy" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/inside/subway,
@@ -29963,30 +29872,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
-"bHA" = (
-/obj/machinery/porta_turret/syndicate,
-/obj/machinery/light,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bHB" = (
-/obj/machinery/porta_turret/syndicate,
-/obj/machinery/light,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bHC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bHD" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old";
@@ -30005,28 +29890,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bHG" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube"
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
-"bHH" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bHI" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
@@ -30070,10 +29933,6 @@
 /obj/docking_port/stationary/bosaway/eleven,
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
-"bHV" = (
-/mob/living/simple_animal/hostile/eyebot,
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bHW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -30300,15 +30159,6 @@
 	tag = "icon-reddirtyfull"
 	},
 /area/f13/clinic)
-"bJe" = (
-/obj/effect/decal/cleanable/blood/gibs/down{
-	icon_state = "gibmid3";
-	pixel_x = -10;
-	pixel_y = -2;
-	tag = "icon-gibmid3"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
 "bJr" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/f13{
@@ -31677,15 +31527,6 @@
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"bNP" = (
-/obj/machinery/porta_turret/syndicate,
-/obj/machinery/light,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bNQ" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -31786,13 +31627,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"bOg" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/caves)
 "bOh" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/decal/remains/xeno,
@@ -40561,17 +40395,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/f13/legion)
-"cmg" = (
-/obj/structure/simple_door/bunker,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"cmh" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
 "cmn" = (
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
@@ -40591,10 +40414,6 @@
 /area/f13/caves)
 "cnc" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"cnd" = (
-/mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "cne" = (
@@ -42277,11 +42096,6 @@
 	tag = "icon-floorrusty"
 	},
 /area/f13/caves)
-"dvi" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "epP" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -42407,11 +42221,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"jdA" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/mining,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "jjW" = (
 /obj/effect/spawner/lootdrop/f13/cash_ncr_high,
 /obj/effect/decal/remains/human,
@@ -42454,11 +42263,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"kjj" = (
-/obj/structure/table/wood,
-/obj/item/gun/ballistic/shotgun/hunting,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "kmN" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /obj/effect/decal/remains/human,
@@ -42612,10 +42416,6 @@
 	tag = "icon-housewood2"
 	},
 /area/f13/village)
-"svG" = (
-/obj/structure/flora/stump,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/city)
 "sAf" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -42715,10 +42515,6 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
-"vaQ" = (
-/obj/structure/guncase/shotgun,
-/turf/open/floor/f13/wood,
-/area/f13/city)
 "vnY" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
@@ -43254,9 +43050,9 @@ ayl
 ayF
 aab
 aae
-aaa
 aae
-aae
+aKZ
+aPg
 aBZ
 aTw
 aBZ
@@ -43511,9 +43307,9 @@ aym
 ayG
 aab
 aae
-aaa
-aae
-aae
+aKZ
+aKZ
+aKZ
 aBZ
 aTw
 aBZ
@@ -43536,15 +43332,15 @@ aUo
 aPI
 aEl
 aEl
+bmS
 btp
-bkd
-bjx
-btp
-bjx
+aTY
+aQH
+aQE
 aEl
-blE
-bmb
-blE
+aPf
+btp
+aOY
 bmF
 blE
 btp
@@ -43768,9 +43564,9 @@ aym
 ayH
 aab
 aab
-aaa
-aae
-aae
+aPg
+aKZ
+aKZ
 aBZ
 aTw
 aBZ
@@ -43793,15 +43589,15 @@ aGv
 aGv
 bej
 aEl
-vaQ
-aLK
-bmS
 bkV
 bjx
-aEl
 bjx
 bjx
-bjv
+bjx
+bhi
+bjx
+bjx
+bnq
 bmF
 bkE
 bjx
@@ -44024,9 +43820,9 @@ aiv
 aiv
 aeV
 ayW
-aae
-aaa
-aae
+aKZ
+aKZ
+aKZ
 aae
 aBZ
 aTw
@@ -44054,11 +43850,11 @@ aLK
 aLK
 aLK
 aLK
-bkd
+bhi
 aEl
-bjt
-blI
-bmn
+aPe
+bjx
+aOZ
 bmF
 bmb
 bjx
@@ -44281,9 +44077,9 @@ aiv
 ayn
 aeV
 ayW
-aae
-aaa
-aae
+aKZ
+aKZ
+aKZ
 aae
 aBZ
 aTw
@@ -44313,9 +44109,9 @@ bkC
 bkY
 bjx
 aEl
-blF
-bjx
-boq
+aEl
+aEl
+aEl
 bmF
 blE
 bjx
@@ -44538,9 +44334,9 @@ aiv
 aiv
 ayN
 ayW
-aae
-aaa
-aae
+aKZ
+aKZ
+aKZ
 aae
 aBZ
 aTw
@@ -44564,7 +44360,7 @@ aEl
 aXY
 bfp
 aEl
-bjq
+aVW
 bkk
 bjx
 bjx
@@ -44795,9 +44591,9 @@ abS
 aiv
 aeV
 ayW
-aae
-aaa
-aae
+aKZ
+aKZ
+aKZ
 aae
 aBZ
 aTw
@@ -44821,11 +44617,11 @@ aEl
 aEl
 aEl
 aEl
-bvk
-kjj
-jdA
-dvi
-bpm
+aEl
+bgz
+bgM
+aEl
+bhi
 aEl
 blJ
 bjx
@@ -45052,8 +44848,8 @@ abT
 ayn
 aeV
 ayW
-aae
-aaa
+aKZ
+aKZ
 aae
 aae
 aBZ
@@ -45075,13 +44871,13 @@ aKr
 aEl
 aPd
 aEl
-aYa
-boi
+aTb
+aVl
 aEl
 bqO
 bjx
 bjx
-bjx
+btp
 bjx
 aEl
 blK
@@ -45309,8 +45105,8 @@ abT
 ayn
 aeW
 ayW
+aKZ
 aae
-aaa
 aae
 aae
 aBZ
@@ -45327,13 +45123,13 @@ aJW
 aLt
 aJU
 aEl
-bkW
-bkW
-bmq
-bkm
-bnj
-bkW
-bkW
+acv
+acv
+ads
+aat
+aoR
+acv
+acv
 aEl
 bjr
 bjx
@@ -45567,7 +45363,7 @@ ayn
 aeT
 ayW
 aae
-aaa
+aae
 aae
 aae
 aBZ
@@ -45584,17 +45380,17 @@ aEl
 aEl
 aEl
 aEl
-bkW
-bkW
-bmq
-bkm
+acv
+acv
+ads
+aat
 aLK
-bnH
-boj
+app
+aVm
 aEl
-bvi
 joT
-bvj
+joT
+bjd
 joT
 joT
 aEl
@@ -45610,9 +45406,9 @@ bji
 aae
 aae
 aae
-bkm
-bkm
-bkm
+aat
+aat
+aat
 bmI
 bjx
 bjx
@@ -45824,7 +45620,7 @@ aer
 aeU
 ayW
 aiO
-aaa
+aae
 aae
 aae
 aBZ
@@ -45835,25 +45631,25 @@ aDC
 aDs
 aEY
 aIC
-bkm
-bkm
-aMa
-bkm
-bkm
-bkA
-bkW
-bkW
-aQo
-bmG
-bmG
-bmG
-bok
-bkW
-bkW
-bkW
-bkW
-bmq
-bkm
+aat
+aat
+aLJ
+aat
+aat
+ach
+acv
+acv
+hlw
+acO
+acO
+acO
+acu
+acv
+acv
+acv
+acv
+ads
+aat
 aLK
 aLK
 bju
@@ -45864,12 +45660,12 @@ bjd
 bju
 bju
 aLK
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
 bmI
 bjx
 bjx
@@ -46092,40 +45888,40 @@ aTw
 aIC
 aIC
 aIC
-bkm
-bkm
-bkm
-bkm
-bkm
-bkA
-bkW
-bkW
-bkW
-aTa
-bkX
-bkX
-bkX
-bkX
-bkX
-bma
-bkW
-aQo
-bmG
-bmG
-bmG
-bmG
-bmG
-bmG
-bok
-bkW
-aQo
-bmG
-bmG
-bmG
-bmG
-bmG
-bmG
-bmG
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+aOh
+acP
+acP
+acP
+acP
+acP
+acw
+acv
+hlw
+acO
+acO
+acO
+acO
+acO
+acO
+acu
+acv
+hlw
+acO
+acO
+acO
+acO
+acO
+acO
+acO
 aLK
 aLK
 bjt
@@ -46346,43 +46142,43 @@ aCT
 aat
 aat
 aIY
-bmG
-bmG
+acO
+acO
 aIY
-bmG
-bmG
-bmG
-bmG
-bmG
-bok
-bkW
-bkW
-aMb
-aLK
-aVl
-bkU
-bkU
+acO
+acO
+acO
+acO
+acO
+acu
+acv
+acv
+aMa
+adN
+aTa
+bsS
+bsS
+aYa
 bhX
-bjw
-bkA
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
 boG
 bjx
 bjx
@@ -46465,7 +46261,7 @@ axe
 axe
 axe
 csf
-bGI
+crO
 csf
 abS
 csy
@@ -46603,43 +46399,43 @@ csu
 cst
 csU
 aJi
-bkW
-bkW
+acv
+acv
 aLk
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-aMb
-aQC
-bkA
-aYr
-bgd
-bkW
-bmq
-bkA
-bkW
-bkW
-bkW
-bnp
-bkX
-bkX
-bkX
-bkX
-bkX
-bkX
-bkX
-bkX
-bma
-bkW
-bkW
-bkW
-bkW
-bkW
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+aMa
+agy
+ach
+aLh
+aVJ
+acv
+ads
+ach
+acv
+acv
+acv
+adr
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acw
+acv
+acv
+acv
+acv
+acv
 boG
 bjx
 bjx
@@ -46722,7 +46518,7 @@ aMF
 csI
 csJ
 csI
-bGG
+crP
 csg
 csr
 csz
@@ -46860,29 +46656,29 @@ csI
 aEa
 aat
 bkA
+acv
+acv
 bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-aMb
-aQC
-bkA
-bkW
-bkW
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+aMa
+agy
+ach
+acv
+acv
+aYr
 biN
-bjE
-aLJ
-bkW
-bkW
-bkW
-bmq
+aLH
+acv
+acv
+acv
+ads
 aLK
 aLK
 aLK
@@ -46891,12 +46687,12 @@ aLK
 aLK
 aLK
 aLK
-bkA
-bkW
-bnp
-bkX
-bkX
-bkX
+ach
+acv
+adr
+acP
+acP
+acP
 aLK
 aLK
 bjt
@@ -46979,7 +46775,7 @@ awZ
 awZ
 csh
 crQ
-bGJ
+crQ
 csh
 abS
 csr
@@ -47117,29 +46913,29 @@ crQ
 aEa
 aat
 bkA
+acv
+acv
 bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-aMb
-aLK
-aVm
-bnH
-bnH
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+aMa
+adN
+aKd
+app
+app
+bgd
 bjc
-bjF
-bkl
-bkW
-bkW
-bkW
-bmq
+bjw
+acv
+acv
+acv
+ads
 aLK
 bmc
 bmp
@@ -47148,13 +46944,13 @@ bjx
 bjx
 bjx
 aLK
-aLJ
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
+aLH
+acv
+ads
+aat
+aat
+aat
+aat
 bmI
 bjx
 bjx
@@ -47374,29 +47170,29 @@ bqX
 bsz
 aGi
 aTw
-bkX
+acP
 aKv
 aTw
-bkX
-aLH
-bkW
-bkW
-aNe
-bkX
-bkX
-bma
-bkW
-aTb
-bmG
-bmG
-bmG
-bmG
-bmG
-bok
-bkW
-bkW
-blp
-bmq
+acP
+brV
+acv
+acv
+bsq
+acP
+acP
+acw
+acv
+aQo
+acO
+acO
+acO
+acO
+acO
+acu
+acv
+acv
+bjE
+ads
 blO
 aGv
 aGv
@@ -47405,13 +47201,13 @@ bjt
 bjx
 bnr
 aLK
-aLJ
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
+aLH
+acv
+ads
+aat
+aat
+aat
+aat
 bmI
 bjx
 bjx
@@ -47634,26 +47430,26 @@ aTw
 aTw
 aTw
 aTw
-bkm
-aLJ
+aat
+aLH
+aMa
+acv
 aMb
-bkW
 aNi
-aOh
-bkm
-bkA
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bmq
+aat
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+ads
 blP
 aGv
 aGv
@@ -47662,13 +47458,13 @@ bjx
 bjx
 bjx
 bjd
-bkA
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
+ach
+acv
+ads
+aat
+aat
+aat
+aat
 aLK
 aLK
 bji
@@ -47886,10 +47682,10 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
 aLK
 bju
 aLK
@@ -47898,19 +47694,19 @@ aLK
 bju
 aLK
 bji
-aPq
-bma
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bmq
+afw
+acw
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+ads
 aLK
 bme
 bmr
@@ -47919,14 +47715,14 @@ bjx
 bmR
 bnq
 aLK
-aLJ
-bkW
-bmq
-bkm
-bkm
-svG
-bkm
-bkm
+aLH
+acv
+ads
+aat
+aat
+aib
+aat
+aat
 aLK
 bqi
 bjx
@@ -48156,18 +47952,18 @@ bjv
 aLK
 aLK
 aLK
-aPq
-bkX
-bkX
-bkX
-bkX
-bkX
-bkX
-bkX
-bkX
-bma
-bkW
-bmq
+afw
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acw
+acv
+ads
 aLK
 aLK
 aLK
@@ -48176,14 +47972,14 @@ aLK
 aLK
 aLK
 aLK
-aLJ
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
-bkm
+aLH
+acv
+ads
+aat
+aKU
+aBO
+aJR
+aat
 bmI
 bsC
 bjx
@@ -48414,33 +48210,33 @@ bjD
 boO
 aLK
 aLK
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkA
-bkW
-aQo
-bmG
-bmG
-bmG
-bmG
-bmG
-bmG
-bmG
-bmG
-bok
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+hlw
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acu
+acv
+ads
+aat
+agl
+aQC
+ayW
+aat
 bmI
 bsC
 bjx
@@ -48671,33 +48467,33 @@ bjx
 bjx
 aLX
 aLK
-byy
-byy
-byy
-byy
-byy
-byy
-bkn
-bkm
-bkA
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
-bkm
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkz
+aat
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+ads
+aat
+agm
+adf
+aWT
+aat
 bmI
 bsC
 bjx
@@ -48934,27 +48730,27 @@ bmG
 bmG
 bmG
 bjX
-aQC
-bkm
-bkZ
-bkW
-bkW
-bkW
-bnp
-bkX
-bma
-bkW
 aNe
-bkX
-bma
-bkW
-bkW
-bmq
-bkm
-svG
-bkm
-bkm
-bkm
+aat
+anl
+acv
+acv
+acv
+adr
+acP
+acw
+acv
+bsq
+acP
+acw
+acv
+acv
+ads
+aat
+aib
+aat
+aat
+aat
 bji
 bqj
 bjx
@@ -49201,17 +48997,17 @@ bju
 aLK
 bji
 lJJ
-bmT
-bkn
-bkA
-bkW
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
-bkm
+bkl
+bkz
+ach
+acv
+acv
+ads
+aat
+aat
+aat
+aat
+aat
 bji
 bji
 bji
@@ -49428,9 +49224,9 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
+aat
+aat
+aat
 bji
 bji
 bjs
@@ -49459,13 +49255,13 @@ bmt
 bmI
 bkX
 bni
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
+aat
 bkq
 bkq
 bkq
@@ -49685,9 +49481,9 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
+aat
+aat
+aat
 bji
 aLr
 bjx
@@ -49716,13 +49512,13 @@ bxA
 bmI
 bkm
 bkm
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
+aat
 bkh
 boH
 boT
@@ -49942,9 +49738,9 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
+aat
+aat
+aat
 bji
 aLr
 bjx
@@ -49973,13 +49769,13 @@ bkE
 aLK
 bmC
 bkm
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
+aat
 bkh
 boI
 bol
@@ -50230,12 +50026,12 @@ bmv
 aLK
 bkm
 bkm
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
 bkh
 bkh
 bkq
@@ -50469,7 +50265,7 @@ bnQ
 bji
 ryU
 bkm
-aQC
+aNe
 bkA
 bkW
 bdi
@@ -50487,12 +50283,12 @@ aLK
 aLK
 bkm
 bkm
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
 bnT
 boh
 boJ
@@ -50726,7 +50522,7 @@ aNu
 bji
 ryU
 bkm
-aQC
+aNe
 bkA
 bkW
 bdY
@@ -50744,12 +50540,12 @@ bmw
 bkm
 blV
 bkm
-aQC
-bkA
-bkW
-bkW
-aQo
-bmG
+aNe
+ach
+acv
+acv
+hlw
+acO
 bnU
 bol
 bol
@@ -50983,7 +50779,7 @@ bmu
 bji
 ryU
 bkm
-aQC
+aNe
 bkA
 aVo
 bkW
@@ -51001,12 +50797,12 @@ bla
 bkm
 bkm
 bkm
-aQC
-bkA
-bkW
-bkW
-bkW
-bkW
+aNe
+ach
+acv
+acv
+acv
+acv
 bog
 bol
 boK
@@ -51240,7 +51036,7 @@ bji
 bji
 bkm
 bkm
-aQC
+aNe
 bkA
 bkW
 bkW
@@ -51258,12 +51054,12 @@ blV
 bqW
 bkm
 bqW
-aQC
-bkA
-bkW
-bkW
-bnp
-bkX
+aNe
+ach
+acv
+acv
+adr
+acP
 bnU
 bol
 boL
@@ -51497,7 +51293,7 @@ bkm
 bkm
 bkm
 bkm
-aQC
+aNe
 aTh
 bkW
 bkW
@@ -51515,12 +51311,12 @@ bkm
 bkm
 bkm
 bkm
-aQC
-bkA
-bkW
-bkW
-bmq
-bnP
+aNe
+ach
+acv
+acv
+ads
+bjF
 bnT
 bom
 boM
@@ -51772,12 +51568,12 @@ bmC
 bqW
 bkm
 bqW
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
 aLK
 bji
 bji
@@ -52011,7 +51807,7 @@ bkm
 bkm
 bkm
 bkm
-aQC
+aNe
 bkA
 bkW
 bkW
@@ -52029,12 +51825,12 @@ bkm
 blW
 bkm
 bkm
-aQC
-bkA
-bkW
-bkW
-bmq
-bkm
+aNe
+ach
+acv
+acv
+ads
+aat
 aLK
 bjs
 bwd
@@ -52268,7 +52064,7 @@ bkm
 bkm
 bkm
 bkm
-aQC
+aNe
 aPq
 bkX
 byu
@@ -52286,12 +52082,12 @@ blV
 bqW
 bkm
 bqW
-aQC
-bkA
-bkW
-bkW
-bmq
-bnP
+aNe
+ach
+acv
+acv
+ads
+bjF
 aLK
 bxA
 bjx
@@ -52512,43 +52308,43 @@ aae
 aBZ
 aTw
 aBZ
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-byy
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
 aLK
-byy
-byy
-byy
-aLK
-aLK
+bkl
+bkl
+bkl
 aLK
 aLK
 aLK
-byy
-byy
-byy
-byy
-byy
-byy
-byy
-bmN
-bkU
-bns
-bok
-bkW
-bkW
-aQo
-bmG
+aLK
+aLK
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkl
+bkz
+acu
+acv
+acv
+hlw
+acO
 aLK
 bjx
 bjx
@@ -52769,43 +52565,43 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bmD
-bmD
-bkA
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+csU
+csU
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
 aLK
 bop
 boP
@@ -53026,43 +52822,43 @@ aat
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-svG
-bkm
-bkm
-bmJ
-bmK
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aib
+aat
+aat
+bgK
+bgs
+acv
+acv
+acv
+acv
+acv
+acv
+acv
 aLK
 bji
 bji
@@ -53283,43 +53079,43 @@ aat
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
-bkm
-bkm
-aVJ
-bkm
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkA
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
-bkW
+aat
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+aat
+ayt
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
 bmI
 boE
 boP
@@ -53540,43 +53336,43 @@ aat
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkA
-bkW
-bkW
-bkW
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+acv
 aae
 boU
 boU
-bkW
-bkW
+acv
+acv
 bjd
 bjx
 boQ
@@ -53797,43 +53593,43 @@ abz
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-lYd
-bmG
-bmG
-bmG
-bmG
-bmK
-bkW
-bnp
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aii
+acO
+acO
+acO
+acO
+bgs
+acv
+adr
 aae
 aae
 boU
 boU
 boU
-bkW
+acv
 bmI
 bvy
 boR
@@ -54054,37 +53850,37 @@ aat
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkA
-bkW
-bkW
-bkW
-bkW
-bkW
-bnp
-sAf
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+acv
+acv
+adr
+afj
 aae
 aae
 boU
@@ -54311,36 +54107,36 @@ aat
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
-bkm
-aVJ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
-bkm
-svG
-bkm
-bkm
-bkm
-svG
-bkm
-bkZ
-bkW
-bnp
-bkX
-bkX
-bkX
-sAf
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+ayt
+aat
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+aib
+aat
+aat
+aat
+aib
+aat
+anl
+acv
+adr
+acP
+acP
+acP
+afj
 aae
 aae
 aae
@@ -54568,36 +54364,36 @@ aat
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkZ
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+anl
+acv
+ads
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -54825,36 +54621,36 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkZ
-bkW
-bmq
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+anl
+acv
+ads
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -55082,35 +54878,35 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkZ
-bkW
-bmq
-bkm
-svG
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+anl
+acv
+ads
+aat
+aib
+aat
 aae
 aae
 aae
@@ -55339,14 +55135,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
 aLK
 aLK
 aLK
@@ -55359,15 +55155,15 @@ aLK
 aLK
 aLK
 aLK
-bkm
-bkm
-bkm
-bkA
-bkW
-bmq
-bkm
-bkm
-bkm
+aat
+aat
+aat
+ach
+acv
+ads
+aat
+aat
+aat
 aae
 aae
 aae
@@ -55596,14 +55392,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 bji
 bjx
 bjx
@@ -55622,9 +55418,9 @@ aLK
 aLK
 bjd
 aLK
-bkm
-bkm
-bkm
+aat
+aat
+aat
 aae
 aae
 aae
@@ -55853,14 +55649,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 bji
 bjx
 bjx
@@ -55879,8 +55675,8 @@ bjx
 bjx
 bjx
 bji
-bkm
-bkm
+aat
+aat
 aae
 aae
 aae
@@ -56110,14 +55906,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkz
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
 bji
 bkd
 bji
@@ -56136,8 +55932,8 @@ bnm
 bfp
 bjx
 bji
-bkm
-bkm
+aat
+aat
 aae
 aae
 aae
@@ -56367,14 +56163,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 bji
 aJA
 aJS
@@ -56393,8 +56189,8 @@ aMH
 bfp
 bjx
 bji
-bkm
-bkm
+aat
+aat
 aae
 aae
 aae
@@ -56624,14 +56420,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 bji
 blr
 bfp
@@ -56650,7 +56446,7 @@ bjx
 aNz
 bjx
 bji
-bkm
+aat
 aae
 aae
 aae
@@ -56881,14 +56677,14 @@ aae
 aBZ
 aTw
 aBZ
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
-bkm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 bji
 bji
 bji
@@ -56907,7 +56703,7 @@ bji
 bji
 bji
 bji
-bkm
+aat
 aae
 aae
 aae
@@ -57921,7 +57717,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aae
 aae
 aae
@@ -58178,7 +57974,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aae
 aae
 aae
@@ -58435,7 +58231,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aae
 aae
 aae
@@ -58692,7 +58488,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aae
 aae
 aae
@@ -58706,22 +58502,22 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -58949,7 +58745,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aae
 aae
 aae
@@ -58961,25 +58757,25 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aak
 aae
 aae
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
 aab
 aae
 bpr
 aae
 aab
-aaa
 aae
-aaa
-aaa
+aae
+aae
+aae
 aae
 aae
 aae
@@ -59206,8 +59002,6 @@ aae
 aae
 aae
 aae
-aaa
-aaa
 aae
 aae
 aae
@@ -59215,29 +59009,31 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
-aak
-aak
-aak
 aae
 aae
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aab
 boU
 bpP
 bpr
 aab
-aaa
 aae
 aae
-aaa
-aaa
+aae
+aae
+aae
 aae
 aae
 aae
@@ -59464,38 +59260,38 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aae
-aae
-aae
-aae
-aaa
-aaa
-aaa
-aak
-aak
-aak
-aak
-aak
 aae
 aae
 aae
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aab
+aae
+aae
+aae
 aab
 aae
-aaa
-aae
-aab
-aaa
 aae
 aae
 aae
-aaa
-aaa
+aae
+aae
 aae
 aae
 aae
@@ -59722,38 +59518,38 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aak
-aak
-aak
-aak
-aak
-aak
 aae
 aae
 aae
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aab
-aaa
-aaa
-aaa
+aae
+aae
+aae
 aab
-aaa
 aae
 aae
 aae
 aae
-aaa
-aaa
+aae
+aae
+aae
 aae
 aae
 aae
@@ -59984,13 +59780,6 @@ aae
 aae
 aae
 aae
-aak
-aak
-aae
-aae
-aae
-aae
-aak
 aae
 aae
 aae
@@ -59998,20 +59787,27 @@ aae
 aae
 aae
 aae
-aaa
-bHc
-aaa
-aaa
-aaa
-bHc
-aaa
 aae
 aae
 aae
 aae
 aae
-aaa
-aaa
+aae
+aae
+aae
+bFF
+aae
+aae
+aae
+bFF
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -60255,23 +60051,23 @@ aae
 aae
 aae
 aae
-aaa
+aae
+aab
+aae
+aae
+aae
 aab
 aae
 aae
 aae
-aab
-aaa
 aae
 aae
 aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
+aae
+aae
 aaa
 "}
 (69,1,1) = {"
@@ -60512,13 +60308,13 @@ aae
 aae
 aae
 aae
-aaa
-aab
-aae
-aae
 aae
 aab
-aaa
+aae
+aae
+aae
+aab
+aae
 aae
 aae
 aae
@@ -60769,7 +60565,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aab
 aae
 aae
@@ -61026,7 +60822,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aab
 aae
 aae
@@ -61283,7 +61079,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aab
 aae
 aae
@@ -61540,7 +61336,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aab
 aae
 aae
@@ -61797,7 +61593,7 @@ aae
 aae
 aae
 aae
-aaa
+aae
 aab
 aae
 aae
@@ -62054,7 +61850,7 @@ agy
 aat
 aat
 aae
-aaa
+aae
 aab
 aae
 bwu
@@ -62311,7 +62107,7 @@ agy
 aat
 aat
 aae
-aaa
+aae
 aab
 bwi
 bwj
@@ -90941,15 +90737,15 @@ aae
 aae
 aat
 aat
+ahJ
+ahJ
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
+ahJ
+ahJ
+ahJ
 aat
 aat
 aat
@@ -91197,17 +90993,17 @@ aae
 aae
 aae
 aae
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+ahJ
+ahJ
+ahJ
+ahJ
+aGf
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aat
 aat
 aat
@@ -91441,11 +91237,11 @@ aae
 aae
 aae
 ank
-axr
-axP
-aer
-ayn
-aeV
+crZ
+cso
+abS
+aiv
+csP
 ank
 aae
 aae
@@ -91454,17 +91250,17 @@ aae
 aae
 aae
 aae
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+ahJ
+ahJ
+ahJ
+aPi
+aGf
+aPi
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aae
 aae
 aae
@@ -91698,11 +91494,11 @@ aae
 aae
 aae
 ank
-adH
-adY
-abS
-aer
-aeV
+aPx
+aQa
+csC
+bka
+bkS
 ank
 aae
 aae
@@ -91712,10 +91508,10 @@ aae
 aae
 aae
 aae
-aat
-aat
-aat
-aat
+ahJ
+ahJ
+ahJ
+aGf
 aae
 aae
 aae
@@ -91955,11 +91751,11 @@ aae
 aae
 aae
 ank
-adI
-adZ
-abS
-aiv
-aeV
+ahJ
+amE
+aLf
+bkb
+ahJ
 ank
 aae
 aae
@@ -91972,7 +91768,7 @@ aae
 aae
 aae
 aae
-aae
+aPh
 aae
 aae
 aae
@@ -92211,13 +92007,13 @@ aae
 aae
 aae
 aae
-ank
-adJ
-aea
-abS
-aiv
-aeV
-ank
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aae
 aae
 aae
@@ -92229,7 +92025,7 @@ aae
 aae
 aae
 aae
-aae
+aaB
 aae
 aae
 aae
@@ -92245,7 +92041,7 @@ aae
 ahz
 aaB
 aaB
-aEu
+aKO
 ahz
 aae
 aae
@@ -92468,13 +92264,13 @@ aae
 aae
 aae
 aae
-ank
-axs
-adY
-abS
-aiv
-aeW
-ank
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aae
 aae
 aae
@@ -92485,9 +92281,9 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
+agT
+aaB
+aaB
 aae
 aae
 aae
@@ -92725,13 +92521,13 @@ aae
 aae
 aae
 aae
-ank
-adK
-aeb
-aes
-aiv
-aeU
-ank
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aae
 aae
 aae
@@ -92744,9 +92540,9 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
+aaB
+aaB
+agT
 aae
 aae
 aae
@@ -92982,13 +92778,13 @@ aae
 aae
 aae
 aae
-ank
-adH
-aec
-abT
-aes
-aeV
-ank
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aae
 aae
 aae
@@ -93002,7 +92798,7 @@ aae
 aae
 aae
 aae
-aae
+aaB
 aae
 aae
 aae
@@ -93239,13 +93035,13 @@ aae
 aae
 aae
 aae
-ank
-adH
-aec
-abT
-ayn
-aeV
-ank
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aae
 aae
 aae
@@ -93259,8 +93055,8 @@ aae
 aae
 aae
 aae
-aae
-aae
+aaB
+aaB
 aae
 aae
 aGc
@@ -93497,11 +93293,11 @@ aat
 aae
 aae
 ank
-adH
-aed
-abT
-ayn
-aeV
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 ank
 aae
 aae
@@ -93517,7 +93313,7 @@ aae
 aae
 aae
 aae
-aae
+aaB
 aae
 ahz
 aGd
@@ -93547,13 +93343,13 @@ aae
 aae
 ahc
 aft
-acB
-adH
+ahJ
+ahJ
 adY
 aer
 ayn
 aeV
-acm
+ahJ
 aaQ
 aaQ
 aaQ
@@ -93754,11 +93550,11 @@ aat
 aae
 aae
 ank
-adH
-adY
-aep
-aiv
-aeV
+ahJ
+ahJ
+aQc
+ahJ
+ahJ
 ank
 aae
 aae
@@ -93774,7 +93570,7 @@ aae
 aae
 aae
 aae
-agT
+aaB
 aae
 ahz
 aGe
@@ -93805,13 +93601,13 @@ aae
 aae
 ank
 ank
-adH
-adY
+ahJ
+ahJ
+csC
 abS
-aer
-aeV
-acm
-ayW
+ahJ
+ahJ
+ahJ
 aat
 aat
 agy
@@ -94011,11 +93807,11 @@ aat
 aat
 ank
 ank
-adH
-adY
-abS
-aiv
-aeV
+ahJ
+ahJ
+axP
+bkc
+ahJ
 ank
 aae
 aae
@@ -94032,7 +93828,7 @@ aae
 aae
 aae
 aaB
-aaB
+agT
 ahz
 ahz
 aGj
@@ -94062,13 +93858,13 @@ aae
 aae
 aae
 ank
-adI
+ahJ
+ahJ
+aLf
 aPv
-abS
-aiv
-aQp
-acm
-ayW
+ahJ
+ahJ
+ahJ
 aat
 aat
 agy
@@ -94319,14 +94115,14 @@ aae
 aae
 aae
 ank
-aPg
-aPw
-abS
-aiv
-aeV
-acm
-ayW
-aat
+ahJ
+aLe
+aLg
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 aat
 agy
 aat
@@ -94548,7 +94344,7 @@ aaB
 ahz
 ahz
 ahz
-aGf
+aaB
 ahz
 aGs
 ahz
@@ -94576,13 +94372,13 @@ aae
 aae
 aae
 ank
-aPh
-adY
-abS
-aQa
-aeW
-adg
-adg
+ahJ
+ahJ
+aLe
+ahJ
+ahJ
+aae
+aae
 aae
 aat
 agy
@@ -94833,11 +94629,11 @@ aae
 aae
 aae
 ank
-aPi
-adY
-abS
-aQa
-aQq
+ahJ
+ahJ
+ahJ
+axs
+ahJ
 adg
 aae
 aae
@@ -95090,11 +94886,11 @@ aae
 aae
 aae
 ank
-adJ
-aeb
-abT
-aiv
-aeT
+ahJ
+ahJ
+ahJ
+ahJ
+ahJ
 adg
 aae
 aae
@@ -95347,11 +95143,11 @@ aae
 aae
 aae
 ank
-aPj
-aPx
-aer
-aer
-aeU
+ahJ
+ahJ
+amE
+ahJ
+ahJ
 adg
 aae
 aae
@@ -95604,11 +95400,11 @@ aae
 aae
 ank
 ank
-adK
-aPx
-abS
-aQb
-aQr
+ahJ
+ahJ
+aLC
+aLg
+ahJ
 adg
 aae
 aae
@@ -95617,9 +95413,9 @@ aae
 aae
 agk
 aTd
-aTr
+aQb
 aTN
-aTr
+aPw
 aUx
 aUQ
 aVh
@@ -95849,7 +95645,7 @@ aat
 aat
 aat
 aKP
-aLe
+aLd
 aLB
 aLR
 aLB
@@ -95861,11 +95657,11 @@ aOk
 aOz
 aqF
 aDt
-adH
-adY
-aeq
-aQc
-aeV
+ahJ
+csu
+cpb
+cpb
+ahJ
 adg
 aae
 acl
@@ -96106,7 +95902,7 @@ aat
 aat
 aat
 aKP
-aLf
+aLd
 aLB
 aLc
 aLB
@@ -96363,8 +96159,8 @@ aat
 aat
 aat
 aKP
-aLg
-aLC
+aLd
+aMq
 aLS
 aMq
 aLc
@@ -96387,7 +96183,7 @@ aRN
 aSh
 acl
 aSH
-ars
+bsP
 aTt
 aTP
 aUh
@@ -97420,7 +97216,7 @@ aQu
 aQu
 aeV
 aUA
-ars
+bsP
 aVi
 aVB
 abP
@@ -98450,7 +98246,7 @@ aeV
 aUA
 aUT
 aVi
-aVD
+aTr
 apO
 aat
 aat
@@ -98799,7 +98595,7 @@ ach
 acv
 bhV
 aat
-aat
+bqC
 aGP
 aat
 ach
@@ -99476,7 +99272,7 @@ aRR
 aQu
 aeV
 aUA
-ars
+bsP
 aVi
 aVF
 abP
@@ -99817,7 +99613,7 @@ bsA
 bqd
 bqv
 bsA
-aat
+bqC
 aat
 aat
 aat
@@ -100078,7 +99874,7 @@ aat
 aat
 csU
 aat
-bqC
+aat
 aat
 ach
 brY
@@ -100225,7 +100021,7 @@ aMC
 aMV
 aNr
 aNL
-aOc
+aVD
 aOc
 aMr
 aOK
@@ -100504,7 +100300,7 @@ aQu
 aQu
 aeV
 aUA
-ars
+bsP
 aVi
 aVG
 abP
@@ -101279,7 +101075,7 @@ abP
 abP
 abP
 abP
-abQ
+aKm
 abQ
 abQ
 abQ
@@ -101534,9 +101330,9 @@ aUk
 aSJ
 acG
 acG
-acG
-acG
-acG
+aSJ
+aSJ
+aSJ
 acG
 acG
 acG
@@ -101792,7 +101588,7 @@ abS
 abS
 abS
 abS
-abS
+axP
 abS
 abS
 abS
@@ -102135,7 +101931,7 @@ bri
 aat
 aat
 aat
-aat
+bqC
 ach
 bhV
 bsw
@@ -109690,7 +109486,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -110396,13 +110192,13 @@ aae
 aae
 aae
 aab
+aQF
 bAY
 bAY
 bAY
 bAY
 bAY
-bAY
-bAY
+aQF
 bAY
 bAY
 bAY
@@ -110412,11 +110208,11 @@ bAY
 bAY
 bAY
 bBm
+aQF
 bAY
-bAY
-bAY
-bAY
-bAY
+bja
+bja
+aQF
 aab
 aae
 aae
@@ -110664,7 +110460,7 @@ bAY
 bAY
 bAY
 bAY
-bAY
+aQF
 bAY
 bAY
 bAY
@@ -110929,7 +110725,7 @@ aab
 aab
 aab
 aab
-bAY
+aQF
 bAY
 bBl
 aab
@@ -111170,16 +110966,16 @@ aab
 bAY
 bAY
 bBl
-bAY
+bja
 bBr
 aab
-bDe
+bip
 bDe
 bDe
 adg
 aae
 aab
-bAY
+aQF
 bAY
 bAY
 aab
@@ -111189,10 +110985,10 @@ aab
 bAY
 bAY
 bBm
+aQF
 bAY
 bAY
-bAY
-bAY
+aQF
 aab
 aae
 aae
@@ -111475,9 +111271,9 @@ aae
 aae
 aae
 aab
-bAY
-bAY
-bAY
+bja
+bja
+bja
 aab
 aae
 aae
@@ -111489,11 +111285,11 @@ aae
 aae
 aae
 bFx
+bjg
 aah
-aah
-boU
-boU
-boU
+bjY
+bjY
+bLg
 aae
 aae
 aae
@@ -111685,11 +111481,11 @@ bAY
 bAY
 bBl
 bAY
-bBs
+aQF
 aab
 bDe
 bDe
-bDe
+bip
 adg
 aae
 aab
@@ -111705,7 +111501,7 @@ bAY
 bBl
 aab
 aab
-bAY
+aQF
 bAY
 aab
 aae
@@ -111732,9 +111528,9 @@ aae
 aae
 aae
 aab
-bAY
-bAY
-bAY
+bja
+bja
+bja
 aab
 aae
 aae
@@ -111746,9 +111542,9 @@ aae
 aae
 aae
 bFx
+bjg
 aah
-aah
-boU
+bjY
 aae
 aae
 aae
@@ -111990,7 +111786,7 @@ bFx
 bFx
 bFx
 bFx
-bAY
+bjZ
 bFx
 bFx
 bFx
@@ -112003,7 +111799,7 @@ bFx
 bFx
 bFx
 bFx
-aah
+bjg
 aah
 bFx
 aae
@@ -112195,7 +111991,7 @@ aae
 aae
 aae
 aab
-bAY
+bja
 bAY
 bAY
 bAY
@@ -112240,6 +112036,7 @@ boU
 boU
 aah
 aah
+biV
 aah
 aah
 aah
@@ -112251,15 +112048,14 @@ aah
 aah
 aah
 aah
+biV
 aah
 aah
 aah
 aah
 aah
 aah
-aah
-aah
-aah
+biV
 aah
 bHi
 bFx
@@ -112452,8 +112248,8 @@ aae
 aae
 aae
 aab
-bAY
-bAY
+bja
+bja
 bAY
 bAY
 bAY
@@ -112504,6 +112300,7 @@ aah
 aah
 aah
 aah
+biV
 aah
 aah
 aah
@@ -112511,8 +112308,7 @@ aah
 aah
 aah
 aah
-aah
-aah
+biV
 aah
 aah
 aah
@@ -112733,7 +112529,7 @@ bAY
 aab
 aae
 aab
-bAY
+aQF
 bAY
 aab
 aae
@@ -112976,7 +112772,7 @@ bAY
 bAY
 bBl
 bAY
-bCQ
+biq
 aab
 aae
 aae
@@ -113009,7 +112805,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -113233,7 +113029,7 @@ bAY
 bAY
 bBm
 bAY
-bBs
+bAY
 aab
 aae
 aae
@@ -113489,7 +113285,7 @@ aab
 bAY
 bAY
 bBl
-bAY
+aQF
 bAY
 aab
 aae
@@ -113762,7 +113558,7 @@ aab
 aae
 aab
 bAY
-bAY
+aQF
 bEJ
 bFF
 bFF
@@ -113802,7 +113598,7 @@ bAY
 bAY
 aab
 bFx
-aah
+biV
 aah
 aah
 bFx
@@ -114267,10 +114063,10 @@ aae
 aae
 aae
 aab
-bAY
-bBs
+aQF
+bja
 bBl
-bAY
+aQF
 bAY
 aab
 aae
@@ -114278,7 +114074,7 @@ aab
 bAY
 bAY
 aah
-bFH
+bjf
 bFx
 bGf
 bGm
@@ -114514,8 +114310,8 @@ aae
 aae
 aae
 aab
+aQF
 bAY
-bBs
 aab
 aae
 aae
@@ -114524,7 +114320,7 @@ aae
 aae
 aae
 aab
-bAY
+bja
 bAY
 bBm
 bAY
@@ -114533,13 +114329,14 @@ aab
 aae
 bBl
 bAY
-bBs
+bAY
 aah
 bFH
 bFS
 aah
 aah
 aah
+biV
 aah
 aah
 aah
@@ -114549,8 +114346,7 @@ aah
 aah
 aah
 aah
-aah
-aah
+biV
 aah
 aah
 bFx
@@ -114577,7 +114373,7 @@ bFx
 bFx
 aah
 aah
-aah
+biV
 bFx
 aae
 aae
@@ -114782,7 +114578,7 @@ aae
 aae
 aab
 bDN
-bAY
+aQF
 bBl
 bAY
 bAY
@@ -114801,7 +114597,7 @@ aah
 aah
 aah
 aah
-aah
+biV
 aah
 aah
 aah
@@ -115026,7 +114822,7 @@ aae
 aae
 aab
 bBr
-bAY
+bja
 bBl
 bAY
 bAY
@@ -115282,8 +115078,8 @@ aae
 aae
 aae
 aab
-bAY
-bAY
+bja
+bja
 bBm
 bAY
 bAY
@@ -115303,10 +115099,10 @@ bAY
 aab
 aae
 aab
-bAY
+bja
 bAY
 aah
-bFH
+bir
 bFI
 aae
 aae
@@ -115539,8 +115335,8 @@ aae
 aae
 aae
 aab
-bBs
-bAY
+bja
+aQF
 bBl
 bAY
 bAY
@@ -115817,7 +115613,7 @@ bAY
 aab
 boU
 bEJ
-bAY
+aQF
 bAY
 aab
 aae
@@ -116075,7 +115871,7 @@ aab
 boU
 bEJ
 bAY
-bAY
+aQF
 aab
 aae
 aae
@@ -116377,7 +116173,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 bHl
 aah
 bFx
@@ -116570,21 +116366,21 @@ aae
 aae
 aae
 aab
-bAY
+bja
 bAY
 bBm
+aQF
+bAY
+bAY
+bAY
+aQF
+bAY
+aQF
 bAY
 bAY
 bAY
 bAY
-bAY
-bAY
-bAY
-bAY
-bAY
-bAY
-bAY
-bAY
+aQF
 bEJ
 boU
 aab
@@ -116827,8 +116623,8 @@ aae
 aae
 aae
 aab
-bAY
-bAY
+bja
+aQF
 bBm
 bAY
 bAY
@@ -117152,7 +116948,7 @@ bFx
 bFx
 aah
 aah
-aah
+biV
 bFx
 aae
 aae
@@ -117347,7 +117143,7 @@ aae
 aae
 aae
 aab
-bAY
+aQF
 bAY
 aab
 aae
@@ -117616,7 +117412,7 @@ aab
 aab
 aab
 aab
-bAY
+aQF
 bAY
 aab
 aae
@@ -117866,7 +117662,7 @@ bAY
 bBm
 bAY
 bAY
-bAY
+aQF
 bAY
 bAY
 bAY
@@ -117922,7 +117718,7 @@ aae
 aae
 bFx
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -118119,19 +117915,19 @@ aae
 aae
 aab
 bAY
-bAY
+aQF
 bBm
 bAY
 bAY
 bAY
 bHP
 bAY
-bAY
+aQF
 bAY
 bAY
 bBm
 bAY
-bAY
+bja
 aab
 aae
 aae
@@ -118375,7 +118171,7 @@ aae
 aae
 aae
 aab
-bBm
+aab
 aab
 aab
 aab
@@ -118631,10 +118427,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -118888,10 +118684,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -119145,10 +118941,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -119207,7 +119003,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -119402,10 +119198,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -119659,10 +119455,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -119916,10 +119712,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -120173,10 +119969,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDj
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -120430,10 +120226,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -120687,10 +120483,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -120944,10 +120740,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -121007,7 +120803,7 @@ aae
 aae
 bFx
 aah
-aah
+biV
 bFx
 aae
 aae
@@ -121201,10 +120997,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -121458,10 +121254,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -121715,10 +121511,10 @@ aae
 aae
 aae
 aae
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -121972,10 +121768,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -122229,10 +122025,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDk
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -122291,7 +122087,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -122486,10 +122282,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -122743,10 +122539,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -123000,10 +122796,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -123257,10 +123053,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -123514,10 +123310,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -123771,10 +123567,10 @@ aae
 aae
 aae
 aae
-adg
-bHV
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -124028,10 +123824,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -124091,7 +123887,7 @@ aae
 aae
 bFx
 aah
-aah
+biV
 bFx
 aae
 aae
@@ -124285,10 +124081,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -124542,10 +124338,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -124799,10 +124595,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -125056,10 +124852,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -125313,10 +125109,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -125570,10 +125366,10 @@ aae
 aae
 aae
 aae
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -125827,10 +125623,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -126084,10 +125880,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -126147,7 +125943,7 @@ bHv
 bHz
 bFx
 aah
-aah
+biV
 bFx
 aae
 aae
@@ -126341,10 +126137,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -126598,10 +126394,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -126855,10 +126651,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -127112,10 +126908,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDk
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -127369,10 +127165,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -127626,10 +127422,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -127883,10 +127679,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -128140,10 +127936,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -128397,10 +128193,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -128459,7 +128255,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -128654,10 +128450,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -128911,10 +128707,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bHV
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -129168,10 +128964,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -129425,10 +129221,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -129682,10 +129478,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -129939,10 +129735,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -130196,10 +129992,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -130453,10 +130249,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -130710,59 +130506,59 @@ aae
 aae
 aae
 aae
-adg
-bDf
-bDf
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -130967,59 +130763,59 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDk
-bDe
-bDk
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDk
-bDe
-bDe
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDf
-bDk
-bDk
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -131224,59 +131020,59 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDt
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bHV
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDk
-bDk
-bDk
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDe
-bDe
-bDf
-bDk
-bDk
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -131286,7 +131082,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -131481,59 +131277,59 @@ aae
 aae
 aae
 aae
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -131787,10 +131583,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -132044,10 +131840,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -132057,16 +131853,16 @@ aae
 aae
 aae
 bFx
+bjg
 aah
 aah
 aah
 aah
 aah
+biV
 aah
 aah
-aah
-aah
-aah
+bjg
 bFx
 bFx
 aae
@@ -132301,10 +132097,10 @@ aae
 aae
 aae
 aae
-adg
-bHV
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -132314,6 +132110,7 @@ aae
 aae
 aae
 bFx
+bjg
 aah
 aah
 aah
@@ -132323,8 +132120,7 @@ aah
 aah
 aah
 aah
-aah
-aah
+biV
 bFx
 bFx
 aae
@@ -132558,10 +132354,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -132815,10 +132611,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -132828,7 +132624,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -133072,10 +132868,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -133329,10 +133125,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bHV
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -133586,10 +133382,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -133843,10 +133639,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -134100,10 +133896,10 @@ aae
 aae
 aae
 aae
-adg
-bHV
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -134357,10 +134153,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -134369,7 +134165,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 aah
 bFx
@@ -134614,10 +134410,10 @@ aae
 aae
 aae
 aae
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -134871,10 +134667,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -135128,10 +134924,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -135385,10 +135181,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -135642,10 +135438,10 @@ aae
 aae
 aae
 aae
-adg
-bDk
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -135899,10 +135695,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -136156,10 +135952,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -136413,10 +136209,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDk
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -136670,22 +136466,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-aae
-aae
-bFx
-bFx
-aah
-aah
-aah
-bFx
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -136693,8 +136473,24 @@ aae
 aae
 aae
 bFx
+bFx
 aah
 aah
+aah
+bFx
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bFx
+aah
+biV
 bFx
 aae
 aae
@@ -136927,14 +136723,14 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 bFx
-aah
+biV
 aah
 aah
 bFx
@@ -137184,10 +136980,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 bFx
 bFx
@@ -137441,13 +137237,13 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 bFx
-aah
+bjg
 aah
 aah
 bFx
@@ -137698,10 +137494,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDk
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -137955,10 +137751,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -138212,14 +138008,14 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDk
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
-aah
+bjg
 bFx
 aae
 aae
@@ -138236,7 +138032,7 @@ aae
 aae
 bFx
 aah
-aah
+bjg
 bFx
 aae
 aae
@@ -138469,10 +138265,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -138726,10 +138522,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 bGZ
@@ -138983,16 +138779,16 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
 aah
 aah
-aah
+biV
 aah
 aah
 bHF
@@ -139010,7 +138806,7 @@ aah
 aah
 aah
 aah
-aah
+bjg
 bHI
 aah
 aah
@@ -139240,10 +139036,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -139258,7 +139054,7 @@ aah
 aah
 aah
 aah
-aah
+biV
 aah
 aah
 aah
@@ -139497,10 +139293,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -139523,7 +139319,7 @@ bFx
 bFx
 bFx
 bFx
-aah
+biV
 aah
 bFx
 bFx
@@ -139748,16 +139544,16 @@ aae
 aae
 aae
 aae
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -140005,16 +139801,16 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -140262,16 +140058,16 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDt
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -140519,16 +140315,16 @@ aae
 aae
 aae
 aae
-adg
-bDf
-bDf
-adg
-adg
-adg
-adg
-adg
-adg
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bFF
 bFx
 aah
@@ -140776,10 +140572,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -140809,7 +140605,7 @@ aae
 aae
 bFx
 aah
-aah
+bjg
 bFx
 bFx
 bFx
@@ -141033,10 +140829,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -141066,12 +140862,12 @@ aae
 aae
 bFx
 aah
+bjg
+bjg
 aah
 aah
 aah
-aah
-aah
-aah
+biV
 aah
 aah
 aah
@@ -141290,27 +141086,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-aae
-aae
-aae
-aae
-aae
-aae
-bFx
-bFx
-aah
-bFx
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -141322,6 +141097,27 @@ aae
 aae
 aae
 bFx
+bFx
+aah
+bFx
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bFx
 aah
 aah
 aah
@@ -141333,7 +141129,7 @@ aah
 aah
 aah
 aah
-aah
+biV
 bFx
 aae
 aae
@@ -141547,10 +141343,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -141558,7 +141354,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -141804,10 +141600,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -141815,7 +141611,7 @@ aae
 aae
 aae
 bFx
-aah
+bjg
 aah
 bFx
 aae
@@ -142061,10 +141857,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -142318,10 +142114,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -142575,10 +142371,10 @@ aae
 aae
 aae
 aae
-adg
-bDj
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -142832,10 +142628,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -142874,7 +142670,7 @@ aae
 aae
 aae
 bFx
-aah
+biV
 aah
 bFx
 aae
@@ -143089,10 +142885,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -143346,10 +143142,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -143603,10 +143399,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -143860,10 +143656,10 @@ aae
 aae
 aae
 aae
-adg
-bDj
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -143880,8 +143676,8 @@ aah
 aah
 aah
 aah
-aah
-aah
+bjg
+bjg
 aah
 aah
 aah
@@ -144117,10 +143913,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -144150,7 +143946,7 @@ aah
 aah
 bHI
 aah
-aah
+biV
 bHI
 aah
 aah
@@ -144374,10 +144170,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -144631,10 +144427,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -144888,10 +144684,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -145145,16 +144941,16 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
 aae
 bFx
-aah
+biV
 aah
 aah
 aah
@@ -145402,16 +145198,16 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
 aae
 bFx
-aah
+bjg
 aah
 aah
 aah
@@ -145659,17 +145455,17 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDj
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
 aae
 bFx
 bGZ
-aah
+bjg
 aah
 aah
 bFx
@@ -145916,10 +145712,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -146173,10 +145969,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -146204,7 +146000,7 @@ aae
 aae
 aae
 bFx
-bJe
+bjq
 aah
 aah
 bFx
@@ -146430,26 +146226,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-aae
-aae
-aae
-aae
-aae
-aae
-bFx
-aah
-aah
-bFx
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -146462,6 +146238,26 @@ aae
 aae
 bFx
 aah
+aah
+bFx
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bFx
+biV
 bHl
 bJA
 bFx
@@ -146687,10 +146483,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -146944,10 +146740,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -147201,10 +146997,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -147458,10 +147254,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -147715,10 +147511,10 @@ aae
 aae
 aae
 aae
-adg
-bDj
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -147972,10 +147768,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -148229,10 +148025,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -148486,10 +148282,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -148743,10 +148539,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -149000,10 +148796,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -149257,10 +149053,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -149514,10 +149310,10 @@ aae
 aae
 aae
 aae
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -149771,10 +149567,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -150028,10 +149824,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -150039,7 +149835,7 @@ aae
 aae
 aae
 bFx
-aah
+bjg
 aah
 aaJ
 aah
@@ -150047,6 +149843,7 @@ aah
 aah
 aah
 aah
+biV
 aah
 aah
 aah
@@ -150056,22 +149853,21 @@ aah
 aah
 aah
 aah
+biV
 aah
 aah
 aah
 aah
 aah
 aah
+bjg
+bjg
 aah
 aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
+biV
 aah
 aah
 aah
@@ -150086,9 +149882,9 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
+biV
+bjg
+bjg
 bHI
 aah
 aah
@@ -150285,10 +150081,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -150297,7 +150093,7 @@ aae
 aae
 bFx
 bGZ
-aah
+bjg
 aah
 aah
 aah
@@ -150320,6 +150116,7 @@ aar
 aah
 aah
 aah
+biV
 aah
 aah
 aah
@@ -150337,8 +150134,7 @@ aah
 aah
 aah
 aah
-aah
-aah
+biV
 aah
 aah
 aah
@@ -150542,10 +150338,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -150799,10 +150595,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -151056,10 +150852,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -151311,12 +151107,12 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -151568,12 +151364,12 @@ aae
 aae
 aae
 aae
-chc
-bGU
-bGV
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -151825,24 +151621,24 @@ aae
 aae
 aae
 aae
-chc
-bGU
-bGV
-bDe
-bDe
-adg
 aae
 aae
 aae
 aae
-chc
-chc
-chc
 aae
 aae
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -152082,24 +151878,24 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-bDe
-bDe
-adg
 aae
 aae
 aae
 aae
-chc
-bHa
-chc
 aae
 aae
-chc
-bHa
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -152341,26 +152137,26 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-adg
-adg
-adg
-adg
-chc
-bGV
-chc
-adg
-adg
-chc
-bGV
-chc
-chc
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -152598,26 +152394,26 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bGV
-bHx
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -152855,26 +152651,26 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bGV
-bHx
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -153112,26 +152908,26 @@ aae
 aae
 aae
 aae
-chc
-bGW
-bGW
-chc
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-bDe
-bDe
-chc
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -153369,23 +153165,23 @@ aae
 aae
 aae
 aae
-chc
-bGV
-bGV
-chc
 aae
 aae
 aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -153626,23 +153422,23 @@ aae
 aae
 aae
 aae
-chc
-bGX
-bGX
-chc
 aae
 aae
 aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -153883,28 +153679,28 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-chc
 aae
 aae
 aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDf
-bDe
-bHV
-adg
 aae
-chc
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -154150,18 +153946,18 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDf
-bDe
-bDe
-adg
 aae
-chc
-bHC
-bHC
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -154407,22 +154203,22 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-adg
-adg
-adg
-adg
-chc
-bGV
-bGV
-chc
-adg
-adg
-adg
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -154664,22 +154460,22 @@ aae
 aae
 aae
 aae
-adg
-bDj
-bDe
-adg
-bDe
-bGW
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -154921,22 +154717,22 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-bDe
-bDe
-bDe
-bGX
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -155176,27 +154972,27 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-bDe
-bDe
-adg
-bDe
-bDe
-bHx
-adg
-bHG
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-chc
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -155433,27 +155229,27 @@ aae
 aae
 aae
 aae
-chc
-bHb
-bGV
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bHA
-adg
-bGU
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bGV
-bHx
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -155690,27 +155486,27 @@ aae
 aae
 aae
 aae
-chc
-bHb
-bGV
-bDe
-bDj
-bDf
-bDe
-bDe
-bDe
-bHB
-adg
-bGU
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bGV
-bHx
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -155947,27 +155743,27 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-bDe
-bDe
-adg
-bDe
-bDe
-bHx
-adg
-bHH
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-chc
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -156206,22 +156002,22 @@ aae
 aae
 aae
 aae
-adg
-bDj
-bDe
-adg
-bDe
-bDe
-bDe
-bHC
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -156463,22 +156259,22 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-bDe
-bGW
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -156720,22 +156516,22 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-adg
-adg
-adg
-adg
-chc
-bGV
-bGV
-chc
-adg
-bDf
-bDf
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -156977,22 +156773,22 @@ aae
 aae
 aae
 aae
-adg
-adg
-adg
-adg
 aae
 aae
 aae
 aae
-chc
-bGX
-bGX
-chc
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -157242,14 +157038,14 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-chc
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -157503,10 +157299,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -157760,10 +157556,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -158017,10 +157813,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -158274,10 +158070,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -158531,10 +158327,10 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -158788,12 +158584,12 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -159045,12 +158841,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bGV
-bHx
-chc
 aae
 aae
 aae
@@ -159079,14 +158869,20 @@ aae
 aae
 aae
 aae
-adg
-adg
 aae
 aae
-adg
-adg
-adg
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -159302,12 +159098,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-chc
-chc
-chc
 aae
 aae
 aae
@@ -159334,19 +159124,25 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -159559,10 +159355,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
 aae
 aae
 aae
@@ -159591,19 +159383,23 @@ aae
 aae
 aae
 aae
-chc
-bHb
-bGV
-bGW
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-bGV
-bHx
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -159816,10 +159612,6 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
 aae
 aae
 aae
@@ -159848,19 +159640,23 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-chc
-chc
-chc
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -160073,50 +159869,50 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-bDe
-bDe
-bHx
-chc
-bDe
-bDe
-bHx
-adg
-adg
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -160330,51 +160126,51 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bHA
-chc
-bDe
-bDe
-bDf
-bDe
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -160587,51 +160383,51 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bHV
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDf
-bDe
-bDe
-bDe
-bNP
-chc
-bDe
-bDe
-bDf
-bDe
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -160844,51 +160640,51 @@ aae
 aae
 aae
 aae
-adg
-bDe
-bDe
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-adg
-chc
-bGV
-bGV
-chc
-bDe
-bDe
-bHx
-chc
-bDe
-bDe
-bHx
-adg
-adg
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -161101,10 +160897,6 @@ aae
 aae
 aae
 aae
-adg
-bGW
-bGW
-adg
 aae
 aae
 aae
@@ -161132,20 +160924,24 @@ aae
 aae
 aae
 aae
-chc
-bGX
-bGX
-chc
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-bDe
-adg
 aae
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -161358,10 +161154,6 @@ aae
 aae
 aae
 aae
-chc
-bGV
-bGV
-chc
 aae
 aae
 aae
@@ -161389,20 +161181,24 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-chc
-bGW
-bDe
-bDe
-bDe
-bDe
-bDe
-bGW
-adg
-aaB
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -161615,10 +161411,6 @@ aae
 aae
 aae
 aae
-chc
-bGX
-bGX
-chc
 aae
 aae
 aae
@@ -161649,17 +161441,21 @@ aae
 aae
 aae
 aae
-chc
-bGV
-chc
-adg
-adg
-adg
-chc
-bGV
-chc
-aaB
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -161872,10 +161668,6 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
-chc
 aae
 aae
 aae
@@ -161906,17 +161698,21 @@ aae
 aae
 aae
 aae
-chc
-bGX
-chc
 aae
 aae
 aae
-chc
-bOg
-chc
-aaB
-cnd
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -162163,17 +161959,17 @@ aae
 aae
 aae
 aae
-chc
-chc
-chc
 aae
 aae
 aae
-chc
-chc
-chc
-aaB
-aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -162430,7 +162226,7 @@ aae
 aae
 aae
 aae
-aaB
+aae
 aae
 aae
 aae
@@ -162683,11 +162479,11 @@ aae
 aae
 aae
 aae
-aaB
-aaB
-aaB
-aaB
-aaB
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -162940,11 +162736,11 @@ aae
 aae
 aae
 aae
-aaB
-cmh
-aaB
-cnc
-aaB
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -163196,9 +162992,9 @@ aae
 aae
 aae
 aae
-chc
-cmg
-chc
+aae
+aae
+aae
 aae
 aae
 aae
@@ -163452,11 +163248,11 @@ aae
 aae
 aae
 aae
-aaB
 aae
-aaB
-aaB
-aaB
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -163708,13 +163504,13 @@ aae
 aae
 aae
 aae
-aaB
-aaB
-aaB
-aaB
 aae
 aae
-aaB
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -163965,7 +163761,7 @@ aae
 aae
 aae
 aae
-cnd
+aaB
 aaB
 aae
 aaB
@@ -164486,7 +164282,7 @@ aaB
 aae
 aaB
 aaB
-cnd
+aaB
 aae
 aae
 aae
@@ -165506,12 +165302,12 @@ aae
 aae
 aae
 aaB
-cnd
+aaB
 aaB
 aae
 aaB
 aaB
-cnc
+aaB
 aaB
 aaB
 aaB
@@ -166025,7 +165821,7 @@ aaB
 aae
 aae
 aaB
-cnd
+aaB
 aaB
 cnc
 aaB
@@ -166535,8 +166331,8 @@ aae
 aae
 aaB
 aaB
-cnd
-cnc
+aaB
+aaB
 aaB
 aaB
 aaB
@@ -167820,7 +167616,7 @@ eOV
 aaB
 aaB
 aaB
-aaB
+aNB
 aaB
 aaB
 aaB

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -523,7 +523,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "Veteran Legionnaire"
 
 /obj/effect/landmark/start/f13/legionary
-	name = "Prime Legionary"
+	name = "Legionnaire"
 	icon_state = "Veteran Legionnaire"
 
 /obj/effect/landmark/start/f13/recleg

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -197,7 +197,7 @@ update_label("John Doe", "Clowny")
 
 /obj/item/card/id/gold/mayor
 	name = "Mayor's mayoral permit"
-	desc = "A golden identification permit reserved for the Mayor of Oasis."
+	desc = "A golden identification permit reserved for the Mayor of Kebab."
 	icon_state = "gold"
 	item_state = "gold_id"
 	id_type = "mayoral permit"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -150,4 +150,4 @@
 	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
 
 /obj/item/radio/intercom/kebob
-	name = "Oasis intercom"
+	name = "Kebab intercom"

--- a/code/game/objects/items/fallout13misc.dm
+++ b/code/game/objects/items/fallout13misc.dm
@@ -177,21 +177,21 @@
 	icon_state = "legionflag"
 	item_state = "legionflag"
 	faction = "Legion"
-
+/*
 /obj/item/flag/oasis
 	name = "Oasis flag"
 	desc = "A flag depicting a stylised pink flower on a green background. It's the symbol of the town of Oasis."
 	icon_state = "oasisflag"
 	item_state = "oasisflag"
 	faction = "Oasis"
-
+*/
 /obj/item/flag/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/stack/sheet/leather) && item_state == "emptyflag")
 		visible_message("<span class='notice'>[user] begins to make a flag.</span>")
 		if(do_after(user, 60, target = src))
 			var/obj/item/stack/sheet/leather/H = I
 			if(H.use(1))
-				var/flag = alert(user, "Please choose which faction flag you wish to create.", "Flag type", "NCR", "Legion", "Oasis",)
+				var/flag = alert(user, "Please choose which faction flag you wish to create.", "Flag type", "NCR", "Legion",)
 				switch(flag)
 					if("NCR")
 						name = "NCR flag"
@@ -205,12 +205,6 @@
 						icon_state = "legionflag"
 						item_state = "legionflag"
 						faction = "Legion"
-					if("Oasis")
-						name = "Oasis flag"
-						desc = "A flag depicting a stylised pink flower on a green background. It's the symbol of the town of Oasis."
-						icon_state = "oasisflag"
-						item_state = "oasisflag"
-						faction = "Oasis"
 				update_icon()
 	else
 		attack_hand(user)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -426,7 +426,7 @@
 
 /obj/item/storage/box/citizenship_permits
 	name = "box of citizenship permits"
-	desc = "A box containing spare citizenship permits for Oasis. Use a mayor's ID on a citizenship permit to assign its owner."
+	desc = "A box containing spare citizenship permits for Kebab. Use a mayor's ID on a citizenship permit to assign its owner."
 	illustration = "id"
 
 /obj/item/storage/box/citizenship_permits/PopulateContents()

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -137,8 +137,8 @@
 	if (!mineralSpawnChanceList)
 		mineralSpawnChanceList = list(
 			/turf/closed/mineral/uranium = 5, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 10,
-			/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11/*,
-			/turf/closed/mineral/gibtonite = 4, /turf/closed/mineral/bscrystal = 1*/)
+			/turf/closed/mineral/silver = 12, /turf/closed/mineral/plasma = 20, /turf/closed/mineral/iron = 40, /turf/closed/mineral/titanium = 11,
+			/turf/closed/mineral/gibtonite = 4, /*/turf/closed/mineral/bscrystal = 1*/)
 	if (display_icon_state)
 		icon_state = display_icon_state
 	. = ..()
@@ -180,8 +180,8 @@
 	mineralChance = 6
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4, /turf/closed/mineral/titanium = 4,
-		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40/*,
-		/turf/closed/mineral/gibtonite = 2, /turf/closed/mineral/bscrystal = 1*/)
+		/turf/closed/mineral/silver = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40,
+		/turf/closed/mineral/gibtonite = 2, /*/turf/closed/mineral/bscrystal = 1*/)
 
 
 /turf/closed/mineral/random/volcanic
@@ -418,7 +418,7 @@
 
 //GIBTONITE
 
-/*/turf/closed/mineral/gibtonite
+/turf/closed/mineral/gibtonite
 	mineralAmt = 1
 	spreadChance = 0
 	spread = 0
@@ -518,4 +518,4 @@
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
-	defer_change = 1*/
+	defer_change = 1

--- a/code/modules/fallout/machinery/light_sources/bar.dm
+++ b/code/modules/fallout/machinery/light_sources/bar.dm
@@ -47,7 +47,7 @@
 
 /obj/machinery/light/kebab_sign/break_light_tube()
 	return 0
-
+/*
 /obj/machinery/light/oasis
 	name = "Oasis sign"
 	icon_state = "Oasis"
@@ -79,7 +79,7 @@
 
 /obj/machinery/light/oasis_sign/break_light_tube()
 	return 0
-
+*/
 /obj/machinery/light/chiken_ranch
 	name = "Chiken Ranch sign"
 	icon_state = "chiken_ranch"

--- a/code/modules/fallout/mob/simple_animal/mobs/supermutant.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/supermutant.dm
@@ -18,8 +18,8 @@
 	response_help = "touches"
 	response_disarm = "tries to perform a kung fu move, then suddenly remembers that it's actually"
 	response_harm = "hits"
-	maxHealth = 150
-	health = 150
+	maxHealth = 450
+	health = 450
 	force_threshold = 15
 	faction = list("hostile", "supermutant")
 	melee_damage_lower = 25
@@ -84,13 +84,13 @@
 	icon_living = "hulk_ranged_s"
 	icon_dead = "hulk_ranged_s"
 	ranged = 1
-	maxHealth = 200
-	health = 200
-	retreat_distance = 4
-	minimum_distance = 6
+	maxHealth = 200//less due to being ranged
+	health = 200//as above
+	retreat_distance = 8
+	minimum_distance = 4
 	projectiletype = /obj/item/projectile/bullet/F13/c308mmBullet
 	projectilesound = 'sound/f13weapons/hunting_rifle.ogg'
-	loot = list(/obj/item/ammo_box/a762)
+	loot = list(/obj/item/ammo_box/a762,/obj/item/gun/ballistic/shotgun/remington)
 
 /mob/living/simple_animal/hostile/supermutant/rangedmutant/death(gibbed)
 	icon = 'icons/fallout/mobs/supermutant_dead.dmi'

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -489,7 +489,7 @@ Prime Legionairy
 */
 
 /datum/job/CaesarsLegion/Legionnaire/f13prime
-	title = "Legionary"
+	title = "Legionnaire"
 	flag = F13LEGIONARY
 	faction = "Legion"
 	total_positions = 12

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -488,7 +488,7 @@ Veteran Legionary
 Prime Legionairy
 */
 
-/datum/job/CaesarsLegion/Legionnaire/f13legionary
+/datum/job/CaesarsLegion/Legionnaire/f13prime
 	title = "Legionary"
 	flag = F13LEGIONARY
 	faction = "Legion"

--- a/code/modules/mob/living/simple_animal/hostile/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ghoul.dm
@@ -11,8 +11,8 @@
 	speak_emote = list("growls")
 	emote_see = list("screeches")
 	a_intent = INTENT_HARM
-	maxHealth = 40
-	health = 40
+	maxHealth = 80
+	health = 80
 	speed = 2
 	harm_intent_damage = 15
 	melee_damage_lower = 10
@@ -39,11 +39,11 @@
 	icon_dead = "ghoulreaver_dead"
 	speed = 2
 	a_intent = INTENT_HARM
-	maxHealth = 100
-	health = 100
+	maxHealth = 150
+	health = 150
 	harm_intent_damage = 6
 	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_upper = 25
 
 /mob/living/simple_animal/hostile/ghoul/reaver/Initialize()
 	. = ..()
@@ -88,8 +88,8 @@
 	icon_state = "glowinghoul"
 	icon_living = "glowinghoul"
 	icon_dead = "glowinghoul_dead"
-	maxHealth = 80
-	health = 80
+	maxHealth = 180
+	health = 180
 	speed = 2
 	harm_intent_damage = 10
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/hostile/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wastebots.dm
@@ -38,8 +38,8 @@
 	icon_dead = "gib7"
 	health = 200
 	maxHealth = 200
-	melee_damage_lower = 72
-	melee_damage_upper = 72
+	melee_damage_lower = 24
+	melee_damage_upper = 32
 	attack_sound = 'sound/items/welder.ogg'
 	attacktext = "shoots a burst of flame at"
 	projectilesound = 'sound/weapons/laser.ogg'
@@ -104,8 +104,8 @@
 	icon_state = "sentrybot"
 	icon_living = "sentrybot"
 	icon_dead = "sentrybot"
-	health = 380
-	maxHealth = 380
+	health = 680
+	maxHealth = 680
 	melee_damage_lower = 48
 	melee_damage_upper = 72
 	extra_projectiles = 4 //5 projectiles
@@ -167,8 +167,8 @@
 	icon_state = "assaultron"
 	icon_living = "assaultron"
 	icon_dead = "gib7"
-	health = 250
-	maxHealth = 250
+	health = 450
+	maxHealth = 450
 	faction = list("wastebot", "enclave")
 	speed = 0
 	melee_damage_lower = 55

--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -86,6 +86,19 @@
 	mob_types = list(/mob/living/simple_animal/hostile/ghoul, /mob/living/simple_animal/hostile/ghoul/reaver, /mob/living/simple_animal/hostile/ghoul/glowing)
 	faction = list("ghoul")
 
+/mob/living/simple_animal/hostile/spawner/ghoul/larger
+	name = "ghoul pit"
+	desc = "A pit full of feral ghouls, and some still seem to be moving"
+	icon_state = "hole"
+	icon_living = "hole"
+	icon = 'icons/mob/nest.dmi'
+	health = 500//less health to make up for more spawns
+	maxHealth = 500//less health to make up for more spawns
+	max_mobs = 12
+	spawn_time = 150
+	mob_types = list(/mob/living/simple_animal/hostile/ghoul, /mob/living/simple_animal/hostile/ghoul/reaver, /mob/living/simple_animal/hostile/ghoul/glowing)
+	faction = list("ghoul")
+
 /mob/living/simple_animal/hostile/spawner/deathclaw
 	name = "death claw nest"
 	desc = "A nest full of deathclaws, some are coming out."

--- a/code/modules/shuttle/f13.dm
+++ b/code/modules/shuttle/f13.dm
@@ -81,7 +81,7 @@
 
 /obj/machinery/computer/shuttle/vault113elevator
 	name = "vault 113 elevator controls"
-	desc = "Controls the elevator between the Vault and Oasis."
+	desc = "Controls the elevator between the Vault and... somewhere..."
 	icon_screen = "shuttle"
 	icon_keyboard = "tech_key"
 	light_color = LIGHT_COLOR_CYAN

--- a/code/modules/vehicles/wasteland/buggy.dm
+++ b/code/modules/vehicles/wasteland/buggy.dm
@@ -1,72 +1,34 @@
 //Fallout 13 dune buggy directory
 
-/obj/vehicle/ridden/fuel/motorcycle/buggy
+/obj/vehicle/ridden/buggy
 	name = "dune buggy"
 	desc = "<i>Ain't no place for fancy cars on the wasteland.<br>No place for classy brands, but nicknames.<br>Only the rusty and trusty death machines.<br>Only fuel and blood.</i>"
 	icon = 'icons/fallout/vehicles/medium_vehicles.dmi'
 	icon_state = "buggy_dune"
-	datum_type = /datum/riding/motorcycle/buggy
 	pixel_x = -17
 	pixel_y = -2
 	obj_integrity = 600
 	max_integrity = 600
-	fuel = 800
-	max_fuel = 800
 	var/list/names = list("Badger", "Bandit", "Desert Punk", "Dune Buddy", "Duster", "Rebel", "Rooster")
 
-/obj/vehicle/ridden/fuel/motorcycle/buggy/New()
+/obj/vehicle/ridden/buggy/New()
 	..()
 	name = pick(names)
 
-/obj/item/key/buggy
-	name = "car key"
-	desc = "A keyring with a small steel key.<br>By the look of the key cuts, it likely belongs to an automobile."
-	icon = 'icons/fallout/vehicles/small_vehicles.dmi'
+/obj/vehicle/ridden/buggy/Initialize()
+	. = ..()
+	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
+	D.vehicle_move_delay = 0.5
+	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(-1, 9), TEXT_SOUTH = list(0, 12), TEXT_EAST = list(-5, 6), TEXT_WEST = list( 3, 6)))
 
-/obj/item/key/buggy/New()
-	..()
-	icon_state = pick("key-buggy-r","key-buggy-y","key-buggy-g","key-buggy-b")
-
-/obj/item/key/buggy/wheel //I am the man... Who grabs the sun... RIDING TO VALHALLA!
-	name = "steering wheel"
-	desc = "A vital part of an automobile that is made of metal and decorated with a freaky skull.<br>Oh, what a day... What a lovely day for taking a ride!"
-	icon_state = "wheel"
-
-/obj/item/key/buggy/wheel/New()
-	..()
-	icon_state = "wheel"
-
-/datum/riding/motorcycle/buggy
-	keytype = /obj/item/key/buggy
-	vehicle_move_delay = 0.8
-
-/datum/riding/motorcycle/buggy/handle_vehicle_offsets()
-	..()
-	if(ridden.has_buckled_mobs())
-		for(var/m in ridden.buckled_mobs)
-			var/mob/living/buckled_mob = m
-			switch(buckled_mob.dir)
-				if(NORTH)
-					buckled_mob.pixel_x = -1
-					buckled_mob.pixel_y = 9
-				if(EAST)
-					buckled_mob.pixel_x = -5
-					buckled_mob.pixel_y = 6
-				if(SOUTH)
-					buckled_mob.pixel_x = 0
-					buckled_mob.pixel_y = 12
-				if(WEST)
-					buckled_mob.pixel_x = 3
-					buckled_mob.pixel_y = 6
-
-/obj/vehicle/ridden/fuel/motorcycle/buggy/olive
+/obj/vehicle/ridden/buggy/olive
 	icon_state = "buggy_olive"
 	names = list("Bang-Bang", "Bolo", "Dittybopper", "Geardo", "Joe", "Pollywog", "Zoomie")
 
-/obj/vehicle/ridden/fuel/motorcycle/buggy/red
+/obj/vehicle/ridden/buggy/red
 	icon_state = "buggy_red"
 	names = list("Crusher", "Grim Reaper", "Meat Grinder", "Mincer", "Reaver", "Ripper", "Ripsaw")
 
-/obj/vehicle/ridden/fuel/motorcycle/buggy/hot
+/obj/vehicle/ridden/buggy/hot
 	icon_state = "buggy_hot"
 	names = list("Dragon", "Fire And Flames", "Flash", "Igniter", "Heat", "Hot Wheels", "Trailblazer")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2754,6 +2754,7 @@
 #include "code\modules\vehicles\speedbike.dm"
 #include "code\modules\vehicles\vehicle_actions.dm"
 #include "code\modules\vehicles\vehicle_key.dm"
+#include "code\modules\vehicles\wasteland\buggy.dm"
 #include "code\modules\vehicles\wasteland\bus.dm"
 #include "code\modules\vehicles\wasteland\car.dm"
 #include "code\modules\vending\_vending.dm"


### PR DESCRIPTION
- - -
Gungeons are far more logical, rather than being "SIXTY THOUSAND MOBS ECKSDEEE"
- - -
Map:
 - As above.
 - In the northern part of the Sewers, you'll start to come across toxic waste.
 - De-Oasis and de-babyproofs some areas.
 - Tunnels between the Raiders and Western part of the map blocked off. Mostly. There's still a method of travel through the rat's nest, if you don't want to go south-west.
- - -
Balance:
 - Gibtonite can now once again spawn.
 - Ghouls rebalanced health wise.
 - 'Borgs rebalanced health wise.
- - -
Other:
 - Oasis flags removed. Gang gang, anti-ERP Fiend gang.
