### PR TITLE
Reverting Molotovs

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -432,21 +432,20 @@
 
 		to_chat(user, "<span class='info'>You light [src] on fire.</span>")
 		add_overlay(GLOB.fire_overlay)
-
-		spawn((100)) //Throw. And pray. //10 = 1 second IRL, 100 = 10 seconds
-			if(active)
-				var/counter
-				var/target = src.loc
-				for(counter = 0, counter<2, counter++)
-					if(istype(target, /obj/item/storage))
-						var/obj/item/storage/S = target
-						target = S.loc
-				if(istype(target, /atom))
-					var/atom/A = target
-					SplashReagents(A)
-					A.fire_act()
-					visible_message("<span class='danger'>The molotov cocktail explodes!</span>")
-				qdel(src)
+		if(!isGlass)
+			spawn(50)
+				if(active)
+					var/counter
+					var/target = src.loc
+					for(counter = 0, counter<2, counter++)
+						if(istype(target, /obj/item/storage))
+							var/obj/item/storage/S = target
+							target = S.loc
+					if(istype(target, /atom))
+						var/atom/A = target
+						SplashReagents(A)
+						A.fire_act()
+					qdel(src)
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/attack_self(mob/user)
 	if(active)


### PR DESCRIPTION
After a couple of people saying they wanted them to be like how they where back on BD, I changed it so now they don't self destroy.
## Motivation and Context
People wanted to carry lit molotovs in their bags, might as well let them do it. Plus I think that the fact that a molotovs can explode on their own after being lit make people not want to use them in the first place.

## How Has This Been Tested?
Locally

## Changelog (necessary)
:cl:
tweak: now molotovs doesn't explode after a certain amount of time.
/:cl:
