### PR TITLE
Tesla powerarmor is now medium armor.

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -815,6 +815,7 @@
 	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably weaker against kinetic impacts."
 	icon_state = "tesla"
 	item_state = "tesla"
+	slowdown = 0.15 // 0.15 + 0.1 from helmet. "The Gannon family Tesla armor is classified as medium armor"
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 95, "energy" = 95, "bomb" = 62, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legion

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -812,7 +812,7 @@
 
 /obj/item/clothing/suit/armor/f13/power_armor/tesla
 	name = "tesla power armor"
-	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably weaker against kinetic impacts."
+	desc = "A variant of the Enclave's advanced power armor Mk I, jury-rigged with a Tesla device that is capable of dispersing a large percentage of the damage done by directed-energy attacks.<br>As it's made of complex composite materials designed to block most of energy damage - it's notably both lighter as armor and weaker against kinetic impacts."
 	icon_state = "tesla"
 	item_state = "tesla"
 	slowdown = 0.15 // 0.15 + 0.1 from helmet. "The Gannon family Tesla armor is classified as medium armor"


### PR DESCRIPTION
## Consistency issue.


## Description
Made it so the tesla powerarmor has the same slowdown as T51b and a more consistent description.

## Motivation and Context
New Vegas had tesla powerarmor as medium armor, not heavy like the remnants armor, our timeline is closest to that of NV so I'll use that as a basis. "The Gannon family Tesla armor is classified as medium armor" - Fallout Fandom wiki.

## How Has This Been Tested?
I would test-merge this considering it's a balance change but given that it's high-class armor that might not be the best to just test it in-game on live rounds.

## Screenshots (if appropriate):
Just a simple variable and description change.

## Changelog (necessary)
:cl:
tweak: You can now move faster in advanced tesla power-armor.
/:cl: