### PR TITLE
Adding Crafting Recipe for Turbo

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1030,6 +1030,14 @@
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_DRUGS
 
+/datum/crafting_recipe/turbo
+	name = "Turbo"
+	result = /obj/item/reagent_containers/pill/patch/turbo
+	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 1, /obj/item/reagent_containers/food/snacks/meat/slab/cazador_meat = 1, /obj/item/reagent_containers/pill/patch/jet = 1, /obj/item/toy/crayon/spraycan = 1)
+	time = 20
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_DRUGS
+
 /datum/crafting_recipe/rags
 	name = "Cut clothing into rags"
 	result = /obj/item/stack/sheet/cloth/three


### PR DESCRIPTION
Title.
## Description
Turbo can now be crafted with the following:
-1 broc flower
-1 slab of cazador meat (to remplace the cazador poison gland which isn't in the code)
-1 jet
-1 spraycan (due to Turpentine being nearly impossible to find and the Fallout wiki mentioning that it's jet attached to a can of hairpray)
## Motivation and Context
Due to the very low amount of Turbo around the map (I think there is only 3-4 in total) and due to it having been nerfed to the ground by DR I think it would be a good idea having people be able to produce it.

## How Has This Been Tested?
Did it locally like usual and it's working.

## Screenshots (if appropriate):
![turbo crafting](https://user-images.githubusercontent.com/61144318/83114041-706dbd00-a096-11ea-95af-e4a0acbe6ddc.PNG)

## Changelog (necessary)
:cl:
add: crafting option for turbo
/:cl:
