### PR TITLE
Changes Ghouls from Bullet Sponges back to How They Used To Be

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ghoul.dm
@@ -11,8 +11,8 @@
 	speak_emote = list("growls")
 	emote_see = list("screeches")
 	a_intent = INTENT_HARM
-	maxHealth = 40
-	health = 40
+	maxHealth = 45
+	health = 45
 	speed = 2
 	harm_intent_damage = 15
 	melee_damage_lower = 10
@@ -44,6 +44,13 @@
 	harm_intent_damage = 6
 	melee_damage_lower = 15
 	melee_damage_upper = 25
+
+/mob/living/simple_animal/hostile/ghoul/reaver/Initialize()
+	. = ..()
+
+/mob/living/simple_animal/hostile/ghoul/reaver/Aggro()
+	..()
+	summon_backup(10)
 
 /mob/living/simple_animal/hostile/ghoul/coldferal
 	name = "cold ghoul feral"

--- a/code/modules/mob/living/simple_animal/hostile/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ghoul.dm
@@ -11,8 +11,8 @@
 	speak_emote = list("growls")
 	emote_see = list("screeches")
 	a_intent = INTENT_HARM
-	maxHealth = 80
-	health = 80
+	maxHealth = 40
+	health = 40
 	speed = 2
 	harm_intent_damage = 15
 	melee_damage_lower = 10
@@ -39,18 +39,11 @@
 	icon_dead = "ghoulreaver_dead"
 	speed = 1
 	a_intent = INTENT_HARM
-	maxHealth = 150
-	health = 150
+	maxHealth = 100
+	health = 100
 	harm_intent_damage = 6
 	melee_damage_lower = 15
 	melee_damage_upper = 25
-
-/mob/living/simple_animal/hostile/ghoul/reaver/Initialize()
-	. = ..()
-
-/mob/living/simple_animal/hostile/ghoul/reaver/Aggro()
-	..()
-	summon_backup(10)
 
 /mob/living/simple_animal/hostile/ghoul/coldferal
 	name = "cold ghoul feral"
@@ -88,8 +81,8 @@
 	icon_state = "glowinghoul"
 	icon_living = "glowinghoul"
 	icon_dead = "glowinghoul_dead"
-	maxHealth = 180
-	health = 180
+	maxHealth = 80
+	health = 80
 	speed = 1
 	harm_intent_damage = 10
 	melee_damage_lower = 20


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ghouls (and subsequently most mobs) being bullet sponges was one of Desert Rose's PVE changes I guess. I changed ghouls back (close) to what they used to be on Bad Deathclaw. A regular ghoul shouldn't take more than an entire mag of 9mm. Now they don't!
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ghouls have no business being bullet sponges. Rotten, sinewy mutant humans who are practically falling apart shouldn't absorb entire magazines. I'm thinking maybe I've made them too weak again, but we'll see I guess.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested it on a local hosted instance.
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
tweak: tweaked ghoul health back to reasonable levels
balance: ghouls no longer bullet sponges
/:cl:
