### PR TITLE
Fixes some roles showing up as "Miscellaneous" in the Wasteland Census (Crew Manifest)

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -75,7 +75,7 @@
 #define F13RECRUITLEG	(1<<9)
 #define F13AUXILIA		(1<<10)
 #define F13LEGIONSLAVE	(1<<11)
-#define F13EXPLORER		(1<<12)
+#define F13EXPLORER 	(1<<12)
 #define F13SLAVEMASTER	(1<<13)
 #define F13CAMPFOLLOWER	(1<<14)
 

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -75,7 +75,7 @@
 #define F13RECRUITLEG	(1<<9)
 #define F13AUXILIA		(1<<10)
 #define F13LEGIONSLAVE	(1<<11)
-#define F13EXPLORER     (1<<12)
+#define F13EXPLORER		(1<<12)
 #define F13SLAVEMASTER	(1<<13)
 #define F13CAMPFOLLOWER	(1<<14)
 

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -75,7 +75,7 @@
 #define F13RECRUITLEG	(1<<9)
 #define F13AUXILIA		(1<<10)
 #define F13LEGIONSLAVE	(1<<11)
-#define F13EXPLORER 	(1<<12)
+#define F13EXPLORER     (1<<12)
 #define F13SLAVEMASTER	(1<<13)
 #define F13CAMPFOLLOWER	(1<<14)
 

--- a/code/modules/jobs/job_types/den.dm
+++ b/code/modules/jobs/job_types/den.dm
@@ -439,7 +439,7 @@ Shopkeeper
     total_positions = 1
     spawn_positions = 1
     supervisors = "the sheriff and the mayor"
-    description = "The capitalist economy of pre-war america survived alongside its people. Now it's your job to continue its survival so make some caps!"
+    description = "The capitalist economy of pre-war America survived alongside its people. Now it's your job to continue its survival, so go make some caps!"
     selection_color = "#dcba97"
     exp_requirements = 180
     exp_type = EXP_TYPE_DEN

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_INIT(ncr_positions, list(
     "NCR Military Police",
     "NCR Heavy Trooper",
     "NCR Corporal",
-    "NCR Specialist"
+    "NCR Specialist",
     "NCR Trooper",
     "NCR Assistant",
     "NCR Ranger"

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -116,7 +116,8 @@ GLOBAL_LIST_INIT(den_positions, list(
     "Settler",
     "Deputy",
     "Farmer",
-    "Prospector"
+    "Prospector",
+    "Shopkeeper"
 ))
 
 GLOBAL_LIST_INIT(legion_command_positions, list(
@@ -130,6 +131,7 @@ GLOBAL_LIST_INIT(legion_positions, list(
     "Veteran Legionary",
 	"Prime Legionary",
     "Recruit Legionary",
+    "Legionnaire",
     "Legion Vexillarius",
     "Legion Explorer",
     "Legion Slavemaster",
@@ -150,6 +152,7 @@ GLOBAL_LIST_INIT(ncr_positions, list(
     "NCR Military Police",
     "NCR Heavy Trooper",
     "NCR Corporal",
+    "NCR Specialist"
     "NCR Trooper",
     "NCR Assistant",
     "NCR Ranger"
@@ -181,7 +184,6 @@ GLOBAL_LIST_INIT(security_positions, list(
 GLOBAL_LIST_INIT(silicon_positions, list(
     "Mr. Handy"
 ))
-
 GLOBAL_LIST_INIT(tribal_positions, list(
     "Chief",
     "Shaman",

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -177,18 +177,22 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
     "Preacher",
     "Wastelander"
 ))
+
 GLOBAL_LIST_INIT(security_positions, list(
     "Vault-tec Security",
     "Deputy"
 ))
+
 GLOBAL_LIST_INIT(silicon_positions, list(
     "Mr. Handy"
 ))
+
 GLOBAL_LIST_INIT(tribal_positions, list(
     "Chief",
     "Shaman",
     "Villager"
 ))
+
 /*
 GLOBAL_LIST_INIT(engineering_positions, list(
     "Chief Engineer",
@@ -256,7 +260,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
     EXP_TYPE_RANGER        = list("titles" = list("NCR Veteran Ranger","NCR Ranger")),
     EXP_TYPE_SCRIBE        = list("titles" = list("Scribe")),
     EXP_TYPE_DECANUS       = list("titles" = list("Legion Decanus")),
-    EXP_TYPE_TRIBAL        = list("titles" = tribal_positions),
+    EXP_TYPE_TRIBAL        = list("titles" = tribal_positions       ),
     EXP_TYPE_TRIBALCOMMAND = list("titles" = list("Chief","Shaman")),
     //EXP_TYPE_ENCLAVE = list("titles" = enclave_positions),
     // EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | list("AI","Cyborg")), // crew positions

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -263,7 +263,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
     EXP_TYPE_RANGER        = list("titles" = list("NCR Veteran Ranger","NCR Ranger")),
     EXP_TYPE_SCRIBE        = list("titles" = list("Scribe")),
     EXP_TYPE_DECANUS       = list("titles" = list("Legion Decanus")),
-    EXP_TYPE_TRIBAL        = list("titles" = tribal_positions       ),
+    EXP_TYPE_TRIBAL        = list("titles" = tribal_positions),
     EXP_TYPE_TRIBALCOMMAND = list("titles" = list("Chief","Shaman")),
     //EXP_TYPE_ENCLAVE = list("titles" = enclave_positions),
     // EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | list("AI","Cyborg")), // crew positions

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -175,7 +175,10 @@ GLOBAL_LIST_INIT(wasteland_positions, list(
     "Raider",
     "Great Khan",
     "Preacher",
-    "Wastelander"
+    "Wastelander",
+    "Chief",
+    "Shaman",
+    "Villager"
 ))
 
 GLOBAL_LIST_INIT(security_positions, list(


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
& other role stuff. Fixes Legionnaire, NCR Specialist, Shopkeeper, Villager, Chief and Shaman showing up in the "Miscellaneous" section of the Wasteland Census. All the tribal roles are moved to the Wasteland section because I decided to do it that way.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It looked kind of stupid so I thought I'd fix it.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested it by hosting locally. Seemed to work just fine.
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
tweak: Legionnaire and NCR Specialist show up in the correct spot on the census
tweak: Tribal roles go to Wasteland instead of something that didn't exist
/:cl:
