### PR TITLE
throwing spears buff

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -387,7 +387,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_flags = SLOWS_WHILE_IN_HAND
 	throw_speed = 12
 	slowdown = 0.3
-	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 50)
+	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 30)
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/throwing_star/throwingknife

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -383,11 +383,11 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "throw_spear"
 	item_state = "tribalspear"
 	force = 20
-	throwforce = 30
+	throwforce = 35
 	item_flags = SLOWS_WHILE_IN_HAND
 	throw_speed = 12
 	slowdown = 0.3
-	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 20)
+	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 50)
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/throwing_star/throwingknife

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -383,11 +383,11 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "throw_spear"
 	item_state = "tribalspear"
 	force = 20
-	throwforce = 25
+	throwforce = 30
 	item_flags = SLOWS_WHILE_IN_HAND
 	throw_speed = 12
 	slowdown = 0.3
-	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 80, "embedded_fall_chance" = 20)
+	embedding = list("embedded_pain_multiplier" = 2, "embed_chance" = 50, "embedded_fall_chance" = 20)
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/throwing_star/throwingknife


### PR DESCRIPTION
I i buffed throwing spears because, with how hard they are to transport,  their slow down and their rate of fire, 25 damages was not enough, so i went with the old 35 bad deathclaw had, next to that i also nerfed the embed chance from 80% to 50%.

throwing spears areimportant for legion, they are part of their identity on the server, giving them a bit of use seem to be a good idea.


More damages on spears, less embed.