### PR TITLE
Removes H&K CAWS and City-Killer Shotgun from crafting

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1070,35 +1070,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/citykiller
-	name = "combat shotgun"
-	result = /obj/item/gun/ballistic/shotgun/automatic/combat
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
-				/obj/item/stack/crafting/metalparts = 4,
-				/obj/item/stack/crafting/goodparts = 2,
-				/obj/item/stack/sheet/metal = 1,
-				/datum/reagent/blackpowder = 35)
-	tools = list(TOOL_WORKBENCH, TOOL_GUNTIER4)
-	traits = list(TRAIT_GUNSMITH_FOUR)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
-/datum/crafting_recipe/caws
-	name = "h&k caws"
-	result = /obj/item/gun/ballistic/automatic/shotgun/caws
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
-				/obj/item/stack/sheet/mineral/titanium = 2,
-				/obj/item/stack/sheet/metal = 2,
-				/obj/item/stack/crafting/metalparts = 3,
-				/obj/item/stack/crafting/goodparts = 3,
-				/datum/reagent/blackpowder = 35)
-	tools = list(TOOL_AWORKBENCH, /obj/item/blueprint/weapon/caws, TOOL_GUNTIER4)
-	traits = list(TRAIT_GUNSMITH_FOUR)
-	time = 120
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
 /datum/crafting_recipe/greasegun
 	name = "M3A1 Grease Gun"
 	result = /obj/item/gun/ballistic/automatic/greasegun


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the H&K CAWS and City-Killer Shotgun from crafting.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I did this because an automatic shotgun with like 12 round capacity is fucking retarded powergame BS and so is gun crafting in general. But we'll have to settle with removing the city-killer.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
tested locally, seems to work just fine.
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
del: Removes some t5 guns from crafting menu.
/:cl:
