### PR TITLE
Removes the Matrix from BOS/Vault

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -32345,9 +32345,6 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault)
-"bRb" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/vault)
 "bRc" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
@@ -40661,9 +40658,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"jNm" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood)
 "jSS" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
@@ -120531,7 +120525,7 @@ aae
 bQH
 bQK
 bQR
-bRb
+bRa
 bRm
 bRm
 bRm
@@ -165064,7 +165058,7 @@ bAD
 bAD
 bAD
 bAD
-jNm
+bAD
 bBa
 bBa
 bBa


### PR DESCRIPTION
## Description
Replaced two matrix turfs with two different turfs.

## Motivation and Context
There's no reason these people should be able to walk into a wall and just boof out of existence. If someone wants to bail for the round, they can go chill in their bed or some shit and just snooze off and/or ghost. If they feel they REALLY need to get removed, and admin can teleport them to a matrix or just delete them from existence. The fact they can just head on out into a matrix through a wall is absurd. 

I've already seen Brotherhood straight dipping during raids in the past.

## How Has This Been Tested?
I confirmed that there is in fact no longer a matrix. 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/51188571/106780317-dc38fa00-6615-11eb-8fae-d8fd5615454b.png)
![image](https://user-images.githubusercontent.com/51188571/106780320-de02bd80-6615-11eb-8cb3-33daf3700509.png)

You're welcome. Merge it.