### PR TITLE
i'm not even going to check if this compiles

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1171,12 +1171,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		for(var/obj/item/I in H.held_items)
 			if(I.item_flags & SLOWS_WHILE_IN_HAND)
 				. += I.slowdown
-		var/health_deficiency = (100 - H.health + H.staminaloss)
-		if(health_deficiency >= 40 && !H.has_trait(TRAIT_IGNOREDAMAGESLOWDOWN))
-			if(flight)
-				. += (health_deficiency / 75)
-			else
-				. += (health_deficiency / 40)
+		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
+			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
+			if(health_deficiency >= H.maxHealth * 0.4)
+				if(flight)
+					. += (health_deficiency / 75)
+				else
+					. += (health_deficiency / 25)
 		if(CONFIG_GET(flag/disable_human_mood))
 			var/hungry = (500 - H.nutrition) / 5 //So overeat would be 100 and default level would be 80
 			if((hungry >= 70) && !flight) //Being hungry will still allow you to use a flightsuit/wings.


### PR DESCRIPTION
makes the start of damage slowdown percent based, in theory, so that the lifegiver trait actually does something

specifically, changes damage slowdown from being caused after taking 40 damage to being caused after taking 40% of your maximum health

in practice i don't even know if this shit will work you guys code is fucking ancient

## Motivation and Context
uhhh i felt like it

## How Has This Been Tested?
what the _fuck_ is a test?

## Changelog (necessary)
:cl:
tweak: damage slowdown is % based on your actual health, so the lifegiver trait actually does something
/:cl:
