### PR TITLE
Melee Tweaks

### DIFF
--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
-	force = 40
+	force = 35
 	armour_penetration = 50
 	throwforce = 10
 	throw_range = 7
@@ -20,8 +20,8 @@
 	name = "\improper Goliath" //the Goliath
 	desc = "A metal gauntlet with a piston-powered ram on top. This one has been painted in the colors of Caesar's Legion, and features a brutal metal spike to increase penetration and damage."
 	icon_state = "goliath"
-	force = 60 //you are Strongly Encouraged not to get hit by this.
-	armour_penetration = 80 //what is armor?
+	force = 40 //you are Strongly Encouraged not to get hit by this.
+	armour_penetration = 70 //what is armor?
 	throwforce = 20
 
 /obj/item/gun/ballistic/revolver/ballisticfist //it's a double-barrel shotgun disguised as a fist shhh
@@ -38,7 +38,6 @@
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_NORMAL
-	item_flags = NEEDS_PERMIT //doesn't slow you down
 	fire_delay = 0
 	distro = 1
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -226,7 +226,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 10
-	force_wielded = 50
+	force_wielded = 55
 	attack_verb = list("axed", "chopped", "cleaved", "torn", "hacked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP
@@ -564,6 +564,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	force = 10
 	var/force_on = 60
+	armour_penetration = 15 //makes it better than a sledgehammer
 	w_class = WEIGHT_CLASS_BULKY
 	throwforce = 20
 	throw_speed = 2
@@ -789,8 +790,8 @@
 	desc = "A potent weapon capable of cutting through nearly anything. Wielding it in two hands will allow you to deflect gunfire."
 	force_unwielded = 20
 	force_wielded = 40
-	armour_penetration = 100
-	block_chance = 40
+	armour_penetration = 75
+	block_chance = 30
 	throwforce = 20
 	throw_speed = 4
 	sharpness = IS_SHARP
@@ -827,7 +828,7 @@
 	icon_state = "bone_axe0"
 	name = "bone axe"
 	desc = "A large, vicious axe crafted out of several sharpened bone plates and crudely tied together. Made of monsters, by killing monsters, for killing monsters."
-	force_wielded = 40
+	force_wielded = 50
 
 /obj/item/twohanded/fireaxe/boneaxe/update_icon()
 	icon_state = "bone_axe[wielded]"
@@ -924,7 +925,8 @@
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	force_unwielded = 12//Likely not able to hit too hard with those noodle arms, bro.
-	force_wielded = 62
+	force_wielded = 50
+	armour_penetration = 5
 	throwforce = 20
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
@@ -941,6 +943,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
+	block_chance = 10
 
 /obj/item/twohanded/fireaxe/bmprsword/update_icon()
 	name = "bumper sword"
@@ -970,7 +973,7 @@
 	force_unwielded = 20
 	force_wielded = 40
 	throwforce = 20
-	armour_penetration = 20
+	armour_penetration = 10
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -110,7 +110,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "warclub"
 	item_state = "warclub"
 	attack_verb = list("mashed", "bashed", "hit", "bludgeoned", "whacked")
-	force = 35
+	force = 30
 	throwforce = 25
 	block_chance = 10
 	armour_penetration = 5
@@ -148,6 +148,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = SLOT_BELT
 	force = 15 //Just try to swing a frying pan
 	throw_speed = 1
+	block_chance = 20 //yes
 	throw_range = 2
 	throwforce = 10
 	w_class = 2
@@ -297,12 +298,13 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	force = 25
+	force = 30
+	armour_penetration = 15 //folded a million times
 	throwforce = 10
 	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 0
+	block_chance = 10
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -550,7 +552,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	item_flags = NODROP | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
-	force = 56
+	force = 50
 	throwforce = 0
 	throw_range = 0
 	throw_speed = 0


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Tones down Centurion's Goliath heavily, less so the generic powerfist.

Nerfs tribal craftable weapons (warclub, warmace) so they are not strictly better than what the Legion gets.

Buffs fire axe to its Bad Deathclaw damage, bumps bone axe variant to what fire axe used to be, adds small block chance to bumper sword to make it worthwhile crafting and slightly better than the fire axe.

Attempts to re-introduce slowdown to ballistic fist, a caravan shotgun that can also double as melee and lets you run around at maximum speed was perhaps too good.

Considerably lowers the sledgehammer's damage, in exchange giving it a very minor armor penetrating property, as should be expected of a heavy blunt weapon.

Buffs the katana to be slightly better than the machete gladius, given its higher rarity, difficult crafting recipe and inability to be stored in a backpack. Essentially a dedicated one-handed weapon, instead of the machete's current role as a melee secondary.

Misc.
Adds 20 block chance to the frying pan, mostly as an easter egg.
Nerfs the high-frequency blade to a state comparable to other high-tier melee weapons, making it possible to introduce it into the loot tables later.

## Motivation and Context
As cited above.

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

## Changelog (necessary)

