### PR TITLE
Pre-war press revival.

### DIFF
--- a/code/modules/crafting/guncrafting.dm
+++ b/code/modules/crafting/guncrafting.dm
@@ -68,7 +68,7 @@
 	density = TRUE
 	layer = BELOW_OBJ_LAYER
 	anchored = TRUE
-	machine_tool_behaviour = TOOL_RELOADER
+	machine_tool_behaviour = list(TOOL_RELOADER, TOOL_MSRELOADER)
 
 /obj/machinery/ammobench/makeshift
 	name = "makeshift reloading bench"


### PR DESCRIPTION
## Description
Adds the ability for the press to actually make ammo.

## Motivation and Context
Crafting update messed with ammo crafting, and this did get unnoticed.

## How Has This Been Tested?
Locally under sleep deprivation.

## Changelog (necessary)
:cl:
fix: The pre-war press is useful now.
/:cl:
