### PR TITLE
add fire delay to revolver

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -503,6 +503,7 @@
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	w_class = WEIGHT_CLASS_SMALL
+	fire_delay = 1
 
 /obj/item/gun/ballistic/revolver/thatgun
 	name = ".223 pistol"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -484,6 +484,7 @@
 	fire_sound = 'sound/weapons/Gunshot.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/improvised9mm
 	spread = 6
+	fire_delay = 1
 
 /obj/item/gun/ballistic/revolver/pipe_rifle
 	name = "pipe rifle"
@@ -495,6 +496,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	spread = 4
+	fire_delay = 1
 
 /obj/item/gun/ballistic/revolver/police
 	name = "police pistol"
@@ -503,7 +505,7 @@
 	fire_sound = 'sound/f13weapons/policepistol.ogg'
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	w_class = WEIGHT_CLASS_SMALL
-	fire_delay = 1
+	fire_delay = 2
 
 /obj/item/gun/ballistic/revolver/thatgun
 	name = ".223 pistol"


### PR DESCRIPTION
there was no fire delay to the police revolver, adds a fire delay of 1

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

## Description
<!--- Describe your changes in detail -->
added a fire delay to the police pistol

## Motivation and Context
<!--- the police revolver had no fire delay, im pretty sure this was an oversight -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/CrashpointF13/CrashpointF13/issues/52

## How Has This Been Tested?
I don't see why this would require testing.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
- added fire delay to police pistol
/:cl:
