### PR TITLE
[READY] Adds back enclave powerarmor to the T5 armor pool also removes ring.

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -345,9 +345,18 @@
 				/obj/item/clothing/suit/armor/f13/power_armor/t51b,
 				/obj/item/clothing/head/helmet/power_armor/t51b
 				)
+	var/loot3 = list(
+				/obj/item/clothing/suit/armor/f13/power_armor/advanced,
+				/obj/item/clothing/head/helmet/power_armor/advanced
+				)
+	var/loot4 = list(
+				/obj/item/clothing/suit/armor/f13/power_armor/advanced/mk2,
+				/obj/item/clothing/head/helmet/power_armor/advanced/mk2
+				)
+// ^^^^ this could be replaced with tesla if it proves to be troublesome
 
 /obj/effect/spawner/lootdrop/f13/armor/tier5/Initialize(mapload) //on mapload, pick what shit to spawn
-	loot = pick(loot1, loot2)
+	loot = pick(loot1, loot2, loot3, loot4)
 	. = ..()
 
 /obj/effect/spawner/lootdrop/f13/armor/random
@@ -365,10 +374,9 @@
     lootcount = 1
 
     loot = list(
-            /obj/effect/spawner/lootdrop/f13/armor/tier2 = 59,
+            /obj/effect/spawner/lootdrop/f13/armor/tier2 = 60,
             /obj/effect/spawner/lootdrop/f13/armor/tier3 = 30,
             /obj/effect/spawner/lootdrop/f13/armor/tier4 = 10,
-            /obj/item/ring = 1 //one ring to rule them all
             )
 
 /* ------------------------------------------------

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -376,7 +376,7 @@
     loot = list(
             /obj/effect/spawner/lootdrop/f13/armor/tier2 = 60,
             /obj/effect/spawner/lootdrop/f13/armor/tier3 = 30,
-            /obj/effect/spawner/lootdrop/f13/armor/tier4 = 10,
+            /obj/effect/spawner/lootdrop/f13/armor/tier4 = 10
             )
 
 /* ------------------------------------------------

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -350,10 +350,9 @@
 				/obj/item/clothing/head/helmet/power_armor/advanced
 				)
 	var/loot4 = list(
-				/obj/item/clothing/suit/armor/f13/power_armor/advanced/mk2,
-				/obj/item/clothing/head/helmet/power_armor/advanced/mk2
+				/obj/item/clothing/suit/armor/f13/power_armor/tesla,
+				/obj/item/clothing/head/helmet/power_armor/tesla
 				)
-// ^^^^ this could be replaced with tesla if it proves to be troublesome
 
 /obj/effect/spawner/lootdrop/f13/armor/tier5/Initialize(mapload) //on mapload, pick what shit to spawn
 	loot = pick(loot1, loot2, loot3, loot4)


### PR DESCRIPTION
The LARP is back, hopefully you get good RNG.
## Description
I removed the one ring from the possibility of getting spawned and added back Enclave PA. This WAS a thing back on BD so I don't know if later on after I left they removed it or what, but it seems redundant since the only place T5 is found is in the enclave bunker.

## Motivation and Context
I don't want a bus item, nor a LOTR reference appearing on normal rounds.
I want to LARP as enclave, I'm sure others do as well. The robust will be able to nab these I suppose?

## How Has This Been Tested?
Should be fine, I made sure to leave no stone unturned when tweaking shit unlike my last PR.

## Screenshots (if appropriate):
N/A even if I did it would just be the enclave bunker with some enclave powerarmor.

## Changelog (necessary)
:cl:
del: Removed the One Ring from rotation/normal gameplay.
add: Enclave Power Armor can once again be found in the Enclave bunker. Not sure why DR removed it.
/:cl:
