### PR TITLE
Comments Gender Reassignment Surgery out of The Code

### DIFF
--- a/code/modules/surgery/gender_reassignment.dm
+++ b/code/modules/surgery/gender_reassignment.dm
@@ -1,3 +1,4 @@
+/*
 /datum/surgery/gender_reassignment_lower
 	name = "gender reassignment - lower surgery"
 	species = list(/mob/living/carbon/human)
@@ -41,7 +42,7 @@
 	H.has_vagina = FALSE
 	target.regenerate_icons()
 	return 1
-
+*/
 /datum/surgery/castration
 	name = "castration"
 	species = list(/mob/living/carbon/human)
@@ -79,7 +80,7 @@
 	target.regenerate_icons()
 	return 1
 
-
+/*
 /datum/surgery/gender_reassignment_top
 	name = "gender reassignment - top surgery"
 	species = list(/mob/living/carbon/human)
@@ -178,3 +179,4 @@
 	H.gender_ambiguous = 1
 	target.regenerate_icons()
 	return 1
+*/


### PR DESCRIPTION
really have no idea how they're doing gender reassignment surgery in the wastes anyways

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
You can't do gender reassignment surgery, top or bottom, anymore. You can still castrate people though. It's still in the code in case anyone wanted it back for some reason...
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This removes the ability for meta-ERP-cliques from turning their friends into big mommy dom futa for the 52nd round in a row. Also, I don't see how filthy wasteland doctors would be performing gender reassignment surgery.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested on local server, works like a charm.
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
del: Removes Gender Reassignment Surgery
/:cl:
