### PR TITLE
Deathsquad Changes

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1,2203 +1,78891 @@
-"aa" = (/turf/open/space/basic,/area/f13/underground/mountain)
-"ab" = (/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"ac" = (/obj/structure/window/reinforced,/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"ad" = (/turf/open/space,/area/f13/underground/mountain)
-"ae" = (/turf/open/space/transit,/area/f13/underground/mountain)
-"af" = (/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"ag" = (/obj/structure/window/reinforced{dir = 4},/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"ah" = (/obj/structure/foamedmetal,/obj/structure/window{dir = 8},/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"ai" = (/obj/structure/foamedmetal,/obj/structure/window{dir = 4},/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"aj" = (/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"ak" = (/obj/structure/table,/obj/item/stack/medical/ointment{heal_burn = 10},/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"al" = (/obj/structure/table/wood{layer = 3.3},/obj/item/twohanded/required/kirbyplants{icon_state = "plant-05"; pixel_y = 4},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"am" = (/obj/structure/closet/crate/bin,/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"an" = (/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"ao" = (/obj/structure/table/wood,/obj/item/flashlight/lamp/green{layer = 3.3},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"ap" = (/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/wildlife)
-"aq" = (/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/offline)
-"ar" = (/turf/open/floor/holofloor/plating/burnmix,/area/holodeck/rec_center/burn)
-"as" = (/turf/open/floor/holofloor{dir = 9; icon_state = "red"},/area/holodeck/rec_center/court)
-"at" = (/turf/open/floor/holofloor{dir = 1; icon_state = "red"},/area/holodeck/rec_center/court)
-"au" = (/turf/open/floor/holofloor{dir = 5; icon_state = "red"},/area/holodeck/rec_center/court)
-"av" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"aw" = (/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"ax" = (/obj/effect/holodeck_effect/mobspawner/penguin,/obj/effect/holodeck_effect/mobspawner/penguin,/obj/item/toy/snowball{pixel_y = 6},/obj/item/toy/snowball{pixel_x = 5},/obj/item/toy/snowball{pixel_x = -4},/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"ay" = (/obj/structure/table,/obj/machinery/recharger,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"az" = (/obj/structure/table/wood,/obj/item/storage/box/matches{pixel_x = -4; pixel_y = 8},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aA" = (/obj/structure/chair/wood/normal,/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aB" = (/obj/effect/holodeck_effect/mobspawner,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/wildlife)
-"aC" = (/obj/effect/holodeck_effect/sparks,/turf/open/floor/holofloor/plating/burnmix,/area/holodeck/rec_center/burn)
-"aD" = (/turf/open/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/rec_center/court)
-"aE" = (/turf/open/floor/holofloor,/area/holodeck/rec_center/court)
-"aF" = (/turf/open/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/rec_center/court)
-"aG" = (/obj/structure/flora/grass/wasteland,/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"aH" = (/obj/structure/table,/obj/item/gun/energy/laser,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"aI" = (/obj/structure/chair/wood/normal{dir = 4},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aJ" = (/obj/structure/table/wood/poker,/obj/item/clothing/mask/cigarette/pipe,/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aK" = (/obj/structure/table/wood/poker,/obj/structure/table/wood/poker,/obj/effect/holodeck_effect/cards,/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aL" = (/obj/structure/chair/wood/normal{dir = 8},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aM" = (/obj/structure/statue/snow/snowman{anchored = 1},/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"aN" = (/obj/structure/chair/wood/normal{dir = 1},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aO" = (/obj/structure/chair/wood/wings,/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"aP" = (/obj/structure/window/reinforced/tinted{dir = 4},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aQ" = (/obj/structure/window/reinforced,/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aR" = (/obj/effect/holodeck_effect/mobspawner/penguin_baby,/obj/structure/flora/tree/pine,/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"aS" = (/obj/structure/chair/wood,/turf/open/floor/holofloor/snow,/area/holodeck/rec_center/winterwonderland)
-"aT" = (/obj/structure/table/wood,/obj/item/twohanded/required/kirbyplants{icon_state = "plant-05"; pixel_y = 10},/turf/open/floor/holofloor{icon_state = "wood"; dir = 9},/area/holodeck/rec_center/lounge)
-"aU" = (/turf/open/floor/holofloor{dir = 9; icon_state = "stairs-l"},/area/holodeck/rec_center/lounge)
-"aV" = (/turf/open/floor/holofloor{dir = 9; icon_state = "stairs-r"},/area/holodeck/rec_center/lounge)
-"aW" = (/turf/open/floor/holofloor{dir = 8; icon_state = "green"},/area/holodeck/rec_center/court)
-"aX" = (/turf/open/floor/holofloor{dir = 4; icon_state = "green"},/area/holodeck/rec_center/court)
-"aY" = (/obj/structure/table/wood,/obj/item/flashlight/lamp/green{pixel_y = 4},/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"aZ" = (/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"ba" = (/obj/structure/chair/comfy/brown{dir = 4},/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"bb" = (/obj/structure/chair/comfy/brown{dir = 8},/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"bc" = (/obj/structure/table,/obj/item/stack/medical/bruise_pack{heal_brute = 10},/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/bunker)
-"bd" = (/obj/structure/table/wood,/obj/item/instrument/violin,/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"be" = (/obj/structure/chair/comfy/brown{buildstackamount = 0; dir = 1},/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"bf" = (/obj/structure/table/wood,/obj/item/book/manual/barman_recipes,/obj/item/clothing/mask/cigarette/pipe,/turf/open/floor/holofloor/carpet,/area/holodeck/rec_center/lounge)
-"bg" = (/turf/open/floor/holofloor{dir = 10; icon_state = "green"},/area/holodeck/rec_center/court)
-"bh" = (/turf/open/floor/holofloor{dir = 2; icon_state = "green"},/area/holodeck/rec_center/court)
-"bi" = (/turf/open/floor/holofloor{dir = 6; icon_state = "green"},/area/holodeck/rec_center/court)
-"bj" = (/obj/structure/window/reinforced{dir = 8},/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"bk" = (/obj/effect/holodeck_effect/mobspawner/bee,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/anthophila)
-"bl" = (/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bm" = (/obj/structure/flora/ausbushes/sunnybush,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bn" = (/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bo" = (/obj/structure/table/glass,/obj/item/surgicaldrill,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bp" = (/obj/structure/table/glass,/obj/item/hemostat,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bq" = (/obj/structure/table/glass,/obj/item/scalpel{pixel_y = 10},/obj/item/circular_saw,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"br" = (/obj/structure/table/glass,/obj/item/retractor,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bs" = (/obj/structure/table/glass,/obj/item/stack/medical/gauze,/obj/item/cautery,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bt" = (/turf/open/floor/holofloor{dir = 9; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"bu" = (/obj/structure/holohoop{layer = 3.9},/turf/open/floor/holofloor{dir = 1; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"bv" = (/turf/open/floor/holofloor{dir = 5; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"bw" = (/turf/open/floor/holofloor/beach,/area/holodeck/rec_center/beach)
-"bx" = (/obj/structure/table,/obj/machinery/readybutton,/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"by" = (/obj/structure/table,/obj/item/clothing/head/helmet/thunderdome,/obj/item/clothing/suit/armor/tdome/red,/obj/item/clothing/under/color/red,/obj/item/holo/esword/red,/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"bz" = (/obj/structure/table,/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"bA" = (/obj/machinery/readybutton,/turf/open/floor/holofloor{dir = 9; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"bB" = (/turf/open/floor/holofloor{dir = 1; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"bC" = (/turf/open/floor/holofloor{dir = 5; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"bD" = (/obj/effect/holodeck_effect/mobspawner/pet,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bE" = (/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bF" = (/obj/effect/holodeck_effect/mobspawner/pet,/obj/structure/flora/ausbushes/brflowers,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bG" = (/obj/structure/table/glass,/obj/item/surgical_drapes,/obj/item/razor,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bH" = (/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bI" = (/turf/open/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"bJ" = (/turf/open/floor/holofloor,/area/holodeck/rec_center/basketball)
-"bK" = (/turf/open/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"bL" = (/obj/effect/overlay/palmtree_r,/turf/open/floor/holofloor/beach,/area/holodeck/rec_center/beach)
-"bM" = (/obj/effect/overlay/palmtree_l,/obj/effect/overlay/coconut,/turf/open/floor/holofloor/beach,/area/holodeck/rec_center/beach)
-"bN" = (/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"bO" = (/turf/open/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"bP" = (/turf/open/floor/holofloor,/area/holodeck/rec_center/dodgeball)
-"bQ" = (/turf/open/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"bR" = (/obj/structure/flora/ausbushes/brflowers,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"bS" = (/obj/item/storage/bag/easterbasket{name = "picnic basket"; pixel_y = 6},/turf/open/floor/holofloor{icon_state = "redbluefull"},/area/holodeck/rec_center/pet_lounge)
-"bT" = (/obj/item/trash/plate,/turf/open/floor/holofloor{icon_state = "redbluefull"},/area/holodeck/rec_center/pet_lounge)
-"bU" = (/obj/structure/table/optable,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bV" = (/obj/machinery/computer/operating{dir = 8},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bW" = (/obj/structure/table/glass,/obj/item/clothing/gloves/color/latex/nitrile,/obj/item/clothing/suit/apron/surgical,/obj/item/clothing/mask/surgical,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"bX" = (/turf/open/floor/holofloor{dir = 1; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"bY" = (/obj/effect/holodeck_effect/mobspawner/monkey,/turf/open/floor/holofloor/beach,/area/holodeck/rec_center/beach)
-"bZ" = (/turf/open/floor/holofloor{dir = 2; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"ca" = (/obj/structure/flora/ausbushes/palebush,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cb" = (/obj/effect/holodeck_effect/mobspawner/pet,/turf/open/floor/holofloor{icon_state = "redbluefull"},/area/holodeck/rec_center/pet_lounge)
-"cc" = (/obj/item/shovel/spade{pixel_x = 2; pixel_y = -2},/turf/open/floor/holofloor{icon_state = "redbluefull"},/area/holodeck/rec_center/pet_lounge)
-"cd" = (/obj/structure/window{dir = 1},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"ce" = (/obj/effect/holodeck_effect/mobspawner/bee,/obj/item/clothing/head/beekeeper_head,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/anthophila)
-"cf" = (/obj/structure/table/glass,/obj/machinery/reagentgrinder,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cg" = (/obj/structure/table/glass,/obj/item/storage/box/syringes{pixel_x = 4; pixel_y = 4},/obj/item/storage/box/beakers,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"ch" = (/obj/machinery/washing_machine,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"ci" = (/turf/open/floor/holofloor{dir = 10; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"cj" = (/turf/open/floor/holofloor{dir = 2; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"ck" = (/turf/open/floor/holofloor{dir = 6; icon_state = "red"},/area/holodeck/rec_center/basketball)
-"cl" = (/obj/item/clothing/under/color/rainbow,/obj/item/clothing/glasses/sunglasses,/turf/open/floor/holofloor/beach,/area/holodeck/rec_center/beach)
-"cm" = (/obj/structure/window,/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"cn" = (/obj/structure/window{dir = 1},/obj/item/toy/beach_ball/holoball/dodgeball,/turf/open/floor/holofloor{dir = 10; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"co" = (/obj/structure/window{dir = 1},/obj/item/toy/beach_ball/holoball/dodgeball,/turf/open/floor/holofloor{dir = 2; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"cp" = (/obj/structure/window{dir = 1},/obj/item/toy/beach_ball/holoball/dodgeball,/turf/open/floor/holofloor{dir = 6; icon_state = "red"},/area/holodeck/rec_center/dodgeball)
-"cq" = (/obj/effect/holodeck_effect/mobspawner/bee,/obj/effect/decal/remains/human,/obj/item/clothing/suit/beekeeper_suit,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/anthophila)
-"cr" = (/obj/effect/holodeck_effect/mobspawner/bee,/obj/item/melee/flyswatter,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/anthophila)
-"cs" = (/obj/machinery/chem_master,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"ct" = (/obj/structure/table/glass,/obj/item/healthanalyzer,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cu" = (/obj/structure/closet/wardrobe/white,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cv" = (/turf/open/floor/holofloor{dir = 9; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"cw" = (/turf/open/floor/holofloor{dir = 1; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"cx" = (/turf/open/floor/holofloor{dir = 5; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"cy" = (/obj/item/toy/beach_ball,/turf/open/floor/holofloor/beach,/area/holodeck/rec_center/beach)
-"cz" = (/obj/structure/window{dir = 1},/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"cA" = (/obj/structure/window,/obj/item/toy/beach_ball/holoball/dodgeball,/turf/open/floor/holofloor{dir = 9; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"cB" = (/obj/structure/window,/obj/item/toy/beach_ball/holoball/dodgeball,/turf/open/floor/holofloor{dir = 1; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"cC" = (/obj/structure/window,/obj/item/toy/beach_ball/holoball/dodgeball,/turf/open/floor/holofloor{dir = 5; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"cD" = (/obj/structure/sink/puddle,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cE" = (/obj/item/reagent_containers/glass/bucket,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cF" = (/turf/open/floor/holofloor{dir = 8; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"cG" = (/obj/item/toy/beach_ball/holoball,/turf/open/floor/holofloor,/area/holodeck/rec_center/basketball)
-"cH" = (/turf/open/floor/holofloor{dir = 4; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"cI" = (/turf/open/floor/holofloor{dir = 8; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"cJ" = (/turf/open/floor/holofloor{dir = 4; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"cK" = (/obj/machinery/hydroponics/soil,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cL" = (/obj/machinery/hydroponics/soil,/obj/item/cultivator,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cM" = (/obj/machinery/hydroponics/soil,/obj/effect/holodeck_effect/mobspawner/pet,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cN" = (/obj/structure/flora/ausbushes/grassybush,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cO" = (/obj/structure/bed,/obj/item/bedsheet/medical,/obj/structure/window{dir = 1},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cP" = (/obj/structure/window{dir = 8},/obj/structure/bed,/obj/item/bedsheet/medical,/obj/structure/window{dir = 1},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cQ" = (/obj/structure/window{dir = 8},/obj/machinery/computer/pandemic,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cR" = (/turf/open/floor/holofloor{dir = 2; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"cS" = (/turf/open/floor/holofloor/beach/coast_t,/area/holodeck/rec_center/beach)
-"cT" = (/obj/item/reagent_containers/glass/bucket,/turf/open/floor/holofloor/beach/coast_t,/area/holodeck/rec_center/beach)
-"cU" = (/obj/item/shovel/spade,/turf/open/floor/holofloor/beach/coast_t,/area/holodeck/rec_center/beach)
-"cV" = (/turf/open/floor/holofloor{dir = 1; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"cW" = (/obj/structure/flora/ausbushes/pointybush,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/pet_lounge)
-"cX" = (/obj/machinery/door/window/westleft,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"cY" = (/turf/open/floor/holofloor/beach/coast_b,/area/holodeck/rec_center/beach)
-"cZ" = (/obj/structure/bed,/obj/item/bedsheet/medical,/obj/machinery/iv_drip,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"da" = (/obj/structure/window{dir = 8},/obj/structure/bed,/obj/item/bedsheet/medical,/obj/machinery/iv_drip,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"db" = (/obj/structure/window{dir = 8},/obj/machinery/sleeper{dir = 1},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"dc" = (/obj/machinery/iv_drip,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"dd" = (/obj/machinery/sleeper{dir = 1},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/medical)
-"de" = (/turf/open/floor/holofloor{dir = 10; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"df" = (/obj/structure/holohoop{dir = 1; layer = 4.1},/turf/open/floor/holofloor{dir = 2; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"dg" = (/turf/open/floor/holofloor{dir = 6; icon_state = "green"},/area/holodeck/rec_center/basketball)
-"dh" = (/turf/open/floor/holofloor/beach/water,/area/holodeck/rec_center/beach)
-"di" = (/obj/structure/table,/obj/item/clothing/head/helmet/thunderdome,/obj/item/clothing/suit/armor/tdome/green,/obj/item/clothing/under/color/green,/obj/item/holo/esword/green,/turf/open/floor/holofloor/basalt,/area/holodeck/rec_center/thunderdome)
-"dj" = (/turf/open/floor/holofloor{dir = 10; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"dk" = (/turf/open/floor/holofloor{dir = 2; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"dl" = (/obj/machinery/readybutton,/turf/open/floor/holofloor{dir = 6; icon_state = "green"},/area/holodeck/rec_center/dodgeball)
-"dm" = (/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/refuel)
-"dn" = (/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/spacechess)
-"do" = (/obj/item/banner/blue,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"dp" = (/obj/structure/table/wood/fancy,/obj/item/clothing/suit/armor/riot/knight/blue,/obj/item/clothing/head/helmet/knight/blue,/obj/item/claymore,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"dq" = (/obj/structure/table/wood/fancy,/obj/item/clothing/head/crown/fancy{pixel_y = 6},/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"dr" = (/obj/structure/table/wood/fancy,/obj/item/clothing/suit/armor/riot/knight/red,/obj/item/clothing/head/helmet/knight/red,/obj/item/claymore,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"ds" = (/obj/item/banner/red,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"dt" = (/turf/open/floor/holofloor/hyperspace,/area/holodeck/rec_center/kobayashi)
-"du" = (/obj/structure/window/reinforced,/turf/open/floor/holofloor/hyperspace,/area/holodeck/rec_center/kobayashi)
-"dv" = (/obj/structure/closet{density = 0},/obj/item/clothing/suit/judgerobe,/obj/item/clothing/head/powdered_wig,/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"dw" = (/obj/structure/table/wood/fancy,/obj/item/clothing/suit/nun,/obj/item/clothing/head/nun_hood,/obj/item/clothing/suit/holidaypriest,/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"dx" = (/obj/structure/table/wood/fancy,/obj/item/storage/book/bible,/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"dy" = (/obj/structure/table/wood/fancy,/obj/item/book/manual/wiki/security_space_law,/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"dz" = (/obj/structure/closet{name = "Evidence Closet"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"dA" = (/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"dB" = (/turf/open/floor/holofloor{dir = 8; icon_state = "green"},/area/holodeck/rec_center/firingrange)
-"dC" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/firingrange)
-"dD" = (/obj/structure/window/reinforced{dir = 1},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/firingrange)
-"dE" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/firingrange)
-"dF" = (/turf/open/floor/holofloor{dir = 4; icon_state = "green"},/area/holodeck/rec_center/firingrange)
-"dG" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/refuel)
-"dH" = (/obj/item/cardboard_cutout/adaptive{color = "#9999BB"; icon_state = "cutout_viva"; name = "Black Rook"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"dI" = (/obj/item/cardboard_cutout/adaptive{color = "#9999BB"; icon_state = "cutout_mime"; name = "Black Queen"},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"dJ" = (/obj/item/cardboard_cutout/adaptive{color = "#9999BB"; icon_state = "cutout_clown"; name = "Black King"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"dK" = (/obj/item/cardboard_cutout/adaptive{color = "#9999BB"; icon_state = "cutout_ian"; name = "Black Knight"},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"dL" = (/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"dM" = (/obj/structure/chair/wood/wings,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"dN" = (/obj/structure/window/reinforced,/obj/machinery/mass_driver{dir = 1; icon_state = "mass_driver"; id = "trektorpedo1"; name = "photon torpedo tube"},/obj/item/toy/minimeteor{color = ""; desc = "A primitive long-range weapon, inferior to Nanotrasen's perfected bluespace artillery."; icon = 'icons/effects/effects.dmi'; icon_state = "impact_laser"; name = "photon torpedo"},/turf/open/floor/holofloor/hyperspace,/area/holodeck/rec_center/kobayashi)
-"dO" = (/obj/structure/window/reinforced{dir = 8},/obj/machinery/computer/arcade/orion_trail{desc = "A test for cadets"; events = list("Raiders" = 3, "Interstellar Flux" = 1, "Illness" = 3, "Breakdown" = 2, "Malfunction" = 2, "Collision" = 1, "Spaceport" = 2); icon = 'icons/obj/machines/particle_accelerator.dmi'; icon_state = "control_boxp"; name = "Kobayashi Maru control computer"; prizes = list(/obj/item/paper/fluff/holodeck/trek_diploma = 1); settlers = list("Kirk","Worf","Gene")},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"dP" = (/obj/machinery/button/massdriver{id = "trektorpedo1"; layer = 3.9; name = "photon torpedo button"; pixel_x = -16; pixel_y = -5},/obj/machinery/button/massdriver{id = "trektorpedo2"; layer = 3.9; name = "photon torpedo button"; pixel_x = 16; pixel_y = -5},/obj/machinery/computer/arcade/orion_trail{desc = "A test for cadets"; events = list("Raiders" = 3, "Interstellar Flux" = 1, "Illness" = 3, "Breakdown" = 2, "Malfunction" = 2, "Collision" = 1, "Spaceport" = 2); icon = 'icons/obj/machines/particle_accelerator.dmi'; icon_state = "control_boxp"; name = "Kobayashi Maru control computer"; prizes = list(/obj/item/paper/fluff/holodeck/trek_diploma = 1); settlers = list("Kirk","Worf","Gene")},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"dQ" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/computer/arcade/orion_trail{desc = "A test for cadets"; events = list("Raiders" = 3, "Interstellar Flux" = 1, "Illness" = 3, "Breakdown" = 2, "Malfunction" = 2, "Collision" = 1, "Spaceport" = 2); icon = 'icons/obj/machines/particle_accelerator.dmi'; icon_state = "control_boxp"; name = "Kobayashi Maru control computer"; prizes = list(/obj/item/paper/fluff/holodeck/trek_diploma = 1); settlers = list("Kirk","Worf","Gene")},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"dR" = (/obj/structure/window/reinforced,/obj/machinery/mass_driver{dir = 1; icon_state = "mass_driver"; id = "trektorpedo2"; name = "photon torpedo tube"},/obj/item/toy/minimeteor{color = ""; desc = "A primitive long-range weapon, inferior to Nanotrasen's perfected bluespace artillery."; icon = 'icons/effects/effects.dmi'; icon_state = "impact_laser"; name = "photon torpedo"},/turf/open/floor/holofloor/hyperspace,/area/holodeck/rec_center/kobayashi)
-"dS" = (/obj/structure/chair{dir = 4},/turf/open/floor/holofloor{icon_state = "chapel"; dir = 1},/area/holodeck/rec_center/chapelcourt)
-"dT" = (/turf/open/floor/holofloor{icon_state = "chapel"; dir = 4},/area/holodeck/rec_center/chapelcourt)
-"dU" = (/obj/structure/chair,/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"dV" = (/turf/open/floor/holofloor{icon_state = "chapel"; dir = 1},/area/holodeck/rec_center/chapelcourt)
-"dW" = (/obj/structure/chair{dir = 8},/turf/open/floor/holofloor{icon_state = "chapel"; dir = 4},/area/holodeck/rec_center/chapelcourt)
-"dX" = (/obj/structure/table/wood,/obj/item/folder,/obj/item/melee/classic_baton/telescopic,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"dY" = (/obj/structure/table/wood,/obj/item/toy/crayon/white,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"dZ" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/snacks/grown/apple,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"ea" = (/obj/structure/window/reinforced{dir = 8},/turf/open/floor/holofloor{icon_state = "white"; dir = 8},/area/holodeck/rec_center/firingrange)
-"eb" = (/obj/structure/target_stake,/obj/machinery/magnetic_module,/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/firingrange)
-"ec" = (/obj/structure/window/reinforced{dir = 4},/turf/open/floor/holofloor{icon_state = "white"; dir = 4},/area/holodeck/rec_center/firingrange)
-"ed" = (/obj/item/cardboard_cutout/adaptive{color = "#9999BB"; icon_state = "cutout_greytide"; name = "Black Pawn"},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"ee" = (/obj/item/cardboard_cutout/adaptive{color = "#9999BB"; icon_state = "cutout_greytide"; name = "Black Pawn"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"ef" = (/obj/machinery/door/window/westleft{dir = 2; icon_state = "right"},/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"eg" = (/obj/structure/window/reinforced,/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"eh" = (/obj/machinery/door/window/westleft{dir = 2},/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"ei" = (/obj/structure/table/glass,/obj/machinery/recharger,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"ej" = (/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"ek" = (/obj/structure/chair/comfy{dir = 1},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"el" = (/obj/structure/table/glass,/obj/item/gun/energy/e_gun/mini/practice_phaser,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"em" = (/obj/structure/chair{dir = 4},/turf/open/floor/holofloor{dir = 8; icon_state = "chapel"},/area/holodeck/rec_center/chapelcourt)
-"en" = (/turf/open/floor/holofloor{icon_state = "chapel"; dir = 2},/area/holodeck/rec_center/chapelcourt)
-"eo" = (/obj/item/gavelblock,/obj/item/gavelhammer,/obj/structure/table/wood,/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"ep" = (/turf/open/floor/holofloor{dir = 8; icon_state = "chapel"},/area/holodeck/rec_center/chapelcourt)
-"eq" = (/obj/structure/chair{dir = 8},/turf/open/floor/holofloor{icon_state = "chapel"; dir = 2},/area/holodeck/rec_center/chapelcourt)
-"er" = (/obj/structure/window/reinforced{dir = 8},/turf/open/floor/holofloor{icon_state = "white"; dir = 10},/area/holodeck/rec_center/firingrange)
-"es" = (/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/firingrange)
-"et" = (/obj/structure/window/reinforced{dir = 4},/turf/open/floor/holofloor{icon_state = "white"; dir = 6},/area/holodeck/rec_center/firingrange)
-"eu" = (/obj/item/weldingtool,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/refuel)
-"ev" = (/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"ew" = (/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"ex" = (/turf/open/floor/holofloor{icon_state = "stairs-old"; dir = 8},/area/holodeck/rec_center/thunderdome1218)
-"ey" = (/obj/structure/table/wood,/obj/item/melee/chainofcommand{name = "chain whip"},/obj/item/twohanded/spear,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/thunderdome1218)
-"ez" = (/obj/structure/table/wood,/obj/item/scythe,/obj/item/twohanded/spear,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/thunderdome1218)
-"eA" = (/obj/structure/table/wood,/obj/item/tailclub,/obj/item/twohanded/spear,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/thunderdome1218)
-"eB" = (/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/chapelcourt)
-"eC" = (/obj/structure/table,/obj/item/paper,/obj/item/pen,/obj/item/clothing/under/schoolgirl,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"eD" = (/obj/structure/table,/obj/item/paper,/obj/item/pen,/obj/item/clothing/under/schoolgirl/green,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"eE" = (/obj/structure/window/reinforced{dir = 8},/turf/open/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/rec_center/firingrange)
-"eF" = (/turf/open/floor/holofloor,/area/holodeck/rec_center/firingrange)
-"eG" = (/obj/structure/window/reinforced{dir = 4},/turf/open/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/rec_center/firingrange)
-"eH" = (/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/thunderdome1218)
-"eI" = (/obj/machinery/modular_computer/console/preset/civilian{dir = 4},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eJ" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eK" = (/obj/structure/chair/office/dark{dir = 4},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eL" = (/obj/machinery/computer/station_alert{dir = 8},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eM" = (/obj/structure/chair{dir = 1},/turf/open/floor/holofloor{icon_state = "chapel"; dir = 1},/area/holodeck/rec_center/chapelcourt)
-"eN" = (/obj/structure/chair{dir = 1},/turf/open/floor/holofloor{icon_state = "chapel"; dir = 4},/area/holodeck/rec_center/chapelcourt)
-"eO" = (/obj/structure/chair{dir = 1},/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"eP" = (/obj/machinery/modular_computer/console/preset/civilian{dir = 4},/obj/structure/window/reinforced,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eQ" = (/obj/machinery/computer/atmos_alert{dir = 8},/obj/structure/window/reinforced,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eR" = (/obj/structure/chair{dir = 1},/turf/open/floor/holofloor{dir = 8; icon_state = "chapel"},/area/holodeck/rec_center/chapelcourt)
-"eS" = (/obj/structure/chair{dir = 1},/turf/open/floor/holofloor{icon_state = "chapel"; dir = 2},/area/holodeck/rec_center/chapelcourt)
-"eT" = (/obj/structure/table,/obj/item/paper,/obj/item/pen,/obj/item/clothing/under/schoolgirl/orange,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"eU" = (/obj/structure/table,/obj/item/paper,/obj/item/pen,/obj/item/clothing/under/schoolgirl/red,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"eV" = (/obj/structure/window/reinforced,/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"eW" = (/obj/item/cardboard_cutout/adaptive{icon_state = "cutout_greytide"; name = "White Pawn"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"eX" = (/obj/item/cardboard_cutout/adaptive{icon_state = "cutout_greytide"; name = "White Pawn"},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"eY" = (/obj/structure/window/reinforced,/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/thunderdome1218)
-"eZ" = (/obj/machinery/door/window/westleft{dir = 2},/turf/open/floor/holofloor/asteroid,/area/holodeck/rec_center/thunderdome1218)
-"fa" = (/obj/machinery/door/window/westleft{dir = 2; icon_state = "right"},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"fb" = (/obj/structure/table,/obj/item/folder,/obj/item/pen/blue,/obj/structure/window/reinforced{dir = 8},/turf/open/floor/holofloor{icon_state = "neutral"; dir = 1},/area/holodeck/rec_center/kobayashi)
-"fc" = (/obj/structure/table,/obj/item/folder,/obj/item/pen,/turf/open/floor/holofloor{icon_state = "neutral"; dir = 1},/area/holodeck/rec_center/kobayashi)
-"fd" = (/obj/structure/table,/obj/structure/window/reinforced{dir = 4},/obj/item/folder,/obj/item/pen/red,/turf/open/floor/holofloor{icon_state = "neutral"; dir = 1},/area/holodeck/rec_center/kobayashi)
-"fe" = (/obj/machinery/door/window/westleft{dir = 2},/turf/open/floor/holofloor/plating,/area/holodeck/rec_center/kobayashi)
-"ff" = (/obj/structure/table,/obj/item/paper,/obj/item/pen,/obj/item/clothing/under/schoolgirl,/obj/item/toy/katana,/turf/open/floor/holofloor,/area/holodeck/rec_center/school)
-"fg" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/open/floor/holofloor{dir = 8; icon_state = "red"},/area/holodeck/rec_center/firingrange)
-"fh" = (/obj/item/paper/guides/jobs/security/range,/turf/open/floor/holofloor,/area/holodeck/rec_center/firingrange)
-"fi" = (/obj/structure/table/reinforced,/obj/machinery/magnetic_controller{autolink = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/open/floor/holofloor{dir = 4; icon_state = "red"},/area/holodeck/rec_center/firingrange)
-"fj" = (/obj/item/cardboard_cutout/adaptive{icon_state = "cutout_viva"; name = "White Rook"},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"fk" = (/obj/item/cardboard_cutout/adaptive{icon_state = "cutout_mime"; name = "White Queen"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"fl" = (/obj/item/cardboard_cutout/adaptive{icon_state = "cutout_clown"; name = "White King"},/turf/open/floor/holofloor{icon_state = "white"},/area/holodeck/rec_center/spacechess)
-"fm" = (/obj/item/cardboard_cutout/adaptive{icon_state = "cutout_ian"; name = "White Knight"},/turf/open/floor/holofloor{dir = 8; icon_state = "dark"},/area/holodeck/rec_center/spacechess)
-"fn" = (/turf/open/floor/holofloor{icon_state = "neutral"; dir = 1},/area/holodeck/rec_center/kobayashi)
-"fo" = (/obj/structure/chair{dir = 1},/turf/open/floor/holofloor,/area/holodeck/rec_center/kobayashi)
-"fp" = (/turf/open/floor/holofloor{dir = 1; icon_state = "green"},/area/holodeck/rec_center/firingrange)
-"fq" = (/obj/structure/chair/wood/normal{dir = 1},/turf/open/floor/holofloor/grass,/area/holodeck/rec_center/thunderdome1218)
-"fr" = (/obj/structure/rack,/obj/item/clothing/under/trek/medsci,/obj/item/clothing/under/trek/medsci,/obj/item/clothing/under/trek/command,/turf/open/floor/holofloor{icon_state = "neutral"; dir = 1},/area/holodeck/rec_center/kobayashi)
-"fs" = (/turf/open/floor/holofloor{icon_state = "neutral"; dir = 2},/area/holodeck/rec_center/kobayashi)
-"ft" = (/obj/structure/rack,/obj/item/clothing/under/trek/engsec,/obj/item/clothing/under/trek/engsec,/turf/open/floor/holofloor{icon_state = "neutral"; dir = 1},/area/holodeck/rec_center/kobayashi)
-"fu" = (/obj/item/target,/obj/item/target/clown,/turf/open/floor/holofloor,/area/holodeck/rec_center/firingrange)
-"fv" = (/obj/item/target,/obj/item/target/syndicate,/turf/open/floor/holofloor,/area/holodeck/rec_center/firingrange)
-"fw" = (/obj/structure/rack,/obj/item/gun/energy/laser/practice,/obj/item/clothing/ears/earmuffs,/turf/open/floor/holofloor,/area/holodeck/rec_center/firingrange)
-"fx" = (/obj/docking_port/stationary{dir = 1; dwidth = 1; height = 4; id = "pod4_away"; name = "recovery ship"; width = 3},/turf/open/space,/area/f13/underground/mountain)
-"fy" = (/obj/machinery/igniter/on,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fz" = (/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fA" = (/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fB" = (/obj/structure/rack,/obj/item/clothing/under/color/red,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/tdome/red,/obj/item/clothing/head/helmet/thunderdome,/obj/item/melee/baton/loaded,/obj/item/melee/transforming/energy/sword/saber/red,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fC" = (/obj/machinery/door/poddoor{id = "thunderdomegen"; name = "General Supply"},/turf/open/floor/plasteel/dark,/area/tdome/arena_source)
-"fD" = (/obj/machinery/door/poddoor{id = "thunderdome"; name = "Thunderdome Blast Door"},/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fE" = (/turf/open/floor/plasteel/red/side{dir = 8},/area/tdome/arena_source)
-"fF" = (/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fG" = (/turf/open/floor/plasteel/neutral/side{dir = 4},/area/tdome/arena_source)
-"fH" = (/turf/open/floor/plasteel/neutral,/area/tdome/arena_source)
-"fI" = (/turf/open/floor/plasteel/neutral/side{dir = 8},/area/tdome/arena_source)
-"fJ" = (/turf/open/floor/plasteel/green/side{dir = 4},/area/tdome/arena_source)
-"fK" = (/obj/structure/rack,/obj/item/clothing/under/color/green,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/tdome/green,/obj/item/clothing/head/helmet/thunderdome,/obj/item/melee/baton/loaded,/obj/item/melee/transforming/energy/sword/saber/green,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fL" = (/turf/open/floor/plasteel/red/corner{dir = 1},/area/tdome/arena_source)
-"fM" = (/turf/open/floor/plasteel/green/corner{dir = 4},/area/tdome/arena_source)
-"fN" = (/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fO" = (/turf/open/floor/circuit/green,/area/tdome/arena_source)
-"fP" = (/obj/machinery/flasher{id = "tdomeflash"; name = "Thunderdome Flash"},/turf/open/floor/circuit/green,/area/tdome/arena_source)
-"fQ" = (/obj/effect/turf_decal/loading_area{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fR" = (/turf/open/floor/plasteel/blue/corner,/area/centcom/evac)
-"fS" = (/turf/open/floor/plasteel/red/corner{dir = 8},/area/tdome/arena_source)
-"fT" = (/turf/open/floor/plasteel/green/corner,/area/tdome/arena_source)
-"fU" = (/obj/machinery/door/poddoor{id = "thunderdomehea"; name = "Heavy Supply"},/turf/open/floor/plasteel/dark,/area/tdome/arena_source)
-"fV" = (/obj/structure/rack,/obj/item/clothing/under/color/red,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/vest,/obj/item/clothing/head/helmet/swat,/obj/item/gun/energy/laser,/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fW" = (/obj/structure/rack,/obj/item/clothing/under/color/green,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/vest,/obj/item/clothing/head/helmet/swat,/obj/item/gun/energy/laser,/turf/open/floor/plasteel,/area/tdome/arena_source)
-"fX" = (/turf/closed/indestructible/riveted,/area/start)
-"fY" = (/obj/effect/landmark/start/new_player,/turf/open/floor/plating,/area/start)
-"fZ" = (/turf/closed/indestructible/riveted,/area/ctf)
-"ga" = (/turf/open/floor/plasteel/darkblue/side{dir = 9},/area/ctf)
-"gb" = (/turf/open/floor/plasteel/darkblue/side{dir = 1},/area/ctf)
-"gc" = (/turf/open/floor/plasteel/darkblue/side{dir = 5},/area/ctf)
-"gd" = (/turf/open/floor/plasteel/darkred/side{dir = 9},/area/ctf)
-"ge" = (/turf/open/floor/plasteel/darkred/side{dir = 1},/area/ctf)
-"gf" = (/turf/open/floor/plasteel/darkred/side{dir = 5},/area/ctf)
-"gg" = (/turf/open/floor/plasteel/darkblue/side{dir = 8},/area/ctf)
-"gh" = (/turf/open/floor/plasteel/dark,/area/ctf)
-"gi" = (/turf/open/floor/plasteel/darkblue/side{dir = 4},/area/ctf)
-"gj" = (/turf/open/floor/plasteel/blue,/area/ctf)
-"gk" = (/turf/open/floor/plasteel/darkblue,/area/ctf)
-"gl" = (/obj/structure/barricade/security/ctf,/turf/open/floor/circuit,/area/ctf)
-"gm" = (/obj/structure/table/reinforced,/turf/open/floor/plasteel/bluespace,/area/ctf)
-"gn" = (/obj/structure/barricade/security/ctf,/turf/open/floor/plasteel/bluespace,/area/ctf)
-"go" = (/turf/open/floor/plasteel/bluespace,/area/ctf)
-"gp" = (/turf/open/floor/plasteel/darkred/side{dir = 8},/area/ctf)
-"gq" = (/obj/structure/barricade/security/ctf,/turf/open/floor/circuit/red,/area/ctf)
-"gr" = (/turf/open/floor/plasteel/darkred/side{dir = 4},/area/ctf)
-"gs" = (/turf/open/floor/plasteel/red,/area/ctf)
-"gt" = (/obj/structure/kitchenspike,/turf/open/floor/plasteel/dark,/area/ctf)
-"gu" = (/turf/closed/indestructible/splashscreen,/area/start)
-"gv" = (/turf/open/floor/plasteel/darkblue/side{dir = 10},/area/ctf)
-"gw" = (/turf/open/floor/plasteel/darkblue/side,/area/ctf)
-"gx" = (/turf/open/floor/plasteel/darkblue/side{dir = 6},/area/ctf)
-"gy" = (/turf/open/floor/plasteel/darkred/side{dir = 10},/area/ctf)
-"gz" = (/turf/open/floor/plasteel/darkred/side,/area/ctf)
-"gA" = (/turf/open/floor/plasteel/darkred/side{dir = 6},/area/ctf)
-"gB" = (/obj/structure/window/reinforced/fulltile{obj_integrity = 5000; max_integrity = 5000; name = "hardened window"},/turf/open/floor/plating,/area/ctf)
-"gC" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/ctf)
-"gD" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel/darkblue/corner,/area/ctf)
-"gE" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/dark,/area/ctf)
-"gF" = (/obj/machinery/light,/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"gG" = (/obj/structure/closet/syndicate/personal,/turf/open/floor/plasteel/dark,/area/syndicate_mothership/control)
-"gH" = (/obj/structure/table,/obj/item/gun/energy/ionrifle{pin = /obj/item/firing_pin},/turf/open/floor/plasteel/dark,/area/syndicate_mothership/control)
-"gI" = (/obj/machinery/power/emitter/energycannon,/turf/open/floor/plating,/area/ctf)
-"gJ" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/ctf)
-"gK" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/darkblue/corner{dir = 4},/area/ctf)
-"gL" = (/turf/open/floor/plasteel/darkblue/corner{dir = 8},/area/ctf)
-"gM" = (/turf/open/floor/plasteel/darkblue/corner{dir = 4},/area/ctf)
-"gN" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plating,/area/ctf)
-"gO" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/dark,/area/ctf)
-"gP" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plating,/area/ctf)
-"gQ" = (/turf/open/floor/plating,/area/ctf)
-"gR" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plating{luminosity = 2},/area/ctf)
-"gS" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/darkblue/corner,/area/ctf)
-"gT" = (/turf/open/floor/plasteel/darkblue/corner{dir = 1},/area/ctf)
-"gU" = (/turf/open/floor/plasteel/darkblue/corner,/area/ctf)
-"gV" = (/turf/closed/indestructible/fakedoor{name = "CentCom Warehouse"},/area/f13/underground/mountain)
-"gW" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/darkblue/corner{dir = 4},/area/ctf)
-"gX" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkblue/corner{dir = 1},/area/ctf)
-"gY" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkblue/corner{dir = 4},/area/ctf)
-"gZ" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/ctf)
-"ha" = (/obj/machinery/power/emitter/energycannon{dir = 1},/turf/open/floor/plating,/area/ctf)
-"hb" = (/obj/structure/trap/ctf/blue,/turf/open/floor/plasteel/blue,/area/ctf)
-"hc" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/circuit,/area/ctf)
-"hd" = (/obj/structure/sign/nanotrasen,/turf/closed/indestructible/riveted,/area/centcom/evac)
-"he" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/circuit,/area/ctf)
-"hf" = (/turf/open/floor/plasteel/darkred,/area/ctf)
-"hg" = (/obj/structure/trap/ctf/red,/turf/open/floor/plasteel/darkred,/area/ctf)
-"hh" = (/turf/closed/indestructible/rock/snow,/area/syndicate_mothership)
-"hi" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/circuit,/area/ctf)
-"hj" = (/turf/open/floor/circuit,/area/ctf)
-"hk" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/circuit,/area/ctf)
-"hl" = (/obj/docking_port/stationary{area_type = /area/syndicate_mothership; dir = 1; dwidth = 25; height = 50; id = "emergency_syndicate"; name = "Syndicate Auxillary Shuttle Dock"; width = 50},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"hm" = (/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/circuit,/area/ctf)
-"hn" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/circuit,/area/ctf)
-"ho" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/circuit,/area/ctf)
-"hp" = (/obj/structure/barricade/security/ctf,/turf/open/floor/circuit/green/off,/area/ctf)
-"hq" = (/obj/structure/trap/ctf/red,/turf/open/floor/plasteel/red,/area/ctf)
-"hr" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel/darkblue/side{dir = 9},/area/ctf)
-"hs" = (/obj/effect/landmark/prisonwarp,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ht" = (/turf/closed/indestructible/fakeglass,/area/centcom/evac)
-"hu" = (/obj/structure/table/reinforced,/obj/item/paper_bin,/obj/item/pen,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"hv" = (/obj/structure/table/reinforced,/obj/item/crowbar/red,/obj/item/tank/internals/emergency_oxygen/engi,/obj/item/clothing/mask/gas,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"hw" = (/obj/structure/table/reinforced,/obj/item/restraints/handcuffs/cable/zipties,/obj/item/assembly/flash/handheld,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"hx" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/darkred/side{dir = 5},/area/ctf)
-"hy" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/darkblue/side{dir = 8},/area/ctf)
-"hz" = (/turf/open/floor/circuit/green/off,/area/ctf)
-"hA" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/darkred/side{dir = 4},/area/ctf)
-"hB" = (/turf/open/floor/circuit/red,/area/ctf)
-"hC" = (/turf/open/floor/circuit/green/anim,/area/ctf)
-"hD" = (/obj/machinery/capture_the_flag/blue,/turf/open/floor/circuit/green/anim,/area/ctf)
-"hE" = (/obj/item/twohanded/ctf/blue,/turf/open/floor/circuit/green/anim,/area/ctf)
-"hF" = (/obj/item/twohanded/ctf/red,/turf/open/floor/circuit/green/anim,/area/ctf)
-"hG" = (/obj/machinery/capture_the_flag/red,/turf/open/floor/circuit/green/anim,/area/ctf)
-"hH" = (/turf/closed/indestructible/rock,/area/f13/brotherhood)
-"hI" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/darkblue/side{dir = 10},/area/ctf)
-"hJ" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkblue/side,/area/ctf)
-"hK" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkblue/side{dir = 6},/area/ctf)
-"hL" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/circuit/green/off,/area/ctf)
-"hM" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/side{dir = 10},/area/ctf)
-"hN" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/side,/area/ctf)
-"hO" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/darkred/side{dir = 6},/area/ctf)
-"hP" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/circuit/red,/area/ctf)
-"hQ" = (/obj/structure/table/reinforced,/obj/item/storage/fancy/donut_box,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"hR" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/circuit/red,/area/ctf)
-"hS" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/circuit/red,/area/ctf)
-"hT" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/circuit/red,/area/ctf)
-"hU" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/circuit/red,/area/ctf)
-"hV" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/circuit/red,/area/ctf)
-"hW" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/circuit/red,/area/ctf)
-"hX" = (/turf/closed/indestructible/fakedoor{name = "CentCom Cell"},/area/centcom/evac)
-"hY" = (/obj/structure/sign/warning/securearea,/turf/closed/indestructible/riveted,/area/centcom/evac)
-"hZ" = (/obj/effect/turf_decal/stripes/line{dir = 9},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"ia" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/darkred/corner{dir = 8},/area/ctf)
-"ib" = (/turf/open/floor/plasteel/darkred/corner,/area/ctf)
-"ic" = (/turf/open/floor/plasteel/darkred/corner{dir = 1},/area/ctf)
-"id" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/darkred/corner{dir = 1},/area/ctf)
-"ie" = (/turf/open/floor/plasteel/darkred/corner{dir = 4},/area/ctf)
-"if" = (/turf/open/floor/plasteel/darkred/corner{dir = 8},/area/ctf)
-"ig" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/darkred/corner{dir = 8},/area/ctf)
-"ih" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/dark,/area/ctf)
-"ii" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/corner{dir = 4},/area/ctf)
-"ij" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/corner{dir = 1},/area/ctf)
-"ik" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/darkred/corner{dir = 1},/area/ctf)
-"il" = (/obj/effect/turf_decal/stripes/line{dir = 5},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"im" = (/obj/structure/reagent_dispensers/peppertank{pixel_x = -32},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"in" = (/obj/structure/extinguisher_cabinet{dir = 4; pixel_x = 24},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"io" = (/obj/machinery/airalarm{dir = 4; pixel_x = -23},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"ip" = (/obj/structure/noticeboard{dir = 8; pixel_x = 32},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"iq" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"ir" = (/obj/machinery/newscaster/security_unit{pixel_x = -32},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"is" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"it" = (/obj/structure/barricade/security,/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"iu" = (/obj/structure/barricade/bars,/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"iv" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"iw" = (/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"ix" = (/turf/closed/wall/f13/vault,/area/tdome/tdomeobserve)
-"iy" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-05"; pixel_y = 10},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"iz" = (/obj/structure/table/reinforced,/obj/item/reagent_containers/food/drinks/trophy/gold_cup,/obj/structure/sign/plaques/golden{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"iA" = (/obj/structure/table/reinforced,/obj/item/reagent_containers/food/drinks/trophy/gold_cup,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"iB" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"; pixel_x = -3; pixel_y = 3},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"iC" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"iD" = (/obj/structure/barricade/sandbags,/turf/open/floor/plasteel,/area/centcom/evac)
-"iE" = (/turf/open/floor/plasteel,/area/tdome/tdomeobserve)
-"iF" = (/obj/machinery/status_display{name = "cargo display"; supply_display = 1},/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"iG" = (/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"iH" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"iI" = (/obj/machinery/manned_turret/ultimate,/turf/open/floor/plasteel,/area/centcom/evac)
-"iJ" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"iK" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/tdome/tdomeobserve)
-"iL" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/tdome/tdomeobserve)
-"iM" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/tdome/tdomeobserve)
-"iN" = (/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"iO" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/brown{dir = 1},/area/f13/underground/mountain)
-"iP" = (/turf/open/floor/plasteel/brown{dir = 1},/area/f13/underground/mountain)
-"iQ" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/open/floor/plasteel/brown{dir = 5},/area/f13/underground/mountain)
-"iR" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/f13/underground/mountain)
-"iS" = (/turf/open/floor/plasteel/neutral,/area/f13/underground/mountain)
-"iT" = (/turf/closed/indestructible/fakedoor{name = "Thunderdome Admin"},/area/centcom/evac)
-"iU" = (/obj/machinery/status_display,/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/centcom/evac)
-"iV" = (/obj/machinery/computer/prisoner,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"iW" = (/obj/machinery/computer/security,/obj/effect/turf_decal/stripes/line,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/centcom/evac)
-"iX" = (/turf/open/floor/plasteel/brown{dir = 4},/area/f13/underground/mountain)
-"iY" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/sign/warning/vacuum/external,/turf/open/floor/plating,/area/f13/underground/mountain)
-"iZ" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/conveyor{dir = 1; id = "XCCQMLoad2"},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"ja" = (/obj/effect/turf_decal/stripes/line,/obj/machinery/light{dir = 1},/obj/machinery/computer/security,/turf/open/floor/plasteel,/area/centcom/evac)
-"jb" = (/obj/machinery/conveyor_switch/oneway{id = "XCCQMLoad2"; pixel_x = 6},/turf/open/floor/plasteel/brown{dir = 8},/area/f13/underground/mountain)
-"jc" = (/turf/open/floor/plasteel/yellowsiding{dir = 1},/area/f13/underground/mountain)
-"jd" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/brown{dir = 4},/area/f13/underground/mountain)
-"je" = (/obj/machinery/door/poddoor{density = 1; id = "XCCQMLoaddoor2"; name = "Supply Dock Loading Door"},/obj/effect/turf_decal/stripes/end{dir = 8},/obj/machinery/conveyor{dir = 4; id = "XCCQMLoad2"},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jf" = (/obj/structure/plasticflaps,/obj/effect/turf_decal/stripes/line{dir = 2},/obj/machinery/conveyor{dir = 4; id = "XCCQMLoad2"},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jg" = (/obj/machinery/computer/secure_data,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"jh" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/centcom{name = "CentCom"; opacity = 1},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"ji" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/obj/structure/window/reinforced{dir = 1},/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"jj" = (/obj/structure/filingcabinet/medical,/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/centcom/evac)
-"jk" = (/obj/machinery/door/poddoor{density = 1; id = "XCCQMLoaddoor2"; name = "Supply Dock Loading Door"},/obj/effect/turf_decal/stripes/line{dir = 2},/obj/machinery/conveyor{dir = 4; id = "XCCQMLoad2"},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jl" = (/obj/effect/turf_decal/stripes/end,/obj/machinery/conveyor/inverted{dir = 10; id = "XCCQMLoad2"},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jm" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jn" = (/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jo" = (/obj/item/stack/packageWrap,/obj/item/hand_labeler,/obj/structure/table,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jp" = (/obj/machinery/door/airlock/external{name = "Supply Shuttle"; req_access_txt = "106"},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jq" = (/obj/structure/fans/tiny,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jr" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"js" = (/obj/effect/decal/cleanable/dirt,/obj/structure/filingcabinet/filingcabinet,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jt" = (/obj/machinery/button/door{id = "XCCQMLoaddoor"; layer = 4; name = "Loading Doors"; pixel_x = -27; pixel_y = -5},/obj/machinery/button/door{dir = 2; id = "XCCQMLoaddoor2"; layer = 4; name = "Loading Doors"; pixel_x = -27; pixel_y = 5},/obj/machinery/computer/cargo{dir = 4},/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"ju" = (/obj/effect/turf_decal/loading_area{dir = 8},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jv" = (/obj/structure/filingcabinet/security,/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel,/area/centcom/evac)
-"jw" = (/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"jx" = (/obj/structure/flora/tree/palm,/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"jy" = (/obj/machinery/status_display,/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"jz" = (/obj/structure/flora/tree/jungle/small,/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"jA" = (/obj/structure/table/reinforced,/obj/item/storage/box/handcuffs,/obj/item/crowbar/red,/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"jB" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"jC" = (/obj/docking_port/stationary{dir = 1; dwidth = 1; height = 4; id = "pod3_away"; name = "recovery ship"; width = 3},/turf/open/space,/area/f13/underground/mountain)
-"jD" = (/obj/machinery/door/poddoor{density = 1; id = "XCCQMLoaddoor"; name = "Supply Dock Loading Door"},/obj/machinery/conveyor{dir = 8; id = "XCCQMLoad"},/obj/effect/turf_decal/stripes/end{dir = 8},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jE" = (/obj/structure/plasticflaps,/obj/machinery/conveyor{dir = 8; id = "XCCQMLoad"},/obj/effect/turf_decal/stripes/line{dir = 2},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jF" = (/obj/structure/flora/tree/joshua,/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"jG" = (/obj/structure/table/reinforced,/obj/item/wrench,/obj/item/restraints/handcuffs,/obj/item/assembly/flash/handheld,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"jH" = (/obj/structure/table/reinforced,/obj/item/gun/ballistic/automatic/wt550,/obj/item/flashlight/seclite,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"jI" = (/obj/machinery/door/poddoor{density = 1; id = "XCCQMLoaddoor"; name = "Supply Dock Loading Door"},/obj/machinery/conveyor{dir = 8; id = "XCCQMLoad"},/obj/effect/turf_decal/stripes/line{dir = 2},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jJ" = (/obj/effect/turf_decal/stripes/end{dir = 1},/obj/machinery/conveyor/inverted{dir = 6; id = "XCCQMLoad2"},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jK" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jL" = (/obj/structure/closet/wardrobe/cargotech,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jM" = (/obj/machinery/conveyor_switch/oneway{dir = 8; id = "XCCQMLoad"; pixel_x = 6},/turf/open/floor/plasteel/brown{dir = 8},/area/f13/underground/mountain)
-"jN" = (/obj/structure/closet/secure_closet/quartermaster,/obj/machinery/airalarm{dir = 8; pixel_x = 24},/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"jO" = (/turf/closed/mineral/random/low_chance,/area/f13/brotherhood)
-"jP" = (/turf/open/floor/plasteel/brown{dir = 8},/area/f13/underground/mountain)
-"jQ" = (/turf/open/floor/plasteel/yellowsiding,/area/f13/underground/mountain)
-"jR" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/obj/machinery/light,/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"jS" = (/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/folder/red,/obj/item/pen/red,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"jT" = (/obj/structure/table/reinforced,/obj/item/storage/box/handcuffs,/obj/item/crowbar/red,/obj/item/crowbar/power,/obj/item/storage/belt/security/full,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"jU" = (/turf/closed/wall/f13/vault,/area/centcom/evac)
-"jV" = (/turf/open/floor/plasteel/stairs/left,/area/centcom/evac)
-"jW" = (/turf/open/floor/plasteel/stairs/right,/area/centcom/evac)
-"jX" = (/obj/effect/landmark/thunderdome/two,/obj/machinery/camera{c_tag = "Arena"; light_power = 25; light_range = 25; name = "thunderdome 1"; network = list("thunder"); pixel_x = 10; resistance_flags = 64},/turf/open/floor/plasteel,/area/tdome/arena)
-"jY" = (/obj/effect/landmark/thunderdome/one,/obj/machinery/camera{c_tag = "Arena"; light_power = 25; light_range = 25; name = "Thunderdome 2"; network = list("thunder"); pixel_x = 10; resistance_flags = 64},/turf/open/floor/plasteel,/area/tdome/arena)
-"jZ" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/obj/structure/window/reinforced{dir = 4},/turf/open/floor/grass,/area/centcom/evac)
-"ka" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/obj/structure/window/reinforced{dir = 8},/turf/open/floor/grass,/area/centcom/evac)
-"kb" = (/obj/machinery/flasher{id = "tdomeflash"; light_power = 25; light_range = 25; name = "Thunderdome Flash"},/turf/open/floor/circuit/green,/area/tdome/arena)
-"kc" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/space/hardsuit/deathsquad{pixel_y = 5},/obj/item/clothing/gloves/combat,/obj/item/clothing/shoes/combat/swat,/obj/item/clothing/mask/gas/sechailer/swat,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kd" = (/obj/structure/table/reinforced,/obj/item/storage/lockbox/loyalty,/obj/item/gun/ballistic/automatic/ar,/obj/machinery/light{dir = 1},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ke" = (/obj/structure/table/reinforced,/obj/item/storage/box/handcuffs,/obj/item/crowbar/red,/obj/item/crowbar/power,/obj/item/storage/belt/security/full,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kf" = (/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kg" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/space/hardsuit/deathsquad{pixel_y = 5},/obj/item/clothing/gloves/combat,/obj/item/clothing/shoes/combat/swat,/obj/item/clothing/mask/gas/sechailer/swat,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kh" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/obj/structure/window/reinforced{dir = 4},/obj/machinery/light{dir = 8},/turf/open/floor/grass,/area/centcom/evac)
-"ki" = (/obj/effect/light_emitter{set_cap = 1; set_luminosity = 4},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"kj" = (/obj/machinery/light,/turf/open/floor/plasteel/brown,/area/f13/underground/mountain)
-"kk" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/obj/structure/window/reinforced{dir = 8},/obj/machinery/light{dir = 4},/turf/open/floor/grass,/area/centcom/evac)
-"kl" = (/obj/machinery/computer/security/telescreen/entertainment,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"km" = (/turf/closed/wall/f13/tunnel,/area/centcom/evac)
-"kn" = (/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ko" = (/turf/closed/indestructible/abductor{icon_state = "alien20"},/area/abductor_ship)
-"kp" = (/turf/closed/indestructible/abductor{icon_state = "alien21"},/area/abductor_ship)
-"kq" = (/turf/closed/indestructible/abductor{icon_state = "alien22"},/area/abductor_ship)
-"kr" = (/turf/closed/indestructible/abductor{icon_state = "alien23"},/area/abductor_ship)
-"ks" = (/turf/closed/indestructible/abductor{icon_state = "alien24"},/area/abductor_ship)
-"kt" = (/obj/structure/flora/grass/wasteland,/obj/effect/light_emitter{set_cap = 1; set_luminosity = 4},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"ku" = (/turf/closed/indestructible/riveted,/area/syndicate_mothership/control)
-"kv" = (/obj/machinery/door/poddoor/shuttledock{checkdir = 1; name = "syndicate blast door"; turftype = /turf/open/floor/plating/asteroid/snow},/turf/open/floor/plating,/area/syndicate_mothership/control)
-"kw" = (/turf/open/floor/plasteel/brown,/area/f13/underground/mountain)
-"kx" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ky" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/grassybush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/pointybush,/obj/structure/window/reinforced{dir = 4},/turf/open/floor/grass,/area/centcom/evac)
-"kz" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/grassybush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/pointybush,/obj/structure/window/reinforced{dir = 8},/turf/open/floor/grass,/area/centcom/evac)
-"kA" = (/obj/machinery/newscaster/security_unit,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"kB" = (/obj/structure/toilet{dir = 4},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"kC" = (/obj/structure/window/reinforced{dir = 8},/obj/machinery/shower{pixel_y = 16},/obj/structure/curtain,/obj/machinery/door/window/brigdoor/southleft{name = "Shower"},/obj/item/soap/deluxe,/obj/machinery/atmospherics/components/unary/vent_pump/on,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"kD" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/sign/directions/engineering{desc = "A sign that shows there are doors here. There are doors everywhere!"; icon_state = "doors"; name = "WARNING: EXTERNAL AIRLOCK"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kE" = (/obj/structure/closet/emcloset,/obj/item/tank/internals/emergency_oxygen/engi,/obj/item/tank/internals/emergency_oxygen/engi,/obj/item/tank/internals/emergency_oxygen/engi,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kF" = (/obj/machinery/light{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kG" = (/obj/machinery/firealarm{pixel_y = 24},/obj/structure/chair{dir = 8},/obj/structure/extinguisher_cabinet{pixel_x = 24},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kH" = (/obj/item/storage/box/handcuffs,/obj/item/ammo_box/a357,/obj/item/ammo_box/a357,/obj/item/gun/ballistic/revolver/mateba,/obj/structure/table/reinforced,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kI" = (/obj/item/gun/energy/pulse/carbine/loyalpin,/obj/item/flashlight/seclite,/obj/structure/table/reinforced,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kJ" = (/obj/item/storage/box/emps{pixel_x = 3; pixel_y = 3},/obj/item/storage/box/flashbangs,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/structure/table/reinforced,/obj/item/clothing/ears/earmuffs,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kK" = (/turf/closed/indestructible/abductor{icon_state = "alien16"},/area/abductor_ship)
-"kL" = (/turf/closed/indestructible/abductor{icon_state = "alien17"},/area/abductor_ship)
-"kM" = (/obj/machinery/abductor/experiment{team_number = 4},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"kN" = (/obj/machinery/abductor/console{team_number = 4},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"kO" = (/obj/machinery/abductor/pad{team_number = 4},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"kP" = (/turf/closed/indestructible/abductor{icon_state = "alien18"},/area/abductor_ship)
-"kQ" = (/turf/closed/indestructible/abductor{icon_state = "alien19"},/area/abductor_ship)
-"kR" = (/obj/item/storage/box/handcuffs,/obj/item/ammo_box/a357,/obj/item/ammo_box/a357,/obj/item/gun/ballistic/revolver/mateba,/obj/structure/table/reinforced,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kS" = (/obj/item/storage/box/emps{pixel_x = 3; pixel_y = 3},/obj/item/storage/box/flashbangs,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/structure/table/reinforced,/obj/item/clothing/ears/earmuffs,/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kT" = (/obj/structure/sign/warning/nosmoking,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"kU" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 6},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"kV" = (/obj/structure/sink{dir = 4; pixel_x = 11},/obj/structure/mirror{pixel_x = 28},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 9},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"kW" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kX" = (/obj/structure/chair{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kY" = (/obj/machinery/door/airlock/centcom{name = "Auxillary Dock"; opacity = 1; req_access_txt = ""},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"kZ" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"la" = (/obj/item/storage/box/handcuffs,/obj/item/ammo_box/a357,/obj/item/ammo_box/a357,/obj/item/gun/ballistic/revolver/mateba,/obj/structure/table/reinforced,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lb" = (/obj/item/gun/energy/pulse/carbine/loyalpin,/obj/item/flashlight/seclite,/obj/structure/table/reinforced,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lc" = (/obj/item/storage/box/emps{pixel_x = 3; pixel_y = 3},/obj/item/storage/box/flashbangs,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/structure/table/reinforced,/obj/item/clothing/ears/earmuffs,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ld" = (/obj/item/storage/box/handcuffs,/obj/item/ammo_box/a357,/obj/item/ammo_box/a357,/obj/item/gun/ballistic/revolver/mateba,/obj/structure/table/reinforced,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"le" = (/obj/item/storage/box/emps{pixel_x = 3; pixel_y = 3},/obj/item/storage/box/flashbangs,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/item/grenade/plastic/x4,/obj/structure/table/reinforced,/obj/item/clothing/ears/earmuffs,/obj/effect/turf_decal/stripes/line{dir = 4},/obj/effect/turf_decal/stripes/line,/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lf" = (/obj/machinery/door/airlock/silver{name = "Bathroom"},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"lg" = (/turf/closed/indestructible/abductor{icon_state = "alien14"},/area/abductor_ship)
-"lh" = (/obj/machinery/computer/camera_advanced/abductor{team_number = 4},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"li" = (/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lj" = (/obj/structure/closet/abductor,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lk" = (/turf/closed/indestructible/abductor{icon_state = "alien15"},/area/abductor_ship)
-"ll" = (/turf/open/floor/plating,/area/syndicate_mothership/control)
-"lm" = (/obj/machinery/light,/turf/open/floor/plating,/area/syndicate_mothership/control)
-"ln" = (/obj/machinery/firealarm{dir = 1; pixel_y = -26},/turf/open/floor/plasteel/brown,/area/f13/underground/mountain)
-"lo" = (/turf/open/floor/plasteel/brown{dir = 6},/area/f13/underground/mountain)
-"lp" = (/obj/machinery/door/airlock/centcom{name = "Shuttle Control Office"; opacity = 1; req_access_txt = "109"},/obj/effect/turf_decal/stripes/line{dir = 2},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"lq" = (/obj/machinery/door/airlock/centcom{name = "CentCom Supply"; req_access_txt = "106"},/obj/effect/turf_decal/stripes/line{dir = 2},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"lr" = (/obj/machinery/ai_status_display,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"ls" = (/obj/machinery/status_display,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"lt" = (/obj/machinery/door/airlock/external{name = "Ferry Airlock"},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lu" = (/obj/structure/fans/tiny,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lv" = (/obj/machinery/door/airlock/external{name = "Ferry Airlock"},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lw" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lx" = (/obj/effect/turf_decal/bot,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ly" = (/obj/structure/chair{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lz" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lA" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"lB" = (/turf/closed/indestructible/abductor{icon_state = "alien12"},/area/abductor_ship)
-"lC" = (/obj/item/retractor/alien,/obj/item/hemostat/alien,/obj/structure/table/abductor,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lD" = (/obj/effect/landmark/abductor/scientist{team_number = 4},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lE" = (/obj/structure/table/optable/abductor,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lF" = (/obj/effect/landmark/abductor/agent{team_number = 4},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lG" = (/obj/structure/table/abductor,/obj/item/storage/box/alienhandcuffs,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lH" = (/turf/closed/indestructible/abductor{icon_state = "alien13"},/area/abductor_ship)
-"lI" = (/turf/open/indestructible/binary,/area/f13/underground/mountain)
-"lJ" = (/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"lK" = (/obj/machinery/computer/auxillary_base{pixel_y = 32},/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/folder/yellow,/obj/item/pen/red,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"lL" = (/obj/structure/table/wood,/obj/item/taperecorder,/obj/item/storage/box/handcuffs,/obj/item/flashlight/seclite,/obj/structure/noticeboard{pixel_y = 28},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"lM" = (/obj/structure/table/wood,/obj/item/storage/photo_album,/obj/item/camera,/obj/structure/reagent_dispensers/peppertank{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"lN" = (/obj/machinery/ai_status_display{pixel_y = 32},/obj/item/twohanded/required/kirbyplants{icon_state = "plant-15"; pixel_x = -6; pixel_y = 12},/turf/open/floor/plasteel/vault{dir = 6},/area/centcom/evac)
-"lO" = (/obj/structure/fireplace,/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"lP" = (/obj/machinery/status_display{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 10},/area/centcom/evac)
-"lQ" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"lR" = (/obj/structure/table/wood,/obj/item/flashlight/lamp,/obj/machinery/requests_console{announcementConsole = 1; department = "Captain's Desk"; departmentType = 5; name = "Captain RC"; pixel_y = 32},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"lS" = (/obj/machinery/computer/card/centcom,/obj/item/card/id/centcom,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"lT" = (/obj/machinery/computer/communications,/obj/machinery/light_switch{pixel_x = 24},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"lU" = (/obj/structure/table/wood,/obj/item/paper_bin,/obj/item/pen/fourcolor,/obj/machinery/vending/wallmed{name = "Emergency NanoMed"; pixel_y = 32; use_power = 0},/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"lV" = (/obj/structure/table/wood,/obj/item/clipboard,/obj/item/folder/blue,/obj/item/melee/chainofcommand,/obj/item/stamp/captain,/obj/machinery/newscaster/security_unit{pixel_y = 32},/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"lW" = (/obj/structure/table/wood,/obj/machinery/computer/security/wooden_tv,/obj/item/storage/secure/safe{pixel_x = 32; pixel_y = 24},/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"lX" = (/turf/closed/indestructible/abductor{icon_state = "alien10"},/area/abductor_ship)
-"lY" = (/obj/item/surgical_drapes,/obj/item/paper/guides/antag/abductor,/obj/item/scalpel/alien,/obj/structure/table/abductor,/obj/item/cautery/alien,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"lZ" = (/turf/closed/indestructible/abductor{icon_state = "alien11"},/area/abductor_ship)
-"ma" = (/obj/structure/flora/grass/wasteland,/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"mb" = (/obj/machinery/computer/shuttle/labor,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"mc" = (/obj/machinery/computer/shuttle/mining,/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"md" = (/obj/machinery/light{dir = 1},/obj/structure/table/reinforced,/obj/item/crowbar/red,/obj/item/wrench,/obj/item/clothing/mask/gas,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"me" = (/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"mf" = (/obj/machinery/airalarm{dir = 8; pixel_x = 24},/obj/structure/filingcabinet/filingcabinet,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"mg" = (/turf/open/floor/plasteel/brown{dir = 9},/area/f13/underground/mountain)
-"mh" = (/obj/machinery/airalarm{dir = 8; pixel_x = 24},/turf/open/floor/plasteel/brown{dir = 5},/area/f13/underground/mountain)
-"mi" = (/obj/machinery/ai_status_display,/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"mj" = (/obj/machinery/computer/cargo{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"mk" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ml" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/space/hardsuit/deathsquad{pixel_y = 5},/obj/item/clothing/gloves/combat,/obj/item/clothing/shoes/combat/swat,/obj/item/clothing/mask/gas/sechailer/swat,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"mm" = (/obj/structure/table/reinforced,/obj/item/storage/lockbox/loyalty,/obj/item/gun/ballistic/automatic/ar,/obj/effect/turf_decal/stripes/line,/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"mn" = (/obj/structure/table/reinforced,/obj/item/storage/box/handcuffs,/obj/item/crowbar/red,/obj/item/crowbar/power,/obj/item/storage/belt/security/full,/obj/effect/turf_decal/stripes/line,/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"mo" = (/obj/item/radio{pixel_x = 5; pixel_y = 5},/obj/item/radio{pixel_x = -5; pixel_y = 5},/obj/item/radio,/obj/structure/table/wood,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"mp" = (/obj/effect/landmark/thunderdome/admin,/obj/structure/chair/comfy/black{dir = 1},/turf/open/floor/plasteel/grimy,/area/tdome/tdomeobserve)
-"mq" = (/obj/structure/chair/comfy/brown{color = "#66b266"; dir = 1},/turf/open/floor/plasteel/darkgreen,/area/tdome/tdomeobserve)
-"mr" = (/turf/closed/indestructible/abductor{icon_state = "alien6"},/area/abductor_ship)
-"ms" = (/turf/closed/indestructible/abductor{icon_state = "alien7"},/area/abductor_ship)
-"mt" = (/obj/machinery/abductor/gland_dispenser,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"mu" = (/obj/structure/table/abductor,/obj/item/surgicaldrill/alien,/obj/item/circular_saw/alien,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"mv" = (/obj/structure/bed/abductor,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"mw" = (/turf/closed/indestructible/abductor{icon_state = "alien8"},/area/abductor_ship)
-"mx" = (/turf/closed/indestructible/abductor{icon_state = "alien9"},/area/abductor_ship)
-"my" = (/obj/structure/flora/tree/wasteland,/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"mz" = (/obj/item/disk/data,/obj/effect/light_emitter{set_cap = 1; set_luminosity = 4},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"mA" = (/obj/item/toy/figure/syndie,/obj/effect/light_emitter{set_cap = 1; set_luminosity = 4},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"mB" = (/obj/effect/baseturf_helper/asteroid/snow,/turf/closed/indestructible/rock/snow,/area/syndicate_mothership)
-"mC" = (/obj/structure/flora/tree/wasteland,/obj/effect/light_emitter{set_cap = 1; set_luminosity = 4},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"mD" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/brown{dir = 9},/area/f13/underground/mountain)
-"mE" = (/obj/machinery/button/flasher{id = "tdomeflash"},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"mF" = (/obj/structure/chair/office/dark{dir = 1},/turf/open/floor/plasteel/brown{dir = 1},/area/f13/underground/mountain)
-"mG" = (/obj/structure/noticeboard{dir = 8; pixel_x = 32},/turf/open/floor/plasteel/brown{dir = 5},/area/f13/underground/mountain)
-"mH" = (/obj/machinery/computer/security/mining{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"mI" = (/turf/open/floor/plasteel/brown{dir = 10},/area/f13/underground/mountain)
-"mJ" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/brown,/area/f13/underground/mountain)
-"mK" = (/obj/item/storage/briefcase{pixel_x = -3; pixel_y = 3},/obj/item/storage/secure/briefcase,/obj/structure/table/wood,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"mL" = (/turf/open/floor/wood,/area/centcom/evac)
-"mM" = (/obj/structure/chair/comfy/brown{dir = 4},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mN" = (/obj/structure/table/wood,/obj/item/storage/fancy/donut_box,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mO" = (/obj/structure/chair/comfy/black{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mP" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/wood,/area/centcom/evac)
-"mQ" = (/obj/structure/table/wood,/obj/item/clipboard,/obj/item/folder/red,/obj/item/stamp/denied{pixel_x = 3; pixel_y = 3},/obj/item/stamp,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mR" = (/obj/structure/chair/comfy/brown{dir = 8},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 6},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mS" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mT" = (/obj/machinery/door/airlock/centcom{name = "Administrative Office"; opacity = 1; req_access_txt = "109"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"mU" = (/obj/structure/chair/comfy/brown{color = "#596479"; dir = 1},/obj/machinery/atmospherics/components/unary/vent_pump/on{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"mV" = (/obj/machinery/modular_computer/console/preset/command{dir = 8},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"mW" = (/obj/machinery/light,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"mX" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"mY" = (/obj/structure/chair{dir = 8},/obj/structure/sign/warning/securearea{pixel_x = 32},/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"mZ" = (/obj/effect/mapping_helpers/airlock/locked,/obj/machinery/door/airlock/vault{name = "Vault Door"; req_access_txt = "53"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"na" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/obj/machinery/firealarm{dir = 8; pixel_x = -24},/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"nb" = (/turf/closed/indestructible/abductor,/area/abductor_ship)
-"nc" = (/turf/closed/indestructible/abductor{icon_state = "alien2"},/area/abductor_ship)
-"nd" = (/turf/closed/indestructible/abductor{icon_state = "alien3"},/area/abductor_ship)
-"ne" = (/turf/closed/indestructible/abductor{icon_state = "alien4"},/area/abductor_ship)
-"nf" = (/turf/closed/indestructible/abductor{icon_state = "alien5"},/area/abductor_ship)
-"ng" = (/obj/effect/baseturf_helper/asteroid/snow,/turf/closed/indestructible/riveted,/area/syndicate_mothership/control)
-"nh" = (/obj/docking_port/stationary{area_type = /area/syndicate_mothership; dheight = 1; dir = 8; dwidth = 12; height = 17; id = "syndicate_away"; name = "syndicate recon outpost"; roundstart_template = /datum/map_template/shuttle/infiltrator/basic; width = 23},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"ni" = (/turf/open/floor/plasteel/grimy,/area/tdome/tdomeobserve)
-"nj" = (/turf/open/floor/plasteel/darkgreen/side{dir = 1},/area/tdome/tdomeobserve)
-"nk" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"nl" = (/obj/structure/plasticflaps/opaque,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"nm" = (/obj/item/clipboard,/obj/item/stamp/denied{pixel_x = 3; pixel_y = 3},/obj/item/stamp,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"nn" = (/obj/machinery/keycard_auth{pixel_y = -24},/obj/structure/table/reinforced,/obj/item/stack/packageWrap,/obj/item/stack/cable_coil/white,/obj/item/hand_labeler,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"no" = (/obj/machinery/newscaster/security_unit{pixel_y = -32},/obj/machinery/computer/cargo{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"np" = (/obj/structure/bookcase/random,/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"nq" = (/obj/machinery/atmospherics/components/unary/vent_pump/on{dir = 4},/turf/open/floor/wood,/area/centcom/evac)
-"nr" = (/obj/structure/chair/comfy/black{dir = 4},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ns" = (/obj/structure/table/wood,/obj/item/phone{desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in."; pixel_x = -3; pixel_y = 3},/obj/item/clothing/mask/cigarette/cigar/cohiba{pixel_x = 6},/obj/item/clothing/mask/cigarette/cigar/havana{pixel_x = 2},/obj/item/clothing/mask/cigarette/cigar{pixel_x = 4.5},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 10},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nt" = (/obj/structure/chair/comfy/brown{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nu" = (/obj/structure/table/wood,/obj/item/paper_bin,/obj/item/pen/fourcolor,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nv" = (/obj/structure/table/wood,/obj/machinery/computer/security/wooden_tv,/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "2-4"},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nw" = (/obj/machinery/light{dir = 4},/obj/machinery/light_switch{pixel_x = 24},/obj/structure/cable/white{icon_state = "0-8"},/obj/machinery/power/apc{dir = 4; name = "Commander's Office APC"; pixel_x = 26},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nx" = (/obj/structure/sign/warning/securearea{desc = "A warning sign which reads 'FOURTH WALL'."; name = "\improper FOURTH WALL"; pixel_x = -32},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"ny" = (/obj/machinery/light{dir = 8},/turf/open/floor/plating,/area/syndicate_mothership/control)
-"nz" = (/turf/closed/indestructible/fakeglass,/area/syndicate_mothership/control)
-"nA" = (/obj/machinery/light_switch{pixel_x = -24},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nB" = (/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nC" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/obj/machinery/light{dir = 4},/obj/structure/mirror{pixel_x = 28},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"nD" = (/obj/machinery/computer/security/mining{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/f13/underground/mountain)
-"nE" = (/obj/machinery/light,/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/underground/mountain)
-"nF" = (/obj/machinery/firealarm{dir = 1; pixel_y = -24},/obj/structure/closet/crate/bin,/obj/structure/extinguisher_cabinet{pixel_x = 24},/turf/open/floor/plasteel/vault{dir = 4},/area/f13/underground/mountain)
-"nG" = (/obj/machinery/firealarm{dir = 1; pixel_y = -26},/turf/open/floor/plasteel/brown{dir = 6},/area/f13/underground/mountain)
-"nH" = (/obj/vehicle/ridden/atv,/turf/open/floor/plasteel,/area/centcom/evac)
-"nI" = (/obj/structure/decoration/clock/active,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"nJ" = (/turf/open/space/basic,/area/centcom/evac)
-"nK" = (/obj/machinery/power/smes/magical,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"nL" = (/obj/effect/turf_decal/loading_area,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"nM" = (/obj/machinery/power/apc{dir = 4; name = "Commander's Office APC"; pixel_x = 26},/obj/structure/table/reinforced,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/plasteel{amount = 15},/obj/item/stack/sheet/rglass{amount = 50; pixel_x = 2; pixel_y = -2},/obj/item/stack/rods/fifty,/obj/item/stack/cable_coil/white,/obj/item/screwdriver/power,/obj/effect/decal/cleanable/dirt,/obj/structure/cable/white{icon_state = "0-2"},/obj/structure/cable/white{icon_state = "0-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"nN" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/centcom{name = "Thunderdome Administration"; opacity = 1; req_access_txt = "102"},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/tdome/tdomeobserve)
-"nO" = (/obj/structure/table/wood,/obj/machinery/recharger,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"nP" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden{dir = 8},/turf/open/floor/wood,/area/centcom/evac)
-"nQ" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/wood,/area/centcom/evac)
-"nR" = (/obj/machinery/atmospherics/pipe/manifold/supply/hidden,/turf/open/floor/wood,/area/centcom/evac)
-"nS" = (/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nT" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/machinery/atmospherics/components/unary/vent_pump/on{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nU" = (/obj/structure/closet/secure_closet/personal/cabinet,/obj/item/clothing/under/rank/curator/treasure_hunter,/obj/item/clothing/under/skirt/black,/obj/item/clothing/under/shorts/black,/obj/item/clothing/under/pants/track,/obj/item/clothing/accessory/armband/deputy,/obj/item/clothing/accessory/waistcoat,/obj/item/clothing/shoes/jackboots,/obj/item/clothing/shoes/laceup,/obj/item/clothing/neck/stripedredscarf,/obj/item/clothing/neck/tie/red,/obj/item/clothing/head/helmet/space/beret,/obj/item/clothing/suit/curator,/obj/item/clothing/suit/space/officer,/obj/item/clothing/gloves/fingerless,/obj/item/clothing/gloves/color/black,/obj/item/clothing/glasses/eyepatch,/obj/machinery/firealarm{dir = 8; pixel_x = -24},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"nV" = (/obj/structure/destructible/cult/tome,/obj/item/book/codex_gigas,/obj/machinery/airalarm{dir = 8; pixel_x = 24},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"nW" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"nX" = (/obj/effect/turf_decal/delivery,/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"nY" = (/obj/machinery/power/terminal{dir = 1},/obj/structure/cable/white{icon_state = "0-4"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"nZ" = (/obj/effect/turf_decal/loading_area{dir = 1},/obj/structure/cable/white{icon_state = "2-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oa" = (/obj/structure/reagent_dispensers/fueltank,/obj/item/weldingtool/experimental,/obj/effect/decal/cleanable/oil,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ob" = (/obj/structure/bookcase/random,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"oc" = (/obj/structure/table/wood,/obj/item/paper_bin,/obj/item/pen/fourcolor,/obj/machinery/light,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"od" = (/obj/structure/table/wood,/obj/item/folder/red,/obj/item/book/manual/wiki/security_space_law,/obj/item/restraints/handcuffs,/obj/item/assembly/flash/handheld,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"oe" = (/obj/structure/table/wood,/obj/item/clipboard,/obj/item/radio/headset/headset_cent,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"of" = (/obj/structure/table/wood,/obj/item/phone{desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in."; pixel_x = -3; pixel_y = 3},/obj/item/clothing/mask/cigarette/cigar/cohiba{pixel_x = 6},/obj/item/clothing/mask/cigarette/cigar/havana{pixel_x = 2},/obj/item/clothing/mask/cigarette/cigar{pixel_x = 4.5},/obj/machinery/airalarm{dir = 1; pixel_y = -22},/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"og" = (/obj/machinery/button/door{id = "thunderdomehea"; name = "Heavy Supply Control"; req_access_txt = "102"},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"oh" = (/obj/machinery/button/door{id = "thunderdome"; name = "Main Blast Doors Control"; req_access_txt = "102"},/obj/structure/table/reinforced,/obj/machinery/light,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"oi" = (/obj/machinery/button/door{id = "thunderdomegen"; name = "General Supply Control"; req_access_txt = "102"},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"oj" = (/obj/structure/table/wood,/obj/item/folder/red,/obj/item/lighter,/obj/machinery/newscaster{pixel_y = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"ok" = (/obj/item/storage/briefcase{pixel_x = -3; pixel_y = 3},/obj/item/storage/secure/briefcase,/obj/structure/table/wood,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"ol" = (/obj/structure/table/wood,/obj/item/storage/fancy/donut_box,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"om" = (/obj/structure/table/wood,/obj/item/storage/box/drinkingglasses,/obj/item/reagent_containers/food/drinks/bottle/whiskey{pixel_y = 5},/obj/machinery/light,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"on" = (/obj/structure/table/wood,/obj/item/folder/red,/obj/item/book/manual/wiki/security_space_law,/obj/item/restraints/handcuffs,/obj/item/assembly/flash/handheld,/obj/machinery/airalarm{dir = 1; pixel_y = -22},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"oo" = (/obj/structure/table/wood,/obj/item/folder/red,/obj/item/lighter,/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"op" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/turf/open/floor/wood,/area/centcom/evac)
-"oq" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/machinery/light_switch{pixel_y = -24},/turf/open/floor/wood,/area/centcom/evac)
-"or" = (/obj/structure/closet/crate/bin,/obj/machinery/light,/turf/open/floor/wood,/area/centcom/evac)
-"os" = (/obj/structure/table/wood,/obj/item/clipboard,/obj/item/toy/figure/dsquad,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ot" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"ou" = (/obj/structure/table/wood,/obj/item/storage/secure/briefcase{pixel_x = 5; pixel_y = 5},/obj/item/storage/lockbox/medal,/obj/machinery/newscaster/security_unit{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ov" = (/obj/structure/table/wood,/obj/item/flashlight/lamp,/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"ow" = (/obj/structure/bed,/obj/item/bedsheet/black,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ox" = (/obj/structure/dresser,/obj/structure/sign/plaques/golden/captain{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"oy" = (/obj/effect/mapping_helpers/airlock/locked,/obj/machinery/door/airlock/vault{name = "Vault Door"; req_access_txt = "53"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel,/area/centcom/evac)
-"oz" = (/obj/machinery/ai_status_display,/turf/closed/indestructible/riveted,/area/tdome/tdomeobserve)
-"oA" = (/obj/machinery/door/airlock/centcom{name = "Administrative Office"; opacity = 1; req_access_txt = "109"},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/effect/turf_decal/stripes/line{dir = 2},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel,/area/centcom/evac)
-"oB" = (/obj/machinery/door/airlock/centcom{name = "Administrative Office"; opacity = 1; req_access_txt = "109"},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/effect/turf_decal/stripes/line{dir = 2},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel,/area/centcom/evac)
-"oC" = (/obj/structure/sign/nanotrasen,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"oD" = (/obj/machinery/computer/auxillary_base{pixel_y = 32},/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/radio/headset/headset_cent,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"oE" = (/obj/machinery/computer/shuttle/labor,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel,/area/centcom/evac)
-"oF" = (/obj/machinery/computer/shuttle/mining,/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/centcom/evac)
-"oG" = (/obj/machinery/light{dir = 1},/obj/structure/table/reinforced,/obj/item/crowbar/red,/obj/item/wrench,/obj/item/clothing/mask/gas,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"oH" = (/obj/structure/filingcabinet/filingcabinet,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"oI" = (/obj/machinery/airalarm{dir = 8; pixel_x = 24},/obj/structure/filingcabinet/filingcabinet,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"oJ" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oK" = (/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oL" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oM" = (/obj/effect/turf_decal/delivery,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oN" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oO" = (/obj/machinery/door/poddoor/shutters{id = "XCCFerry"; name = "XCC Ferry Hangar"},/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oP" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oQ" = (/obj/machinery/button/door{id = "XCCFerry"; name = "Hanger Bay Shutters"; pixel_y = 24; req_access_txt = "2"},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"oR" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/turf/open/floor/plasteel,/area/centcom/evac)
-"oS" = (/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"oT" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"oU" = (/obj/docking_port/stationary/bos,/turf/closed/mineral/random/low_chance,/area/f13/brotherhood)
-"oV" = (/obj/machinery/vr_sleeper{dir = 4},/obj/machinery/light{dir = 8},/turf/open/floor/wood,/area/centcom/holding)
-"oW" = (/obj/item/toy/figure/syndie,/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"oX" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-05"; pixel_y = 10},/obj/structure/table/reinforced,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/centcom/evac)
-"oY" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-15"; pixel_x = -6; pixel_y = 12},/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"oZ" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"pa" = (/obj/machinery/door/poddoor/shutters{id = "XCCsec1"; name = "XCC Checkpoint 1 Shutters"},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"pb" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pc" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pd" = (/obj/structure/reagent_dispensers/fueltank,/obj/item/weldingtool/experimental,/obj/effect/decal/cleanable/oil,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"pe" = (/obj/machinery/power/smes/magical,/obj/machinery/light{dir = 1},/obj/effect/decal/cleanable/dirt,/obj/structure/cable/white{icon_state = "0-4"},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"pf" = (/obj/machinery/power/apc{dir = 4; name = "Commander's Office APC"; pixel_x = 26},/obj/structure/table/reinforced,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/plasteel{amount = 15},/obj/item/stack/sheet/rglass{amount = 50; pixel_x = 2; pixel_y = -2},/obj/item/stack/rods/fifty,/obj/item/stack/cable_coil/white,/obj/item/screwdriver/power,/obj/effect/decal/cleanable/dirt,/obj/structure/cable/white{icon_state = "0-2"},/obj/structure/cable/white{icon_state = "0-8"},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"pg" = (/obj/machinery/computer/shuttle/white_ship{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ph" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pi" = (/obj/structure/chair/office/dark{dir = 1},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pj" = (/obj/structure/noticeboard{dir = 8; pixel_x = 32},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pk" = (/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pl" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/sign/directions/engineering{desc = "A sign that shows there are doors here. There are doors everywhere!"; icon_state = "doors"; name = "WARNING: BLAST DOORS"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pm" = (/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,/area/centcom/evac)
-"pn" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"po" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pp" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pq" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 9},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pr" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 6},/obj/structure/cable/white{icon_state = "2-4"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ps" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pt" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 9},/obj/structure/cable/white{icon_state = "1-4"},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pu" = (/obj/machinery/door/airlock/centcom{name = "Equipment Room"; opacity = 1; req_access_txt = "150"},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pv" = (/obj/machinery/atmospherics/pipe/manifold/supply/visible{dir = 1},/obj/machinery/meter,/obj/structure/cable/white{icon_state = "4-8"},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"pw" = (/obj/machinery/power/terminal{dir = 1},/obj/machinery/atmospherics/pipe/manifold/supply/visible{dir = 1},/obj/structure/cable/white{icon_state = "0-8"},/obj/structure/cable/white{icon_state = "0-4"},/obj/structure/cable/white{icon_state = "0-2"},/obj/structure/cable/white{icon_state = "0-8"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"px" = (/obj/machinery/atmospherics/pipe/manifold/supply/visible{dir = 1},/obj/machinery/meter,/obj/structure/cable/white{icon_state = "1-8"},/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"py" = (/obj/machinery/smartfridge,/turf/closed/indestructible{icon = 'icons/turf/walls/wood_wall.dmi'; icon_state = "wood"; smooth = 1},/area/centcom/holding)
-"pz" = (/obj/machinery/computer/shuttle/ferry{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pA" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pB" = (/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pC" = (/obj/structure/sign/plaques/thunderdome{icon_state = "nanotrasen_sign1"},/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,/area/centcom/evac)
-"pD" = (/obj/structure/sign/plaques/thunderdome{icon_state = "nanotrasen_sign2"},/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,/area/centcom/evac)
-"pE" = (/obj/machinery/plantgenes/seedvault,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"pF" = (/obj/machinery/door/airlock/centcom{name = "Auxillary Dock"; opacity = 1; req_access_txt = ""},/turf/open/floor/plating,/area/syndicate_mothership/control)
-"pG" = (/obj/structure/statue/uranium/nuke,/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"pH" = (/obj/structure/sign/plaques/thunderdome{icon_state = "nanotrasen_sign3"},/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,/area/centcom/evac)
-"pI" = (/obj/structure/sign/plaques/thunderdome{icon_state = "nanotrasen_sign4"},/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,/area/centcom/evac)
-"pJ" = (/obj/structure/sign/plaques/thunderdome{icon_state = "nanotrasen_sign5"},/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,/area/centcom/evac)
-"pK" = (/obj/machinery/button/door{id = "XCCsec1"; name = "CC Shutter 1 Control"; pixel_y = -24},/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pL" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"pM" = (/obj/machinery/atmospherics/components/unary/portables_connector/visible{dir = 1},/obj/machinery/airalarm{dir = 1; pixel_y = -22},/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/machinery/portable_atmospherics/canister/air,/obj/structure/cable/white{icon_state = "1-4"},/turf/open/floor/plasteel,/area/centcom/evac)
-"pN" = (/obj/machinery/computer/monitor/secret{dir = 1},/obj/machinery/atmospherics/components/unary/vent_pump/on{dir = 1},/obj/effect/decal/cleanable/dirt,/obj/structure/cable/white{icon_state = "4-8"},/obj/structure/cable/white{icon_state = "1-8"},/obj/machinery/light,/turf/open/floor/plasteel,/area/centcom/evac)
-"pO" = (/obj/machinery/atmospherics/components/unary/tank/air{dir = 1},/obj/machinery/firealarm{dir = 1; pixel_y = -24},/obj/effect/decal/cleanable/dirt,/obj/structure/cable/white{icon_state = "1-8"},/turf/open/floor/plasteel,/area/centcom/evac)
-"pP" = (/obj/machinery/keycard_auth{pixel_y = -24},/obj/structure/table/reinforced,/obj/machinery/recharger,/obj/machinery/button/door{id = "XCCFerry"; name = "Hanger Bay Shutters"; pixel_y = -38},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"pQ" = (/obj/machinery/computer/emergency_shuttle{dir = 1},/obj/machinery/newscaster/security_unit{pixel_y = -32},/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel,/area/centcom/evac)
-"pR" = (/obj/machinery/computer/communications{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/centcom/evac)
-"pS" = (/obj/structure/table,/obj/item/stack/packageWrap,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"pT" = (/obj/machinery/light,/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"pU" = (/obj/machinery/firealarm{dir = 1; pixel_y = -24},/obj/structure/closet/crate/bin,/obj/structure/extinguisher_cabinet{pixel_x = 24},/turf/open/floor/plasteel/vault{dir = 4},/area/centcom/evac)
-"pV" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"pW" = (/obj/effect/landmark/ai_multicam_room,/turf/open/ai_visible,/area/ai_multicam_room)
-"pX" = (/obj/item/storage/crayons,/obj/structure/table,/obj/item/storage/crayons,/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"pY" = (/obj/machinery/washing_machine,/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"pZ" = (/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"qa" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"qb" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/machinery/door/airlock/centcom{name = "Administrative Office"; opacity = 1; req_access_txt = "109"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qc" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/turf/closed/wall/f13/vault,/area/centcom/evac)
-"qd" = (/obj/structure/sign/warning/securearea,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"qe" = (/obj/machinery/door/airlock/centcom{name = "Briefing Room"; opacity = 1; req_access_txt = "101"},/obj/effect/turf_decal/stripes/line{dir = 2},/turf/open/floor/plasteel,/area/centcom/evac)
-"qf" = (/obj/machinery/ai_status_display,/obj/structure/cable/white{icon_state = "1-2"},/turf/closed/wall/f13/vault,/area/centcom/evac)
-"qg" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/turf/open/floor/plasteel/darkred/side{dir = 4},/area/centcom/evac)
-"qh" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/turf/open/floor/plasteel/darkred/side{dir = 8},/area/centcom/evac)
-"qi" = (/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"qj" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"qk" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ql" = (/obj/structure/table/wood,/obj/item/storage/fancy/donut_box,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"qm" = (/obj/structure/table/wood,/obj/item/phone{desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in."; pixel_x = -3; pixel_y = 3},/obj/item/clothing/mask/cigarette/cigar/cohiba{pixel_x = 6},/obj/item/clothing/mask/cigarette/cigar/havana{pixel_x = 2},/obj/item/clothing/mask/cigarette/cigar{pixel_x = 4.5},/obj/machinery/newscaster{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"qn" = (/obj/structure/target_stake,/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"qo" = (/turf/closed/indestructible/rock,/area/centcom/evac)
-"qp" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"qq" = (/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"qr" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"qs" = (/obj/structure/closet/secure_closet/ertEngi,/obj/structure/sign/directions/engineering{pixel_y = 24},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qt" = (/obj/structure/closet/secure_closet/ertEngi,/obj/machinery/airalarm{pixel_y = 24},/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qu" = (/obj/structure/table/reinforced,/obj/item/flashlight/seclite,/obj/structure/noticeboard{pixel_y = 28},/obj/effect/turf_decal/stripes/line,/obj/item/gun/energy/laser/wattz/magneto,/obj/item/gun/energy/laser/wattz/magneto,/obj/item/gun/energy/laser/wattz/magneto,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qv" = (/obj/structure/table/reinforced,/obj/item/grenade/plastic/c4{pixel_x = 6},/obj/item/grenade/plastic/c4{pixel_x = -4},/obj/machinery/firealarm{pixel_y = 24},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qw" = (/obj/structure/rack,/obj/effect/turf_decal/stripes/line{dir = 10},/obj/item/gun/energy/laser/aer9,/obj/item/gun/energy/laser/aer9,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qx" = (/turf/closed/indestructible/riveted,/area/centcom/evac)
-"qy" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/grass,/area/centcom/evac)
-"qz" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/grassybush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/pointybush,/turf/open/floor/grass,/area/centcom/evac)
-"qA" = (/obj/structure/closet/secure_closet/ertCom,/obj/structure/sign/directions/command{dir = 2; pixel_y = 24},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"qB" = (/turf/open/floor/plasteel/darkred/side{dir = 4},/area/centcom/evac)
-"qC" = (/turf/open/floor/plasteel/darkred/side{dir = 8},/area/centcom/evac)
-"qD" = (/obj/structure/sink{dir = 8; pixel_x = -12},/turf/open/floor/plasteel/whitered/side{dir = 9},/area/centcom/evac)
-"qE" = (/turf/closed/indestructible/riveted/uranium,/area/wizard_station)
-"qF" = (/obj/machinery/light{dir = 1},/obj/structure/kitchenspike,/turf/open/floor/plasteel/whitered/side{dir = 1},/area/centcom/evac)
-"qG" = (/obj/structure/kitchenspike,/turf/open/floor/plasteel/whitered/side{dir = 1},/area/centcom/evac)
-"qH" = (/obj/machinery/shower{dir = 8},/turf/open/floor/plasteel/whitered/side{dir = 5},/area/centcom/evac)
-"qI" = (/obj/item/twohanded/required/kirbyplants,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"qJ" = (/obj/machinery/computer/shuttle/syndicate/recall,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"qK" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"qL" = (/obj/machinery/vending/cola,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"qM" = (/obj/machinery/vending/cigarette{products = list(/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 7, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 3, /obj/item/storage/fancy/cigarettes/cigpack_robust = 2, /obj/item/storage/fancy/cigarettes/cigpack_carp = 3, /obj/item/storage/fancy/cigarettes/cigpack_midori = 1, /obj/item/storage/box/matches = 10, /obj/item/lighter/greyscale = 4, /obj/item/storage/fancy/rollingpapers = 5)},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"qN" = (/obj/structure/urinal{pixel_y = 28},/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"qO" = (/obj/item/soap/syndie,/obj/structure/mopbucket,/obj/machinery/light/small{dir = 1},/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"qP" = (/obj/structure/mirror{pixel_x = 28},/obj/item/mop,/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"qQ" = (/obj/item/scalpel{pixel_y = 12},/obj/item/circular_saw,/obj/item/retractor{pixel_x = 4},/obj/item/hemostat{pixel_x = -4},/obj/item/clothing/gloves/color/latex,/obj/item/clothing/mask/surgical,/obj/structure/table/reinforced,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"qR" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"qS" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"qT" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/machinery/newscaster{pixel_x = -32},/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"qU" = (/obj/machinery/light_switch{pixel_y = 24},/turf/open/floor/wood,/area/centcom/evac)
-"qV" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/centcom/evac)
-"qW" = (/obj/machinery/light{dir = 8},/obj/item/key,/turf/open/floor/plasteel,/area/centcom/evac)
-"qX" = (/obj/item/flashlight/lamp,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"qY" = (/obj/machinery/computer/card/centcom,/obj/item/card/id/centcom,/obj/machinery/computer/security/telescreen{desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office."; name = "Research Monitor"; network = list("rd","minisat"); pixel_y = 28},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"qZ" = (/turf/open/floor/engine/cult,/area/wizard_station)
-"ra" = (/obj/machinery/computer/shuttle,/turf/open/floor/engine/cult,/area/wizard_station)
-"rb" = (/turf/closed/indestructible/rock,/area/f13/underground/mountain)
-"rc" = (/turf/closed/mineral/random,/area/f13/underground/mountain)
-"rd" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"re" = (/obj/item/paper/fluff/stations/centcom/disk_memo,/obj/structure/noticeboard{pixel_x = -32},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"rf" = (/obj/structure/chair/stool,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"rg" = (/obj/structure/window/reinforced{dir = 8},/turf/open/floor/grass,/area/centcom/holding)
-"rh" = (/obj/machinery/door/airlock/centcom{name = "Restroom"; opacity = 1; req_access_txt = "150"},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"ri" = (/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"rj" = (/obj/structure/mirror{pixel_x = 28},/obj/structure/sink{dir = 4; pixel_x = 11},/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"rk" = (/obj/structure/table/wood,/obj/item/storage/box/drinkingglasses,/obj/item/reagent_containers/food/drinks/bottle/whiskey{pixel_y = 5},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"rl" = (/obj/structure/chair/office/dark,/obj/effect/landmark/ert_spawn,/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rm" = (/obj/structure/chair/office/dark,/obj/effect/landmark/ert_spawn,/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"rn" = (/obj/structure/chair/office/dark,/obj/effect/landmark/ert_spawn,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ro" = (/obj/structure/sink{dir = 8; pixel_x = -12},/turf/open/floor/plasteel/whitered/corner{dir = 1},/area/centcom/evac)
-"rp" = (/turf/open/floor/plasteel/white,/area/centcom/evac)
-"rq" = (/obj/machinery/shower{dir = 8},/turf/open/floor/plasteel/whitered/corner{dir = 4},/area/centcom/evac)
-"rr" = (/obj/structure/table/optable,/obj/item/surgical_drapes,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"rs" = (/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"rt" = (/obj/structure/chair/comfy/black,/obj/machinery/computer/security/telescreen/entertainment{pixel_x = -32},/obj/machinery/atmospherics/components/unary/vent_pump/on{dir = 4},/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ru" = (/obj/structure/chair/comfy/black,/obj/machinery/atmospherics/pipe/manifold/supply/hidden,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"rv" = (/obj/structure/chair/office/dark{dir = 4},/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable/white{icon_state = "2-4"},/turf/open/floor/wood,/area/centcom/evac)
-"rw" = (/obj/item/clipboard,/obj/structure/table/reinforced,/obj/item/detective_scanner,/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"rx" = (/obj/structure/chair/office/dark{dir = 8},/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,/obj/structure/cable/white{icon_state = "4-8"},/obj/structure/cable/white{icon_state = "1-4"},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ry" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden{dir = 4},/obj/structure/cable/white{icon_state = "4-8"},/obj/machinery/power/apc{dir = 4; name = "Commander's Office APC"; pixel_x = 26},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"rz" = (/obj/machinery/photocopier,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"rA" = (/obj/structure/table/reinforced,/obj/item/folder/red{pixel_x = -2; pixel_y = -2},/obj/item/folder/blue{pixel_x = 2; pixel_y = 2},/obj/item/lighter,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"rB" = (/obj/structure/table/reinforced,/obj/item/storage/secure/briefcase,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"rC" = (/obj/structure/table/reinforced,/obj/item/storage/firstaid/regular,/obj/structure/cable/white{icon_state = "1-4"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"rD" = (/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/folder/white,/obj/item/pen/blue,/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"rE" = (/obj/structure/table/reinforced,/obj/item/paper_bin,/obj/item/pen,/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"rF" = (/obj/structure/chair/office/dark{dir = 8},/obj/effect/landmark/ert_spawn,/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rG" = (/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"rH" = (/obj/machinery/door/poddoor/ert,/obj/effect/turf_decal/delivery,/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rI" = (/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rJ" = (/obj/structure/table/reinforced,/obj/item/restraints/handcuffs,/obj/item/radio,/obj/effect/turf_decal/stripes/line{dir = 9},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rK" = (/obj/structure/table/reinforced,/obj/item/storage/firstaid/regular,/obj/effect/turf_decal/stripes/line{dir = 5},/obj/structure/cable/white{icon_state = "4-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rL" = (/obj/structure/cable/white{icon_state = "2-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rM" = (/obj/structure/extinguisher_cabinet{pixel_x = 26},/obj/structure/guncase/shotgun,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rN" = (/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/obj/machinery/light/small{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"rO" = (/obj/machinery/shower{dir = 8},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"rP" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/goonplaque{desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."},/area/centcom/evac)
-"rQ" = (/obj/structure/table/wood,/obj/structure/sign/plaques/golden{pixel_y = 32},/obj/item/clothing/accessory/lawyers_badge{desc = "A badge of upmost glory."; name = "thunderdome badge"},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"rR" = (/obj/structure/table/wood,/obj/structure/sign/plaques/golden{pixel_y = 32},/obj/item/clothing/accessory/medal/silver{pixel_y = 5},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"rS" = (/obj/machinery/status_display,/turf/closed/indestructible/riveted,/area/centcom/evac)
-"rT" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/goonplaque{desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."},/area/centcom/evac)
-"rU" = (/obj/machinery/computer/operating{dir = 4},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"rV" = (/obj/machinery/light,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"rW" = (/obj/machinery/light{dir = 8},/turf/open/floor/engine/cult,/area/wizard_station)
-"rX" = (/obj/machinery/light{dir = 4},/turf/open/floor/engine/cult,/area/wizard_station)
-"rY" = (/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"rZ" = (/obj/machinery/computer/operating{dir = 8},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"sa" = (/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light/small{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"sb" = (/obj/structure/table/wood,/obj/item/storage/pill_bottle/dice,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sc" = (/obj/structure/table/wood,/obj/item/toy/cards/deck/cas{pixel_x = -5; pixel_y = 5},/obj/item/toy/cards/deck/cas/black{pixel_x = 5; pixel_y = 5},/obj/item/gun/energy/pulse/pistol/m1911,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sd" = (/obj/structure/chair/office/dark{dir = 4},/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/wood,/area/centcom/evac)
-"se" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"sf" = (/obj/structure/table/wood,/obj/item/paicard,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"sg" = (/obj/structure/table/wood,/obj/item/pizzabox,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"sh" = (/obj/structure/chair/stool,/obj/effect/landmark/start/nukeop,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"si" = (/obj/machinery/computer/telecrystals/uplinker,/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/mineral/plastitanium,/area/syndicate_mothership/control)
-"sj" = (/obj/structure/toilet{dir = 8},/obj/structure/window/reinforced/tinted{dir = 1},/obj/machinery/door/window{name = "Tactical Toilet"; icon_state = "right"; dir = 8; opacity = 1},/turf/open/floor/plasteel/freezer{dir = 2},/area/syndicate_mothership/control)
-"sk" = (/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"sl" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"sm" = (/obj/effect/turf_decal/stripes/line{dir = 2},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"sn" = (/obj/effect/turf_decal/stripes/line{dir = 2},/obj/machinery/light{dir = 1},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"so" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"sp" = (/obj/effect/turf_decal/stripes/corner{dir = 1},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"sq" = (/obj/structure/table/reinforced,/obj/item/folder/red,/obj/item/restraints/handcuffs,/obj/item/assembly/flash/handheld,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"sr" = (/obj/item/storage/fancy/donut_box,/obj/structure/table/reinforced,/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ss" = (/obj/item/paper_bin,/obj/item/pen/fourcolor,/obj/structure/table/reinforced,/obj/machinery/light{dir = 4},/obj/machinery/newscaster{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"st" = (/obj/machinery/door/airlock/external{name = "Backup Emergency Escape Shuttle"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"su" = (/obj/structure/chair/comfy/brown{color = "#596479"; dir = 4},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sv" = (/obj/structure/table/reinforced,/obj/item/gun/ballistic/automatic/m72,/obj/item/ammo_box/magazine/m2mm,/obj/item/ammo_box/magazine/m2mm,/obj/item/ammo_box/magazine/m2mm,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sw" = (/obj/structure/table/reinforced,/obj/item/flashlight/seclite,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"sx" = (/obj/machinery/shuttle_manipulator,/turf/open/floor/circuit/green,/area/centcom/evac)
-"sy" = (/turf/open/floor/circuit/green,/area/centcom/evac)
-"sz" = (/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/folder/red,/obj/item/pen/red,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"sA" = (/obj/structure/chair/office/dark{dir = 8},/obj/effect/landmark/ert_spawn,/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"sB" = (/obj/machinery/door/poddoor/ert,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"sC" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/stripes/line{dir = 8},/obj/item/gun/energy/e_gun/stun,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"sD" = (/obj/structure/table/reinforced,/obj/item/storage/box/zipties,/obj/item/crowbar/red,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"sE" = (/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"sF" = (/obj/structure/cable/white{icon_state = "1-4"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"sG" = (/obj/structure/cable{icon_state = "0-2"},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"sH" = (/obj/machinery/power/apc{dir = 4; name = "Briefing Area APC"; pixel_x = 26},/obj/structure/cable/white{icon_state = "0-8"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"sI" = (/obj/structure/sign/barsign,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"sJ" = (/obj/machinery/door/airlock/silver{name = "Bathroom"},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"sK" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/drinks/trophy/gold_cup,/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sL" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/drinks/trophy/gold_cup,/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sM" = (/obj/machinery/door/airlock/silver{name = "Bathroom"},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"sN" = (/obj/machinery/light{dir = 4},/obj/item/key,/turf/open/floor/plasteel,/area/centcom/evac)
-"sO" = (/obj/structure/chair,/turf/open/floor/plasteel,/area/centcom/evac)
-"sP" = (/obj/structure/chair,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/centcom/evac)
-"sQ" = (/obj/structure/chair/comfy/black{dir = 1},/obj/machinery/computer/security/telescreen/entertainment{pixel_x = -32},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sR" = (/obj/structure/chair/comfy/black{dir = 1},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sS" = (/obj/structure/cable/white{icon_state = "1-2"},/turf/open/floor/wood,/area/centcom/evac)
-"sT" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/centcom/evac)
-"sU" = (/obj/machinery/atmospherics/components/unary/vent_pump/on{dir = 1},/turf/open/floor/wood,/area/centcom/evac)
-"sV" = (/obj/structure/table/wood,/obj/item/paper_bin,/obj/item/pen/fourcolor,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"sW" = (/obj/structure/showcase{desc = "A strange machine supposedly from another world. The Wizard Federation has been meddling with it for years."; icon = 'icons/obj/machines/telecomms.dmi'; icon_state = "processor"; name = "byond random number generator"},/turf/open/floor/engine/cult,/area/wizard_station)
-"sX" = (/obj/structure/showcase{desc = "A historical figure of great importance to the wizard federation. He spent his long life learning magic, stealing artifacts, and harassing idiots with swords. May he rest forever, Rodney."; icon = 'icons/mob/mob.dmi'; icon_state = "nim"; name = "wizard of yendor showcase"},/turf/open/floor/engine/cult,/area/wizard_station)
-"sY" = (/obj/machinery/computer/card/centcom{dir = 1},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"sZ" = (/obj/structure/table/reinforced,/obj/item/book/manual/wiki/security_space_law,/obj/item/taperecorder,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ta" = (/obj/structure/table/reinforced,/obj/item/storage/fancy/donut_box,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tb" = (/obj/structure/table/reinforced,/obj/item/crowbar/red,/obj/item/tank/internals/emergency_oxygen/engi,/obj/item/clothing/mask/gas,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tc" = (/turf/closed/wall/f13/tunnel,/area/f13/underground/mountain)
-"td" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "horizontalbottomborderbottom0"},/area/f13/underground/mountain)
-"te" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"tf" = (/obj/structure/table/wood,/obj/item/reagent_containers/food/drinks/beer{pixel_x = 5; pixel_y = -2},/obj/item/toy/cards/deck/syndicate{icon_state = "deck_syndicate_full"; pixel_x = -6; pixel_y = 6},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"tg" = (/obj/machinery/computer/telecrystals/uplinker,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/mineral/plastitanium,/area/syndicate_mothership/control)
-"th" = (/obj/structure/closet/cardboard,/obj/effect/turf_decal/stripes/corner,/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"ti" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"tj" = (/obj/structure/fluff/rails,/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"tk" = (/turf/closed/wall/f13,/area/f13/underground/mountain)
-"tl" = (/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"tm" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "horizontaltopbordertop0"},/area/f13/underground/mountain)
-"tn" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"to" = (/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/folder/yellow,/obj/item/pen/blue,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tp" = (/obj/structure/chair/office/dark{dir = 8},/obj/effect/landmark/ert_spawn,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"tq" = (/obj/structure/table/reinforced,/obj/item/storage/lockbox/loyalty,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"tr" = (/obj/structure/table/reinforced,/obj/item/storage/toolbox/mechanical,/obj/item/tank/internals/emergency_oxygen/engi,/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ts" = (/obj/machinery/newscaster/security_unit{pixel_x = 32},/obj/structure/guncase/ecase,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"tt" = (/obj/machinery/chem_master/condimaster{name = "HoochMaster 2000"},/turf/open/floor/plasteel/red,/area/centcom/evac)
-"tu" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"tv" = (/turf/open/floor/plasteel/red,/area/centcom/evac)
-"tw" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/goonplaque,/area/centcom/evac)
-"tx" = (/obj/structure/table/wood,/obj/item/clothing/accessory/medal/gold{pixel_x = 3; pixel_y = 5},/obj/item/clothing/accessory/medal/gold,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ty" = (/obj/structure/table/wood,/obj/item/clothing/accessory/medal{pixel_y = 5},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"tz" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel/goonplaque,/area/centcom/evac)
-"tA" = (/obj/item/defibrillator/loaded,/obj/structure/table/reinforced,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"tB" = (/obj/item/reagent_containers/glass/bottle/epinephrine{pixel_x = 6},/obj/item/reagent_containers/glass/bottle/charcoal{pixel_x = -3},/obj/item/reagent_containers/glass/bottle/epinephrine{pixel_x = -3; pixel_y = 8},/obj/item/reagent_containers/glass/bottle/charcoal{pixel_x = 6; pixel_y = 8},/obj/item/reagent_containers/syringe/epinephrine{pixel_x = 3; pixel_y = -2},/obj/item/reagent_containers/syringe/epinephrine{pixel_x = 4; pixel_y = 1},/obj/item/reagent_containers/syringe/epinephrine{pixel_x = -2; pixel_y = 5},/obj/item/reagent_containers/syringe/epinephrine{pixel_x = 2; pixel_y = 8},/obj/structure/table/reinforced,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"tC" = (/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/regular{pixel_x = 2; pixel_y = 3},/obj/structure/table/reinforced,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"tD" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/o2{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"tE" = (/obj/structure/bookcase/random,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tF" = (/obj/structure/table/wood,/obj/item/paper_bin,/obj/item/pen/fourcolor,/obj/machinery/airalarm{dir = 1; pixel_y = -22},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tG" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/turf/open/floor/plasteel/vault{dir = 6},/area/centcom/evac)
-"tH" = (/obj/structure/cable/white,/turf/open/floor/plasteel/vault,/area/centcom/evac)
-"tI" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/turf/open/floor/plasteel/vault{dir = 10},/area/centcom/evac)
-"tJ" = (/obj/structure/closet/crate/bin,/obj/machinery/light_switch{pixel_y = -24},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tK" = (/obj/structure/table/wood,/obj/item/dice/d20{pixel_x = 3; pixel_y = 3},/obj/item/dice/d10{pixel_x = -3},/obj/machinery/computer/security/telescreen/entertainment{pixel_y = -32},/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tL" = (/obj/structure/table/wood,/obj/item/clipboard,/obj/item/radio/headset/headset_cent,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tM" = (/obj/structure/chair/office/dark{dir = 1},/obj/effect/landmark/ert_spawn,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"tN" = (/obj/structure/chair/office/dark{dir = 1},/obj/effect/landmark/ert_spawn,/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"tO" = (/obj/structure/table/wood,/obj/machinery/chem_dispenser/drinks/beer,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"tP" = (/obj/structure/table/reinforced,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"tQ" = (/obj/structure/displaycase/captain,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"tR" = (/obj/machinery/ai_status_display,/turf/closed/indestructible/riveted,/area/centcom/evac)
-"tS" = (/obj/machinery/sleeper{dir = 4},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"tT" = (/obj/machinery/sleeper{dir = 8},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"tU" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"tV" = (/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/centcom/evac)
-"tW" = (/obj/structure/rack,/obj/item/nullrod/claymore{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"tX" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Cockpit"},/turf/open/floor/engine/cult,/area/wizard_station)
-"tY" = (/obj/structure/table/wood,/obj/item/folder/red,/obj/item/book/manual/wiki/security_space_law,/obj/item/restraints/handcuffs,/obj/item/assembly/flash/handheld,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"tZ" = (/obj/structure/table/wood,/obj/item/folder/red,/obj/item/lighter,/obj/machinery/newscaster{pixel_y = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ua" = (/obj/structure/bookcase/random,/obj/machinery/light,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ub" = (/obj/structure/filingcabinet/medical,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"uc" = (/obj/structure/filingcabinet/security,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ud" = (/obj/machinery/door/poddoor/shutters{id = "nukeop_ready"; name = "shuttle dock"},/turf/open/floor/plating,/area/syndicate_mothership/control)
-"ue" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"uf" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ug" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/machinery/power/apc{dir = 2; name = "Briefing Room APC"; pixel_y = -26},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"uh" = (/obj/machinery/airalarm{dir = 1; pixel_y = -22},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ui" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"uj" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/machinery/light,/obj/structure/noticeboard{dir = 1; pixel_y = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"uk" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/obj/structure/extinguisher_cabinet{pixel_y = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ul" = (/obj/item/radio{pixel_x = 5; pixel_y = 5},/obj/item/radio{pixel_x = -5; pixel_y = 5},/obj/item/radio,/obj/structure/table/wood,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"um" = (/obj/structure/closet/secure_closet/ertMed,/obj/structure/sign/directions/medical{dir = 1; pixel_y = -24},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"un" = (/obj/structure/closet/secure_closet/ertMed,/obj/machinery/vending/wallmed{name = "Emergency NanoMed"; pixel_y = -32; use_power = 0},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uo" = (/obj/structure/table/reinforced,/obj/item/storage/box/emps,/obj/item/gun/energy/ionrifle,/obj/structure/sign/departments/medbay/alt{pixel_y = -32},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"up" = (/obj/structure/table/reinforced,/obj/item/storage/box/syringes,/obj/item/gun/syringe/rapidsyringe,/obj/structure/reagent_dispensers/peppertank{pixel_y = -32},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uq" = (/obj/structure/closet/secure_closet/ertSec,/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"ur" = (/obj/structure/closet/secure_closet/ertSec,/obj/structure/sign/directions/security{dir = 1},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"us" = (/obj/structure/table/wood,/obj/machinery/chem_dispenser/drinks,/turf/open/floor/plasteel/red,/area/centcom/evac)
-"ut" = (/obj/structure/displaycase/trophy,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"uu" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"uv" = (/obj/machinery/vending/boozeomat,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"uw" = (/obj/structure/table/wood,/obj/item/clothing/accessory/lawyers_badge{desc = "A badge of upmost glory."; name = "thunderdome badge"},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"ux" = (/obj/structure/table/wood,/obj/item/clothing/accessory/medal/silver{pixel_y = 5},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"uy" = (/obj/machinery/light{dir = 1},/turf/open/floor/wood,/area/centcom/evac)
-"uz" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uA" = (/obj/structure/chair{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"uB" = (/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"uC" = (/obj/machinery/computer/camera_advanced,/turf/open/floor/wood,/area/wizard_station)
-"uD" = (/obj/structure/table/wood/fancy,/obj/item/radio/intercom{desc = "Talk smack through this."; syndie = 1},/turf/open/floor/wood,/area/wizard_station)
-"uE" = (/turf/open/floor/carpet,/area/wizard_station)
-"uF" = (/obj/structure/chair/wood/wings,/turf/open/floor/carpet,/area/wizard_station)
-"uG" = (/obj/machinery/autolathe/constructionlathe,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"uH" = (/obj/machinery/autolathe/hacked,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"uI" = (/obj/structure/closet/secure_closet/security,/obj/item/storage/belt/security/full,/obj/item/gun/ballistic/automatic/wt550,/obj/item/clothing/head/helmet/swat/nanotrasen,/obj/item/crowbar/red,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uJ" = (/obj/machinery/door/airlock/external{req_access_txt = "150"},/turf/open/floor/plating,/area/syndicate_mothership/control)
-"uK" = (/obj/structure/table/wood,/obj/item/book/manual/barman_recipes,/obj/item/reagent_containers/food/drinks/shaker,/obj/item/reagent_containers/glass/rag,/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"uL" = (/obj/machinery/button/door{id = "nukeop_ready"; name = "mission launch control"; pixel_x = -26; req_access_txt = "151"},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"uM" = (/obj/machinery/computer/telecrystals/uplinker,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/mineral/plastitanium,/area/syndicate_mothership/control)
-"uN" = (/obj/structure/table/reinforced,/obj/machinery/microwave{desc = "Cooks and boils stuff, somehow."; pixel_x = -3; pixel_y = 5},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"uO" = (/obj/structure/table/reinforced,/obj/machinery/reagentgrinder{desc = "Used to grind things up into raw materials and liquids."; pixel_y = 5},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"uP" = (/obj/item/storage/fancy/cigarettes/cigars{pixel_y = 6},/obj/item/storage/fancy/cigarettes/cigars/cohiba{pixel_y = 3},/obj/item/storage/fancy/cigarettes/cigars/havana,/obj/structure/table/wood,/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"uQ" = (/obj/structure/table/wood,/obj/structure/sign/plaques/thunderdome{pixel_y = -32},/obj/item/clothing/accessory/medal/gold{pixel_x = 3; pixel_y = 5},/obj/item/clothing/accessory/medal/gold,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"uR" = (/obj/structure/table/wood,/obj/structure/sign/plaques/thunderdome{pixel_y = -32},/obj/item/clothing/accessory/medal{pixel_y = 5},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"uS" = (/obj/structure/sign/departments/medbay/alt,/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uT" = (/obj/structure/closet/secure_closet/security,/obj/item/storage/belt/security/full,/obj/item/gun/ballistic/automatic/wt550,/obj/item/clothing/head/helmet/swat/nanotrasen,/obj/item/crowbar/red,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uU" = (/obj/structure/table/reinforced,/obj/item/gun/ballistic/automatic/wt550,/obj/item/flashlight/seclite,/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uV" = (/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uW" = (/obj/structure/table/reinforced,/obj/item/gun/ballistic/automatic/wt550,/obj/item/flashlight/seclite,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"uX" = (/obj/structure/closet/secure_closet/freezer/kitchen,/obj/item/reagent_containers/food/snacks/grown/banana,/obj/item/reagent_containers/food/snacks/grown/banana,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/vanillapod,/obj/item/reagent_containers/food/snacks/grown/vanillapod,/obj/item/reagent_containers/food/snacks/grown/sugarcane,/obj/item/reagent_containers/food/snacks/grown/sugarcane,/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/oat,/obj/item/reagent_containers/food/snacks/grown/grapes,/obj/item/reagent_containers/food/snacks/grown/grapes,/obj/item/reagent_containers/food/snacks/grown/corn,/obj/item/reagent_containers/food/snacks/grown/corn,/obj/item/reagent_containers/food/snacks/grown/chili,/obj/item/reagent_containers/food/snacks/grown/chili,/obj/item/reagent_containers/food/snacks/grown/carrot,/obj/item/reagent_containers/food/snacks/grown/apple,/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"uY" = (/obj/structure/closet/secure_closet/freezer/fridge,/obj/item/reagent_containers/food/snacks/grown/potato,/obj/item/reagent_containers/food/snacks/grown/potato,/obj/item/reagent_containers/food/snacks/grown/whitebeet,/obj/item/reagent_containers/food/snacks/grown/whitebeet,/obj/item/reagent_containers/food/snacks/grown/tomato,/obj/item/reagent_containers/food/snacks/grown/tomato,/obj/item/reagent_containers/food/snacks/grown/rice,/obj/item/reagent_containers/food/snacks/grown/rice,/obj/item/reagent_containers/food/snacks/grown/icepepper,/obj/item/reagent_containers/food/snacks/grown/icepepper,/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,/obj/item/reagent_containers/food/snacks/grown/citrus/lime,/obj/item/reagent_containers/food/snacks/grown/citrus/orange,/obj/item/reagent_containers/food/snacks/grown/cherries,/obj/item/reagent_containers/food/snacks/grown/apple,/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,/turf/open/floor/plasteel/red,/area/centcom/evac)
-"uZ" = (/obj/structure/closet/secure_closet/freezer/meat,/obj/item/reagent_containers/food/snacks/meat/rawbacon,/obj/item/reagent_containers/food/snacks/meat/rawbacon,/obj/item/reagent_containers/food/snacks/meat/rawbacon,/obj/item/reagent_containers/food/snacks/meat/rawbacon,/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,/obj/item/reagent_containers/food/snacks/sausage,/obj/item/reagent_containers/food/snacks/sausage,/obj/item/reagent_containers/food/snacks/meat/rawcutlet,/obj/item/reagent_containers/food/snacks/meat/rawcutlet,/obj/item/reagent_containers/food/snacks/meat/rawcutlet,/obj/item/reagent_containers/food/snacks/carpmeat,/obj/item/reagent_containers/food/snacks/carpmeat,/obj/item/reagent_containers/food/snacks/carpmeat,/obj/item/reagent_containers/food/snacks/carpmeat,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"va" = (/obj/structure/closet/secure_closet/freezer/meat,/obj/item/reagent_containers/food/snacks/meat/slab/bear,/obj/item/reagent_containers/food/snacks/meat/slab/bear,/obj/item/reagent_containers/food/snacks/meat/slab/bear,/obj/item/reagent_containers/food/snacks/meat/slab/bear,/obj/item/reagent_containers/food/snacks/meat/slab/goliath,/obj/item/reagent_containers/food/snacks/meat/slab/goliath,/obj/item/reagent_containers/food/snacks/meat/slab/goliath,/obj/item/reagent_containers/food/snacks/meat/slab/goliath,/obj/item/reagent_containers/food/snacks/meat/slab/xeno,/obj/item/reagent_containers/food/snacks/meat/slab/xeno,/obj/item/reagent_containers/food/snacks/meat/slab/xeno,/obj/item/reagent_containers/food/snacks/meat/slab/xeno,/obj/item/reagent_containers/food/snacks/spaghetti,/obj/item/reagent_containers/food/snacks/spaghetti,/obj/item/reagent_containers/food/snacks/meat/rawcutlet,/obj/item/reagent_containers/food/snacks/meat/rawcutlet,/obj/item/reagent_containers/food/snacks/meat/rawcutlet,/turf/open/floor/plasteel/red,/area/centcom/evac)
-"vb" = (/obj/machinery/light,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"vc" = (/obj/machinery/processor,/turf/open/floor/plasteel/red,/area/centcom/evac)
-"vd" = (/obj/structure/table/reinforced,/obj/item/reagent_containers/food/condiment/saltshaker{pixel_x = -8; pixel_y = 5},/obj/item/reagent_containers/food/condiment/peppermill{pixel_x = -8},/obj/item/kitchen/knife,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"ve" = (/obj/docking_port/stationary{dir = 4; dwidth = 1; height = 4; id = "pod2_away"; name = "recovery ship"; width = 3},/turf/open/space,/area/f13/underground/mountain)
-"vf" = (/turf/open/floor/plasteel/blue/side,/area/centcom/evac)
-"vg" = (/turf/open/floor/plasteel/blue/corner{dir = 8},/area/centcom/evac)
-"vh" = (/obj/structure/table/reinforced,/obj/item/reagent_containers/food/snacks/mint,/obj/item/reagent_containers/food/condiment/enzyme{pixel_y = 5},/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"vi" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced,/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"vj" = (/turf/open/floor/wood,/area/wizard_station)
-"vk" = (/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/wood,/area/wizard_station)
-"vl" = (/obj/structure/chair/wood/wings{dir = 4},/turf/open/floor/carpet,/area/wizard_station)
-"vm" = (/obj/structure/table/wood/poker,/obj/item/toy/figure/wizard,/turf/open/floor/carpet,/area/wizard_station)
-"vn" = (/obj/structure/chair/wood/wings{dir = 8},/turf/open/floor/carpet,/area/wizard_station)
-"vo" = (/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/o2{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/obj/machinery/airalarm{dir = 8; pixel_x = 24},/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"vp" = (/obj/machinery/door/airlock/centcom{name = "CentCom"; opacity = 1},/turf/open/floor/plasteel,/area/centcom/evac)
-"vq" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"vr" = (/obj/structure/table/reinforced,/obj/effect/spawner/bundle/costume/waiter,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"vs" = (/obj/machinery/vending/hydronutrients,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"vt" = (/obj/structure/rack,/obj/item/nullrod/claymore/katana{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"vu" = (/obj/item/storage/box/drinkingglasses,/obj/item/reagent_containers/food/drinks/bottle/rum,/obj/structure/table/wood,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"vv" = (/obj/structure/table/wood,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"vw" = (/obj/structure/table/wood,/obj/item/syndicatedetonator{desc = "This gaudy button can be used to instantly detonate syndicate bombs that have been activated on the station. It is also fun to press."},/turf/open/floor/wood,/area/syndicate_mothership/control)
-"vx" = (/obj/structure/table/wood,/obj/item/toy/nuke,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"vy" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"vz" = (/obj/structure/guncase/ecase,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"vA" = (/obj/structure/guncase/shotgun,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"vB" = (/obj/structure/filingcabinet/security,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"vC" = (/obj/machinery/computer/card/centcom,/turf/open/floor/plasteel/darkred/corner{dir = 8},/area/centcom/evac)
-"vD" = (/obj/structure/table,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"vE" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/turf/open/floor/plasteel,/area/centcom/evac)
-"vF" = (/obj/structure/table,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"vG" = (/obj/machinery/computer/card/centcom,/turf/open/floor/plasteel/darkred/corner,/area/centcom/evac)
-"vH" = (/obj/vehicle/ridden/secway,/turf/open/floor/plasteel/darkred/corner{dir = 8},/area/centcom/evac)
-"vI" = (/obj/item/cardboard_cutout{desc = "They seem to be ignoring you... Typical."; dir = 1; icon_state = "cutout_ntsec"; name = "Private Security Officer"},/turf/open/floor/plasteel/darkred/side{dir = 8},/area/centcom/evac)
-"vJ" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/table/reinforced,/obj/item/book/manual/wiki/security_space_law,/turf/open/floor/plasteel,/area/centcom/evac)
-"vK" = (/obj/machinery/light/floor,/turf/open/floor/plasteel,/area/centcom/evac)
-"vL" = (/obj/structure/chair{dir = 8},/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"vM" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/table/reinforced,/obj/item/book/manual/wiki/security_space_law,/turf/open/floor/plasteel,/area/centcom/evac)
-"vN" = (/obj/item/cardboard_cutout{desc = "They seem to be ignoring you... Typical."; dir = 1; icon_state = "cutout_ntsec"; name = "Private Security Officer"},/turf/open/floor/plasteel/darkred/side{dir = 4},/area/centcom/evac)
-"vO" = (/turf/open/floor/plasteel/darkred/side{dir = 10},/area/centcom/evac)
-"vP" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"vQ" = (/obj/item/cardboard_cutout{desc = "They seem to be ignoring you... Typical."; icon_state = "cutout_ntsec"; name = "Private Security Officer"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"vR" = (/obj/structure/chair/office/dark{dir = 4},/turf/open/floor/plasteel/darkred/side{dir = 8},/area/centcom/evac)
-"vS" = (/obj/machinery/door/window/brigdoor{name = "CentCom Customs"; icon_state = "rightsecure"; dir = 4; req_access_txt = "109"; base_state = "rightsecure"},/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"vT" = (/obj/machinery/door/window/brigdoor{name = "CentCom Customs"; icon_state = "rightsecure"; dir = 8; req_access_txt = "109"; base_state = "rightsecure"},/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"vU" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/darkred/side{dir = 4},/area/centcom/evac)
-"vV" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/turf/open/space/basic,/area/centcom/evac)
-"vW" = (/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"vX" = (/turf/open/floor/plasteel/blue,/area/centcom/evac)
-"vY" = (/turf/open/floor/plasteel/blue/side{dir = 4},/area/centcom/evac)
-"vZ" = (/turf/open/floor/plasteel/blue/side{dir = 8},/area/centcom/evac)
-"wa" = (/turf/open/floor/plasteel/darkred/side{dir = 6},/area/centcom/evac)
-"wb" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Observation Room"},/turf/open/floor/engine/cult,/area/wizard_station)
-"wc" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Game Room"},/turf/open/floor/engine/cult,/area/wizard_station)
-"wd" = (/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/carpet,/area/wizard_station)
-"we" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/corner{dir = 4},/area/centcom/evac)
-"wf" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"wg" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"wh" = (/obj/machinery/recharger,/obj/structure/table/reinforced,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wi" = (/obj/machinery/computer/secure_data{dir = 1},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wj" = (/obj/machinery/computer/security{dir = 1},/turf/open/floor/plasteel/darkred/side{dir = 8},/area/centcom/evac)
-"wk" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"wl" = (/obj/machinery/light,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"wm" = (/obj/effect/landmark/start/nukeop_leader,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"wn" = (/turf/open/floor/wood,/area/syndicate_mothership/control)
-"wo" = (/obj/machinery/door/window{base_state = "right"; dir = 4; icon_state = "right"; name = "Uplink Management Control"; req_access_txt = "151"},/turf/open/floor/wood,/area/syndicate_mothership/control)
-"wp" = (/obj/machinery/light,/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"wq" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/table/reinforced,/turf/open/floor/plasteel,/area/centcom/evac)
-"wr" = (/obj/machinery/computer/security{dir = 1},/turf/open/floor/plasteel/darkred/side{dir = 4},/area/centcom/evac)
-"ws" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"wt" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel/darkred/corner{dir = 1},/area/centcom/evac)
-"wu" = (/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/obj/machinery/light/small{dir = 8},/obj/vehicle/ridden/atv,/obj/item/key,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wv" = (/obj/machinery/light,/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"ww" = (/obj/structure/closet/secure_closet/security,/obj/item/storage/belt/security/full,/obj/item/gun/ballistic/automatic/wt550,/obj/item/clothing/head/helmet/swat/nanotrasen,/obj/item/crowbar/red,/turf/open/floor/plasteel/darkred/corner{dir = 1},/area/centcom/evac)
-"wx" = (/obj/structure/closet/secure_closet/security,/obj/item/storage/belt/security/full,/obj/item/gun/ballistic/automatic/wt550,/obj/item/clothing/head/helmet/swat/nanotrasen,/obj/item/crowbar/red,/turf/open/floor/plasteel/darkred/corner{dir = 4},/area/centcom/evac)
-"wy" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wz" = (/obj/structure/closet/secure_closet/security,/obj/item/storage/belt/security/full,/obj/item/gun/ballistic/automatic/wt550,/obj/item/clothing/head/helmet/swat/nanotrasen,/obj/item/crowbar/red,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wA" = (/obj/structure/sign/departments/security,/turf/closed/wall/f13/vault,/area/centcom/evac)
-"wB" = (/obj/structure/vault_door/old{max_integrity = 1000; obj_integrity = 1000},/turf/open/floor/plasteel,/area/centcom/evac)
-"wC" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/centcom/evac)
-"wD" = (/obj/machinery/door/airlock/centcom{name = "CentCom"; opacity = 1},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wE" = (/obj/machinery/door/airlock/centcom{name = "CentCom"; opacity = 1},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wF" = (/obj/machinery/shower{dir = 4},/turf/open/floor/plasteel/whitegreen/side{dir = 9},/area/centcom/evac)
-"wG" = (/obj/machinery/door/airlock/centcom{name = "CentCom Security"; opacity = 1; req_access_txt = "101"},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wH" = (/obj/machinery/shower{dir = 8},/turf/open/floor/plasteel/whitegreen/side{dir = 5},/area/centcom/evac)
-"wI" = (/obj/effect/turf_decal/stripes/line{dir = 4},/obj/machinery/light/small{dir = 4},/obj/vehicle/ridden/atv,/obj/item/key,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"wJ" = (/obj/machinery/door/firedoor,/obj/machinery/door/airlock/centcom{name = "CentCom"; opacity = 1},/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"wK" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"wL" = (/obj/item/soap/nanotrasen,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"wM" = (/obj/structure/chair/wood/wings{dir = 8},/turf/open/floor/wood,/area/wizard_station)
-"wN" = (/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/engine/cult,/area/wizard_station)
-"wO" = (/obj/machinery/light/small{dir = 4},/turf/open/floor/engine/cult,/area/wizard_station)
-"wP" = (/obj/structure/table/wood/fancy,/obj/item/camera/spooky,/turf/open/floor/carpet,/area/wizard_station)
-"wQ" = (/obj/structure/table/wood/poker,/obj/item/toy/cards/deck,/turf/open/floor/carpet,/area/wizard_station)
-"wR" = (/obj/machinery/shower{dir = 4},/turf/open/floor/plasteel/whitegreen/corner{dir = 1},/area/centcom/evac)
-"wS" = (/turf/closed/wall/f13/vault,/area/f13/underground/mountain)
-"wT" = (/obj/machinery/shower{dir = 4},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"wU" = (/obj/machinery/door/airlock/silver{name = "Shower"},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"wV" = (/obj/machinery/computer/telecrystals/boss{dir = 1},/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/mineral/plastitanium,/area/syndicate_mothership/control)
-"wW" = (/obj/structure/sign/map/left{pixel_y = -32},/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi'; icon_state = "minibar_left"; name = "skeletal minibar"},/obj/item/reagent_containers/food/drinks/bottle/vodka,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"wX" = (/obj/structure/sign/map/right{pixel_y = -32},/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi'; icon_state = "minibar_right"; name = "skeletal minibar"},/obj/item/reagent_containers/food/drinks/bottle/gin,/turf/open/floor/wood,/area/syndicate_mothership/control)
-"wY" = (/obj/machinery/door/airlock/centcom{name = "Equipment Room"; opacity = 1; req_access_txt = "150"},/turf/open/floor/plasteel/bar{dir = 2},/area/syndicate_mothership/control)
-"wZ" = (/obj/structure/fluff/arc,/turf/open/floor/plasteel,/area/centcom/evac)
-"xa" = (/obj/structure/table,/obj/structure/bedsheetbin,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/whitered/side{dir = 8},/area/centcom/evac)
-"xb" = (/obj/docking_port/stationary{dir = 4; dwidth = 2; height = 7; id = "pod1_away"; name = "recovery ship"; width = 5},/turf/open/space,/area/f13/underground/mountain)
-"xc" = (/obj/machinery/door/airlock/silver{name = "Shower"},/turf/open/floor/plasteel,/area/centcom/evac)
-"xd" = (/obj/structure/table,/obj/structure/bedsheetbin,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/whitegreen/side{dir = 4},/area/centcom/evac)
-"xe" = (/obj/structure/sink{dir = 8; pixel_x = -12},/obj/structure/mirror{pixel_x = -28},/turf/open/floor/plasteel/whitered/corner{dir = 1},/area/centcom/evac)
-"xf" = (/obj/structure/closet/secure_closet/personal,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"xg" = (/obj/structure/sink{dir = 4; pixel_x = 11},/obj/structure/mirror{pixel_x = 28},/turf/open/floor/plasteel/whitegreen/corner{dir = 4},/area/centcom/evac)
-"xh" = (/obj/structure/sink{dir = 8; pixel_x = -12},/obj/structure/mirror{pixel_x = -28},/turf/open/floor/plasteel/white,/area/centcom/evac)
-"xi" = (/obj/structure/safe,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"xj" = (/obj/machinery/light{dir = 1},/obj/structure/chalkboard,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"xk" = (/obj/structure/sink{dir = 4; pixel_x = 11},/obj/structure/mirror{pixel_x = 28},/turf/open/floor/plasteel/whitegreen/corner,/area/centcom/evac)
-"xl" = (/obj/structure/noticeboard{pixel_y = 28},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"xm" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-22"},/obj/machinery/light,/turf/open/floor/plasteel,/area/centcom/evac)
-"xn" = (/obj/machinery/vending/donksofttoyvendor,/turf/open/floor/plasteel,/area/centcom/evac)
-"xo" = (/obj/machinery/vending/snack,/turf/open/floor/plasteel,/area/centcom/evac)
-"xp" = (/obj/structure/table/reinforced,/obj/item/gun/ballistic/shotgun/toy/crossbow,/turf/open/floor/plasteel,/area/centcom/evac)
-"xq" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel,/area/centcom/evac)
-"xr" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/sign/directions/engineering{desc = "A sign that shows there are doors here. There are doors everywhere!"; icon_state = "doors"; name = "WARNING: BLAST DOORS"},/turf/open/floor/plating,/area/centcom/evac)
-"xs" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-05"; pixel_y = 10},/obj/machinery/light,/turf/open/floor/plasteel,/area/centcom/evac)
-"xt" = (/obj/machinery/vending/cigarette,/turf/open/floor/plasteel,/area/centcom/evac)
-"xu" = (/obj/machinery/light,/turf/open/floor/wood,/area/wizard_station)
-"xv" = (/obj/item/statuebust{pixel_y = 12},/obj/structure/table/wood/fancy,/turf/open/floor/wood,/area/wizard_station)
-"xw" = (/obj/machinery/vending/magivend,/turf/open/floor/engine/cult,/area/wizard_station)
-"xx" = (/obj/machinery/vending/snack,/turf/open/floor/engine/cult,/area/wizard_station)
-"xy" = (/obj/structure/table/wood/fancy,/obj/item/storage/pill_bottle/dice{icon_state = "magicdicebag"},/turf/open/floor/carpet,/area/wizard_station)
-"xz" = (/obj/structure/table/wood/fancy,/obj/item/storage/photo_album,/obj/machinery/light,/turf/open/floor/carpet,/area/wizard_station)
-"xA" = (/obj/machinery/vending/cola,/turf/open/floor/plasteel,/area/centcom/evac)
-"xB" = (/obj/machinery/vending/toyliberationstation,/turf/open/floor/plasteel,/area/centcom/evac)
-"xC" = (/obj/machinery/vending/wallmed{name = "Emergency NanoMed"; pixel_y = 32; use_power = 0},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"xD" = (/turf/open/floor/plasteel/stairs/medium,/area/centcom/evac)
-"xE" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"xF" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"xG" = (/turf/open/floor/plasteel/dark,/area/syndicate_mothership/control)
-"xH" = (/obj/machinery/mech_bay_recharge_port,/turf/open/floor/plating,/area/syndicate_mothership/control)
-"xI" = (/obj/machinery/light{dir = 1},/turf/open/floor/mech_bay_recharge_floor,/area/syndicate_mothership/control)
-"xJ" = (/obj/machinery/computer/mech_bay_power_console,/turf/open/floor/plating,/area/syndicate_mothership/control)
-"xK" = (/obj/machinery/vending/tool,/turf/open/floor/plasteel/dark,/area/syndicate_mothership/control)
-"xL" = (/obj/structure/closet/cardboard/metal,/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"xM" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"xN" = (/obj/docking_port/stationary{area_type = /area/syndicate_mothership/control; dir = 1; dwidth = 3; height = 7; name = "escape pod loader"; roundstart_template = /datum/map_template/shuttle/assault_pod/default; width = 7},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"xO" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"xP" = (/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"xQ" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/grass,/area/centcom/evac)
-"xR" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"xS" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"xT" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"xU" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"xV" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"xW" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"xX" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"xY" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass,/area/centcom/evac)
-"xZ" = (/turf/open/floor/plasteel/blue/corner{dir = 4},/area/centcom/evac)
-"ya" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Study"},/turf/open/floor/engine/cult,/area/wizard_station)
-"yb" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Break Room"},/turf/open/floor/engine/cult,/area/wizard_station)
-"yc" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/ppflowers,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"yd" = (/obj/structure/flora/ausbushes/fernybush,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/obj/machinery/light{dir = 8},/turf/open/floor/grass,/area/centcom/holding)
-"ye" = (/obj/structure/chalkboard,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"yf" = (/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yg" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"yh" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yi" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/grass,/area/centcom/evac)
-"yj" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"yk" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/plating/airless,/area/syndicate_mothership/control)
-"yl" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"ym" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yn" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yo" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yp" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/grass,/area/centcom/evac)
-"yq" = (/obj/machinery/telecomms/relay/preset/mining,/obj/machinery/light/small{dir = 1},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"yr" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"ys" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yt" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/tree/jungle/small,/turf/open/floor/grass,/area/centcom/evac)
-"yu" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yv" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/tree/jungle/small,/turf/open/floor/grass,/area/centcom/evac)
-"yw" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass,/area/centcom/evac)
-"yx" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yy" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"yz" = (/obj/item/storage/secure/safe{pixel_x = 32; pixel_y = 24},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"yA" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yB" = (/turf/open/floor/plasteel/blue/corner{dir = 1},/area/centcom/evac)
-"yC" = (/obj/structure/chair/wood/wings,/turf/open/floor/engine/cult,/area/wizard_station)
-"yD" = (/obj/structure/table/wood,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/turf/open/floor/engine/cult,/area/wizard_station)
-"yE" = (/obj/structure/table/wood,/obj/item/retractor,/obj/machinery/light{dir = 1},/turf/open/floor/engine/cult,/area/wizard_station)
-"yF" = (/obj/structure/table/wood,/obj/item/clothing/suit/wizrobe/magusblue,/obj/item/clothing/head/wizard/magus,/obj/item/staff,/obj/structure/mirror/magic{pixel_y = 28},/obj/machinery/light{dir = 1},/turf/open/floor/engine/cult,/area/wizard_station)
-"yG" = (/obj/structure/table/wood,/obj/item/clothing/suit/wizrobe/magusred,/obj/item/clothing/head/wizard/magus,/obj/item/staff,/turf/open/floor/engine/cult,/area/wizard_station)
-"yH" = (/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,/turf/open/floor/grass,/area/wizard_station)
-"yI" = (/obj/effect/decal/cleanable/blood/splatter,/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/grass,/area/wizard_station)
-"yJ" = (/obj/effect/decal/remains/xeno/larva,/turf/open/floor/grass,/area/wizard_station)
-"yK" = (/obj/effect/decal/cleanable/blood/splatter,/turf/open/floor/grass,/area/wizard_station)
-"yL" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/tree/jungle,/turf/open/floor/grass,/area/centcom/evac)
-"yM" = (/obj/structure/table/wood/bar,/obj/structure/safe/floor,/obj/item/seeds/cherry/bomb,/turf/open/floor/wood,/area/centcom/holding)
-"yN" = (/obj/structure/flora/stump,/turf/open/floor/grass,/area/centcom/evac)
-"yO" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yP" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"yQ" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"yR" = (/obj/machinery/computer/security/telescreen/entertainment{pixel_x = -32},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"yS" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/grass,/area/centcom/evac)
-"yT" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"yU" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/fullgrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"yV" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"yW" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"yX" = (/obj/structure/chair/stool,/turf/open/floor/plasteel/dark,/area/syndicate_mothership/control)
-"yY" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/fullgrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"yZ" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"za" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zb" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/brflowers,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zc" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zd" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"ze" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zf" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zg" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zh" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ppflowers,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zi" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zj" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"zk" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/tree/palm,/turf/open/floor/grass,/area/centcom/evac)
-"zl" = (/turf/open/floor/plasteel/blue/side{dir = 1},/area/centcom/evac)
-"zm" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/tree/palm,/turf/open/floor/grass,/area/centcom/evac)
-"zn" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/fullgrass,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zo" = (/obj/structure/destructible/cult/tome,/turf/open/floor/engine/cult,/area/wizard_station)
-"zp" = (/obj/structure/closet/crate{icon_state = "crateopen"},/obj/item/clothing/suit/wizrobe/red,/obj/item/clothing/head/wizard/red,/obj/item/staff,/obj/item/clothing/shoes/sandal/magic,/turf/open/floor/engine/cult,/area/wizard_station)
-"zq" = (/turf/open/floor/grass,/area/wizard_station)
-"zr" = (/obj/item/reagent_containers/food/snacks/meat/slab/corgi,/turf/open/floor/grass,/area/wizard_station)
-"zs" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zt" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zu" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zv" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zw" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zx" = (/obj/structure/filingcabinet/security,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"zy" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zz" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/grass,/area/centcom/evac)
-"zA" = (/obj/structure/filingcabinet/employment,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"zB" = (/obj/machinery/newscaster/security_unit{pixel_x = 32},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"zC" = (/turf/open/indestructible/ground/outside/road{icon_state = "innershade"},/area/centcom/evac)
-"zD" = (/turf/open/indestructible/ground/outside/desert,/area/centcom/evac)
-"zE" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zF" = (/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/tree/palm,/turf/open/floor/grass,/area/centcom/evac)
-"zG" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zH" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/grass,/area/centcom/evac)
-"zI" = (/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/tree/jungle/small,/turf/open/floor/grass,/area/centcom/evac)
-"zJ" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zK" = (/turf/open/floor/plating/f13/outside/road,/area/centcom/evac)
-"zL" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zM" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zN" = (/obj/structure/bookcase/random/reference,/turf/open/floor/engine/cult,/area/wizard_station)
-"zO" = (/obj/structure/destructible/cult/talisman{desc = "An altar dedicated to the Wizards' Federation"},/obj/item/kitchen/knife/ritual,/turf/open/floor/engine/cult,/area/wizard_station)
-"zP" = (/obj/item/clothing/shoes/sandal/marisa,/obj/item/clothing/suit/wizrobe/marisa,/obj/item/clothing/head/wizard/marisa,/obj/item/staff/broom,/turf/open/floor/engine/cult,/area/wizard_station)
-"zQ" = (/obj/effect/decal/cleanable/blood/splatter,/mob/living/simple_animal/hostile/netherworld{name = "Experiment 35b"},/turf/open/floor/grass,/area/wizard_station)
-"zR" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/ppflowers,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zS" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zT" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/turf/open/floor/grass,/area/centcom/evac)
-"zU" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/tree/palm,/obj/machinery/light/floor,/turf/open/floor/grass,/area/centcom/evac)
-"zV" = (/obj/structure/closet/secure_closet/freezer/meat{locked = 0},/obj/machinery/atmospherics/components/unary/vent_scrubber/on{dir = 4},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"zW" = (/obj/vehicle/ridden/atv,/obj/item/key,/turf/open/floor/plasteel/darkred/side{dir = 9},/area/centcom/evac)
-"zX" = (/obj/structure/table,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"zY" = (/obj/vehicle/ridden/atv,/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"zZ" = (/obj/vehicle/ridden/bicycle,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"Aa" = (/obj/vehicle/ridden/janicart/upgraded,/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"Ab" = (/obj/vehicle/ridden/lavaboat/dragon,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"Ac" = (/obj/vehicle/ridden/secway,/turf/open/floor/plasteel/darkred/side{dir = 5},/area/centcom/evac)
-"Ad" = (/obj/structure/chair/office/dark{dir = 4},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"Ae" = (/obj/structure/table/reinforced,/obj/item/paper_bin,/obj/item/pen/fourcolor,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"Af" = (/obj/structure/table/reinforced,/obj/item/storage/fancy/donut_box,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"Ag" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"Ah" = (/obj/effect/turf_decal/bot/left,/turf/open/floor/plasteel,/area/centcom/evac)
-"Ai" = (/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/centcom/evac)
-"Aj" = (/obj/effect/turf_decal/bot/right,/turf/open/floor/plasteel,/area/centcom/evac)
-"Ak" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"Al" = (/obj/structure/closet/firecloset/full,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"Am" = (/obj/structure/closet/radiation,/turf/open/floor/wood,/area/centcom/evac)
-"An" = (/obj/machinery/light{dir = 1},/obj/structure/closet/wardrobe/mixed,/turf/open/floor/wood,/area/centcom/evac)
-"Ao" = (/obj/structure/table/wood,/turf/open/floor/wood,/area/centcom/evac)
-"Ap" = (/obj/structure/table/wood,/obj/effect/spawner/lootdrop/armory_contraband,/turf/open/floor/wood,/area/centcom/evac)
-"Aq" = (/obj/machinery/light{dir = 1},/obj/structure/closet/secure_closet/tac,/turf/open/floor/wood,/area/centcom/evac)
-"Ar" = (/obj/structure/closet/secure_closet/armory2,/turf/open/floor/wood,/area/centcom/evac)
-"As" = (/obj/structure/closet/secure_closet/armory3,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"At" = (/turf/open/floor/plating/f13/outside/road{icon_state = "cross1"},/area/centcom/evac)
-"Au" = (/obj/machinery/abductor/experiment{team_number = 3},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"Av" = (/obj/machinery/abductor/console{team_number = 3},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"Aw" = (/obj/machinery/abductor/pad{team_number = 3},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"Ax" = (/turf/closed/indestructible/fakeglass{color = "#008000"},/area/wizard_station)
-"Ay" = (/obj/effect/landmark/start/wizard,/turf/open/floor/engine/cult,/area/wizard_station)
-"Az" = (/obj/effect/decal/remains/human,/obj/effect/decal/cleanable/blood/splatter,/turf/open/floor/grass,/area/wizard_station)
-"AA" = (/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,/turf/open/floor/grass,/area/wizard_station)
-"AB" = (/obj/effect/decal/remains/xeno,/turf/open/floor/grass,/area/wizard_station)
-"AC" = (/obj/effect/turf_decal/delivery,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"AD" = (/obj/machinery/door/airlock/centcom{name = "CentCom Supply"; req_access_txt = "106"},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"AE" = (/obj/structure/table/reinforced,/obj/item/storage/firstaid/regular{pixel_x = 2; pixel_y = 3},/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"AF" = (/obj/machinery/workbench/advanced,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"AG" = (/obj/structure/ladder/unbreakable/binary/space,/turf/open/indestructible/airblock,/area/fabric_of_reality)
-"AH" = (/obj/structure/curtain,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"AI" = (/obj/machinery/door/airlock/centcom{name = "CentCom Supply"; req_access_txt = "106"},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"AJ" = (/obj/structure/table/reinforced,/obj/item/storage/fancy/cigarettes/cigars/havana,/obj/item/storage/fancy/cigarettes/cigars/havana,/obj/item/storage/fancy/cigarettes/cigars/havana,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"AK" = (/obj/machinery/workbench,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"AL" = (/obj/vehicle/ridden/space/speedwagon,/turf/open/indestructible/ground/outside/road{icon_state = "innershade"},/area/centcom/evac)
-"AM" = (/turf/open/floor/plasteel/darkred/side{dir = 5},/area/centcom/evac)
-"AN" = (/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"AO" = (/obj/machinery/door/airlock/centcom{name = "CentCom Supply"; req_access_txt = "106"},/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"AP" = (/turf/open/floor/plasteel/darkred/side{dir = 9},/area/centcom/evac)
-"AQ" = (/obj/structure/table/reinforced,/obj/item/storage/secure/briefcase,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"AR" = (/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/clipboard,/obj/item/storage/toolbox/mechanical,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"AS" = (/obj/structure/closet/gimmick/tacticool,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"AT" = (/obj/structure/closet/gimmick/russian,/turf/open/floor/wood,/area/centcom/evac)
-"AU" = (/obj/machinery/light,/obj/structure/closet/syndicate/resources/everything,/turf/open/floor/wood,/area/centcom/evac)
-"AV" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel,/area/centcom/evac)
-"AW" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"AX" = (/obj/structure/table/wood,/obj/effect/spawner/lootdrop/clothing_legend,/turf/open/floor/wood,/area/centcom/evac)
-"AY" = (/obj/machinery/light,/obj/structure/closet/secure_closet/security/sec,/turf/open/floor/wood,/area/centcom/evac)
-"AZ" = (/obj/structure/closet/secure_closet/warden,/turf/open/floor/wood,/area/centcom/evac)
-"Ba" = (/obj/item/twohanded/required/kirbyplants{icon_state = "plant-21"},/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/centcom/evac)
-"Bb" = (/obj/structure/closet/secure_closet/armory1,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"Bc" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/centcom/evac)
-"Bd" = (/obj/vehicle/ridden/scooter,/turf/open/floor/plasteel/darkred/side{dir = 10},/area/centcom/evac)
-"Be" = (/obj/machinery/computer/camera_advanced/abductor{team_number = 3},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"Bf" = (/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/engine/cult,/area/wizard_station)
-"Bg" = (/mob/living/simple_animal/bot/medbot/mysterious{desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway."; faction = list("neutral","silicon","creature"); name = "Nobody's Perfect"},/turf/open/floor/engine/cult,/area/wizard_station)
-"Bh" = (/obj/machinery/light,/turf/open/floor/engine/cult,/area/wizard_station)
-"Bi" = (/obj/item/reagent_containers/food/snacks/meat/slab/xeno,/turf/open/floor/grass,/area/wizard_station)
-"Bj" = (/obj/vehicle/ridden/scooter/skateboard,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"Bk" = (/obj/vehicle/ridden/space/speedbike,/obj/machinery/light,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"Bl" = (/obj/machinery/light,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"Bm" = (/obj/vehicle/ridden/space/speedbike/red,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"Bn" = (/obj/item/twohanded/required/kirbyplants,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"Bo" = (/obj/structure/table,/obj/machinery/reagentgrinder,/obj/item/reagent_containers/glass/beaker/large,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Bp" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/grimy,/area/centcom/evac)
-"Bq" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/effect/spawner/bundle/costume/plaguedoctor,/turf/open/floor/plasteel/cmo,/area/centcom/evac)
-"Br" = (/obj/machinery/light{dir = 1},/obj/machinery/doorButtons/wornvaultButton,/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"Bs" = (/obj/structure/table/wood,/obj/machinery/computer/libraryconsole/bookmanagement,/turf/open/floor/wood,/area/centcom/holding)
-"Bt" = (/obj/structure/tank_dispenser/plasma,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"Bu" = (/obj/structure/tank_dispenser/oxygen,/turf/open/floor/plasteel/dark,/area/centcom/evac)
-"Bv" = (/turf/open/indestructible/ground/outside/sidewalk{dir = 1; icon_state = "outerturn"},/area/centcom/evac)
-"Bw" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "horizontalbottomborderbottom0"},/area/centcom/evac)
-"Bx" = (/turf/open/indestructible/ground/outside/sidewalk{dir = 4; icon_state = "outerturn"},/area/centcom/evac)
-"By" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "verticalrightborderright0"},/area/centcom/evac)
-"Bz" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "transition3"},/area/centcom/evac)
-"BA" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "horizontaloutermain0"},/area/centcom/evac)
-"BB" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "transition4"},/area/centcom/evac)
-"BC" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "verticalleftborderleft2"},/area/centcom/evac)
-"BD" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "verticaloutermain0"},/area/centcom/evac)
-"BE" = (/obj/structure/flora/tree/jungle,/turf/open/indestructible/ground/outside/desert,/area/centcom/evac)
-"BF" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "verticalrightborderright2bottom"},/area/centcom/evac)
-"BG" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "verticalleftborderleft3"},/area/centcom/evac)
-"BH" = (/obj/vehicle/ridden/secway,/obj/machinery/button/door{id = "nukeop_ready"; name = "mission launch control"; pixel_x = -26; req_access_txt = "151"},/turf/open/floor/plasteel/darkred/corner,/area/centcom/evac)
-"BI" = (/obj/machinery/light{dir = 1},/obj/machinery/button/door{id = "XCCFerry"; name = "Hanger Bay Shutters"; pixel_y = 24; req_access_txt = "2"},/turf/open/floor/plasteel/darkred/side,/area/centcom/evac)
-"BJ" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "transition1"},/area/centcom/evac)
-"BK" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "transition2"},/area/centcom/evac)
-"BL" = (/turf/open/indestructible/ground/outside/sidewalk{dir = 8; icon_state = "outerturn"},/area/centcom/evac)
-"BM" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "horizontaltopbordertop0"},/area/centcom/evac)
-"BN" = (/turf/open/indestructible/ground/outside/sidewalk{icon_state = "outerturn"},/area/centcom/evac)
-"BO" = (/obj/machinery/button/door{dir = 2; id = "XCCQMLoaddoor2"; layer = 4; name = "Loading Doors"; pixel_x = -27; pixel_y = 5},/obj/machinery/button/door{id = "XCCQMLoaddoor"; layer = 4; name = "Loading Doors"; pixel_x = -27; pixel_y = -5},/turf/open/floor/plasteel/darkred/side{dir = 4},/area/centcom/evac)
-"BP" = (/turf/closed/indestructible/opshuttle,/area/f13/underground/mountain)
-"BQ" = (/obj/effect/landmark/abductor/scientist{team_number = 3},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"BR" = (/obj/effect/landmark/abductor/agent{team_number = 3},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"BS" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Observation Deck"},/turf/open/floor/engine/cult,/area/wizard_station)
-"BT" = (/turf/open/floor/plasteel/dark,/area/f13/underground/mountain)
-"BU" = (/turf/open/floor/plasteel/stairs,/area/f13/underground/mountain)
-"BV" = (/obj/machinery/chem_dispenser/drinks/beer,/turf/closed/indestructible{icon = 'icons/turf/walls/wood_wall.dmi'; icon_state = "wood"; smooth = 1},/area/centcom/holding)
-"BW" = (/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"BX" = (/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"BY" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"BZ" = (/obj/effect/turf_decal/loading_area{dir = 8},/turf/open/floor/plasteel,/area/centcom/evac)
-"Ca" = (/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel,/area/centcom/evac)
-"Cb" = (/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"Cc" = (/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"Cd" = (/obj/vehicle/ridden/secway,/obj/machinery/button/door{id = "lmrestroom"; name = "Lock Control"; pixel_y = -28},/turf/open/floor/plasteel/darkred/corner{dir = 4},/area/centcom/evac)
-"Ce" = (/obj/structure/table/reinforced,/obj/item/restraints/handcuffs/cable/zipties,/obj/item/assembly/flash/handheld,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"Cf" = (/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"Cg" = (/obj/machinery/button/door{id = "XCCsec1"; name = "CC Shutter 1 Control"; pixel_y = -24},/obj/machinery/button/door{id = "XCCFerry"; name = "Hanger Bay Shutters"; pixel_y = -38},/turf/open/floor/plasteel/darkred/side{dir = 1},/area/centcom/evac)
-"Ch" = (/obj/machinery/button/door{id = "thunderdomegen"; name = "General Supply Control"; req_access_txt = "102"},/turf/closed/wall/f13/vault,/area/centcom/evac)
-"Ci" = (/obj/machinery/light{dir = 1},/turf/open/floor/engine/cult,/area/wizard_station)
-"Cj" = (/obj/machinery/button/door{id = "thunderdomehea"; name = "Heavy Supply Control"; req_access_txt = "102"},/turf/closed/wall/f13/vault,/area/centcom/evac)
-"Ck" = (/obj/effect/turf_decal/stripes/line{icon_state = "warningline"; dir = 8},/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"Cl" = (/obj/machinery/button/door{id = "thunderdome"; name = "Main Blast Doors Control"; req_access_txt = "102"},/turf/closed/wall/f13/vault,/area/centcom/evac)
-"Cm" = (/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"Cn" = (/obj/effect/turf_decal/stripes/line{dir = 9},/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/cobweb,/turf/open/floor/plasteel,/area/centcom/evac)
-"Co" = (/obj/effect/turf_decal/caution,/turf/open/floor/plasteel,/area/centcom/evac)
-"Cp" = (/turf/open/space/basic,/area/syndicate_mothership)
-"Cq" = (/turf/closed/indestructible/opshuttle,/area/centcom/evac)
-"Cr" = (/obj/effect/decal/cleanable/cobweb,/turf/open/floor/plasteel,/area/centcom/evac)
-"Cs" = (/obj/structure/table/reinforced,/obj/effect/turf_decal/delivery,/obj/item/banhammer,/turf/open/floor/plasteel,/area/centcom/evac)
-"Ct" = (/obj/effect/turf_decal/caution,/turf/open/floor/plasteel/blue/corner{dir = 8},/area/centcom/evac)
-"Cu" = (/obj/effect/turf_decal/caution,/turf/open/floor/plasteel/blue/corner,/area/centcom/evac)
-"Cv" = (/obj/machinery/shower{dir = 4},/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/whitered/side{dir = 9},/area/centcom/evac)
-"Cw" = (/obj/machinery/light{dir = 1},/obj/effect/decal/cleanable/molten_object/large,/turf/open/floor/plasteel/whitered/side{dir = 1},/area/centcom/evac)
-"Cx" = (/obj/effect/turf_decal/stripes/line{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/centcom/evac)
-"Cy" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/centcom/evac)
-"Cz" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/blue,/area/centcom/evac)
-"CA" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/blue/side{dir = 4},/area/centcom/evac)
-"CB" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/centcom/evac)
-"CC" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/blue/side{dir = 8},/area/centcom/evac)
-"CD" = (/obj/machinery/light{dir = 1},/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/whitegreen/side{dir = 1},/area/centcom/evac)
-"CE" = (/obj/machinery/shower{dir = 4},/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/whitered/corner{dir = 1},/area/centcom/evac)
-"CF" = (/obj/machinery/light/floor,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/centcom/evac)
-"CG" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/blue/side{dir = 4},/area/centcom/evac)
-"CH" = (/obj/machinery/light/floor,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/centcom/evac)
-"CI" = (/obj/machinery/shower{dir = 8},/obj/effect/spawner/bundle/costume/sexyclown,/turf/open/floor/plasteel/whitegreen/corner{dir = 4},/area/centcom/evac)
-"CJ" = (/obj/machinery/shower{dir = 4},/obj/effect/spawner/bundle/costume/nyangirl,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"CK" = (/obj/machinery/shower{dir = 8},/obj/effect/decal/cleanable/molten_object/large,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"CL" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/blue,/area/centcom/evac)
-"CM" = (/obj/structure/sink{dir = 4; pixel_x = 11},/obj/structure/mirror{pixel_x = 28},/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"CN" = (/obj/structure/sink{dir = 8; pixel_x = -12},/obj/structure/mirror{pixel_x = -28},/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/whitered/corner{dir = 8},/area/centcom/evac)
-"CO" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"CP" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/blue/side{dir = 1},/area/centcom/evac)
-"CQ" = (/turf/open/floor/plasteel/vault{dir = 5},/area/centcom/evac)
-"CR" = (/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/white,/area/centcom/evac)
-"CS" = (/obj/machinery/washing_machine,/obj/effect/decal/cleanable/molten_object,/obj/effect/decal/cleanable/molten_object,/turf/open/floor/plasteel/whitered/side{dir = 8},/area/centcom/evac)
-"CT" = (/obj/machinery/vr_sleeper{dir = 4},/turf/open/floor/wood,/area/centcom/holding)
-"CU" = (/obj/machinery/washing_machine,/obj/effect/decal/cleanable/leaper_sludge,/turf/open/floor/plasteel/whitegreen/side{dir = 4},/area/centcom/evac)
-"CV" = (/obj/structure/chair/stool,/turf/open/floor/wood,/area/centcom/holding)
-"CW" = (/obj/effect/decal/cleanable/leaper_sludge,/turf/open/floor/plasteel/stairs/left,/area/centcom/evac)
-"CX" = (/obj/structure/wreck/trash/machinepile,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"CY" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"CZ" = (/obj/structure/billboard/cola/pristine,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Da" = (/obj/structure/billboard/ritas/pristine,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Db" = (/obj/structure/wreck/trash/two_barrels,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dc" = (/obj/structure/wreck/trash/two_tire,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dd" = (/obj/structure/wreck/trash/autoshaft,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"De" = (/obj/effect/decal/fakelattice,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Df" = (/obj/effect/decal/waste,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dg" = (/obj/structure/wreck/trash/secway,/obj/effect/decal/waste,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dh" = (/obj/item/clipboard,/obj/item/folder/red,/obj/item/stamp/denied{pixel_x = 3; pixel_y = 3},/obj/item/stamp,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"Di" = (/turf/closed/indestructible/riveted,/area/ai_multicam_room)
-"Dj" = (/obj/machinery/vr_sleeper{dir = 8},/turf/open/floor/wood,/area/centcom/holding)
-"Dk" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dl" = (/obj/effect/decal/cleanable/oil/slippery,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dm" = (/obj/structure/wreck/car/bike,/obj/effect/decal/fakelattice,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dn" = (/obj/structure/wreck/trash/three_barrels,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Do" = (/obj/structure/wreck/trash/machinepiletwo,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dp" = (/obj/effect/decal/fakelattice,/obj/effect/decal/fakelattice,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dq" = (/obj/effect/decal/waste{icon_state = "goo10"},/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Dr" = (/obj/structure/wreck/trash/engine,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"Ds" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"Dt" = (/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Du" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"Dv" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/sparsegrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"Dw" = (/obj/structure/flora/ausbushes/fullgrass,/obj/structure/wreck/trash/one_tire,/turf/open/floor/grass,/area/centcom/evac)
-"Dx" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/sparsegrass,/obj/machinery/light/floor,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"Dy" = (/obj/structure/window/reinforced,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"Dz" = (/obj/effect/decal/cleanable/ash/large,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"DA" = (/obj/structure/table/reinforced,/obj/item/book/manual/wiki/security_space_law,/obj/item/taperecorder,/turf/open/floor/plasteel/vault{dir = 8},/area/centcom/evac)
-"DB" = (/turf/open/indestructible/ground/inside/subway,/area/centcom/evac)
-"DC" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Storage"},/turf/open/floor/engine/cult,/area/wizard_station)
-"DD" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Personal Quarters"},/turf/open/floor/engine/cult,/area/wizard_station)
-"DE" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Bathroom"},/turf/open/floor/engine/cult,/area/wizard_station)
-"DF" = (/turf/open/floor/plating/snowed/temperatre,/area/f13/underground/mountain)
-"DG" = (/turf/open/floor/plating/foam,/area/f13/underground/mountain)
-"DH" = (/obj/machinery/door/airlock/freezer,/turf/open/floor/plating/f13/inside/mountain,/area/f13/underground/mountain)
-"DI" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/flora/ausbushes/ppflowers,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DJ" = (/obj/structure/wreck/trash/secway,/turf/open/floor/plasteel/neutral,/area/centcom/evac)
-"DK" = (/turf/open/floor/plating/f13/inside/mountain,/area/f13/underground/mountain)
-"DL" = (/obj/item/clothing/suit/wizrobe/black,/obj/item/clothing/head/wizard/black,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/wizard_station)
-"DM" = (/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/wizard_station)
-"DN" = (/obj/item/cardboard_cutout,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/wizard_station)
-"DO" = (/obj/structure/table/wood,/obj/item/dice/d20,/obj/item/dice,/turf/open/floor/carpet,/area/wizard_station)
-"DP" = (/obj/structure/punching_bag,/turf/open/floor/carpet,/area/wizard_station)
-"DQ" = (/obj/structure/urinal{pixel_y = 28},/turf/open/floor/plasteel/white,/area/wizard_station)
-"DR" = (/turf/open/floor/plasteel/white,/area/wizard_station)
-"DS" = (/obj/structure/mirror/magic{pixel_y = 28},/obj/structure/sink{pixel_y = 20},/turf/open/floor/plasteel/white,/area/wizard_station)
-"DT" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DU" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DV" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DW" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/flora/ausbushes/ywflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DX" = (/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sparsegrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DY" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"DZ" = (/obj/item/cautery/alien,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/wizard_station)
-"Ea" = (/obj/item/coin/antagtoken,/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/wizard_station)
-"Eb" = (/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/carpet,/area/wizard_station)
-"Ec" = (/obj/structure/bed,/obj/item/bedsheet/wiz,/turf/open/floor/carpet,/area/wizard_station)
-"Ed" = (/obj/machinery/light/small{dir = 4},/turf/open/floor/carpet,/area/wizard_station)
-"Ee" = (/obj/item/soap/homemade,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/plasteel/white,/area/wizard_station)
-"Ef" = (/obj/machinery/light/small{dir = 4},/turf/open/floor/plasteel/white,/area/wizard_station)
-"Eg" = (/obj/structure/barricade/bars,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Eh" = (/obj/structure/closet/cardboard,/obj/item/banhammer,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/wizard_station)
-"Ei" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/wizard_station)
-"Ej" = (/obj/vehicle/ridden/scooter/skateboard{icon_state = "skateboard"; dir = 4},/obj/effect/turf_decal/stripes/line,/obj/machinery/light/small,/turf/open/floor/plasteel,/area/wizard_station)
-"Ek" = (/obj/structure/dresser,/obj/item/storage/backpack/satchel,/turf/open/floor/carpet,/area/wizard_station)
-"El" = (/obj/structure/table/wood,/obj/item/storage/bag/tray,/obj/item/reagent_containers/food/snacks/burger/spell,/turf/open/floor/carpet,/area/wizard_station)
-"Em" = (/obj/structure/bookcase/random/adult,/turf/open/floor/plasteel/white,/area/wizard_station)
-"En" = (/obj/structure/toilet{dir = 1},/turf/open/floor/plasteel/white,/area/wizard_station)
-"Eo" = (/obj/structure/table/wood/fancy,/obj/item/skub{pixel_y = 16},/turf/open/floor/plasteel/white,/area/wizard_station)
-"Ep" = (/turf/closed/indestructible/riveted,/area/tdome/tdomeobserve)
-"Eq" = (/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/fullgrass,/obj/effect/decal/cleanable/leaper_sludge,/turf/open/floor/grass,/area/centcom/evac)
-"Er" = (/obj/structure/flora/ausbushes/genericbush,/obj/structure/flora/ausbushes/fullgrass,/obj/effect/decal/cleanable/glass,/turf/open/floor/grass,/area/centcom/evac)
-"Es" = (/turf/open/lava/plasma,/area/f13/underground/mountain)
-"Et" = (/obj/structure/barricade/bars,/turf/open/floor/plating/f13/inside/mountain,/area/f13/underground/mountain)
-"Eu" = (/obj/effect/spawner/lootdrop/organ_spawner,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Ev" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/tdome/tdomeobserve)
-"EA" = (/turf/closed/wall/f13/ruins,/area/f13/underground/mountain)
-"EB" = (/obj/structure/simple_door/house,/turf/open/floor/wood/f13/old/ruinedcornerbl,/area/f13/underground/mountain)
-"EC" = (/obj/machinery/door/airlock{icon = 'icons/obj/doors/airlocks/station/uranium.dmi'; name = "Engine Room"},/obj/structure/barricade/wooden,/turf/open/floor/engine/cult,/area/wizard_station)
-"ED" = (/obj/machinery/vending/boozeomat{req_access_txt = "0"},/turf/closed/indestructible{icon = 'icons/turf/walls/wood_wall.dmi'; icon_state = "wood"; smooth = 1},/area/centcom/holding)
-"EE" = (/turf/open/floor/wood/f13/old,/area/f13/underground/mountain)
-"EF" = (/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,/turf/open/floor/wood/f13,/area/f13/underground/mountain)
-"EG" = (/turf/open/floor/wood/f13,/area/f13/underground/mountain)
-"EH" = (/obj/structure/flora/wasteplant/wild_mutfruit,/turf/open/floor/wood/f13,/area/f13/underground/mountain)
-"EI" = (/obj/structure/window/fulltile/ruins/broken,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EJ" = (/obj/structure/simple_door/house,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EK" = (/obj/machinery/status_display,/turf/closed/indestructible/riveted,/area/tdome/tdomeobserve)
-"EL" = (/obj/structure/window/fulltile/ruins,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EM" = (/obj/structure/table/reinforced,/obj/effect/spawner/lootdrop/snowdin/dungeonlite,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EN" = (/obj/structure/table/reinforced,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EO" = (/obj/structure/simple_door/dirtyglass,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EP" = (/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EQ" = (/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,/obj/effect/spawner/lootdrop/food,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"ER" = (/obj/structure/rack,/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,/turf/open/floor/wood/f13/old,/area/f13/underground/mountain)
-"ES" = (/obj/structure/table/reinforced,/obj/effect/spawner/lootdrop/maintenance,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"ET" = (/obj/structure/flora/wasteplant/wild_xander,/turf/open/floor/wood/f13/old/ruinedstraighteast,/area/f13/underground/mountain)
-"EU" = (/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,/obj/effect/spawner/lootdrop/trash,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EV" = (/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,/obj/effect/spawner/lootdrop/food,/obj/effect/spawner/lootdrop/food,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"EW" = (/obj/structure/table/wood,/turf/open/floor/engine/cult,/area/wizard_station)
-"EX" = (/obj/structure/table/wood,/obj/item/gun/magic/wand{desc = "Used in emergencies to reignite magma engines."; max_charges = 0; name = "wand of emergency engine ignition"},/turf/open/floor/engine/cult,/area/wizard_station)
-"EY" = (/obj/structure/table/wood,/obj/item/bikehorn/golden{pixel_x = -8; pixel_y = 8},/turf/open/floor/engine/cult,/area/wizard_station)
-"EZ" = (/obj/structure/simple_door/brokenglass,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Fa" = (/obj/structure/table/wood,/obj/item/instrument/piano_synth,/turf/open/floor/carpet/black,/area/centcom/holding)
-"Fb" = (/obj/structure/piano,/obj/machinery/light{dir = 8},/turf/open/floor/carpet/black,/area/centcom/holding)
-"Fc" = (/obj/structure/sign/barsign{pixel_y = 32},/obj/structure/chair/stool,/turf/open/floor/carpet/black,/area/centcom/holding)
-"Fd" = (/turf/open/floor/wood/f13/old/ruinedstraighteast,/area/f13/underground/mountain)
-"Fe" = (/obj/effect/spawner/lootdrop/trash,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Ff" = (/obj/effect/spawner/lootdrop/three_course_meal,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Fg" = (/obj/structure/rack,/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,/turf/open/floor/wood/f13/old,/area/f13/underground/mountain)
-"Fh" = (/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Fi" = (/obj/structure/chair/wood/wings{dir = 3},/obj/machinery/light{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"Fj" = (/obj/machinery/vending/cigarette,/turf/open/floor/wood,/area/centcom/holding)
-"Fk" = (/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/wood/f13/old/ruinedstraightwest,/area/f13/underground/mountain)
-"Fl" = (/obj/effect/spawner/lootdrop/f13/cash_ncr_low,/turf/open/floor/wood/f13/old/ruinedstraighteast,/area/f13/underground/mountain)
-"Fm" = (/obj/structure/rack,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Fn" = (/obj/structure/rack,/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Fo" = (/obj/effect/spawner/lootdrop/f13/armor/clothes,/obj/structure/rack,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Fp" = (/obj/effect/spawner/lootdrop/three_course_meal,/turf/closed/mineral/random,/area/f13/underground/mountain)
-"Fq" = (/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,/obj/effect/spawner/lootdrop/trash,/obj/effect/spawner/lootdrop/food,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"FT" = (/obj/structure/destructible/cult/forge{desc = "An engine used in powering the wizard's ship"; name = "magma engine"},/turf/open/floor/engine/cult,/area/wizard_station)
-"FU" = (/obj/structure/speaking_tile/tragedy,/turf/closed/mineral/ash_rock,/area/f13/underground/mountain)
-"FW" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/turf/open/floor/wood,/area/centcom/holding)
-"FX" = (/turf/open/floor/plasteel/stairs,/area/centcom/holding)
-"FZ" = (/obj/structure/speaking_tile/tragedy,/turf/closed/mineral/ash_rock,/area/syndicate_mothership/control)
-"Ga" = (/obj/structure/cable{icon_state = "1-4"},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"Gr" = (/obj/structure/window/reinforced{resistance_flags = 3; color = "#008000"; dir = 1},/turf/open/lava,/area/wizard_station)
-"Gs" = (/obj/machinery/light{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"Gt" = (/obj/structure/cable{icon_state = "2-8"},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"Gz" = (/obj/structure/shuttle/engine/heater{resistance_flags = 3},/obj/structure/window/reinforced{resistance_flags = 3; color = "#008000"; dir = 1},/turf/open/lava/airless,/area/wizard_station)
-"GA" = (/obj/machinery/light_switch{pixel_y = -25},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"GB" = (/obj/machinery/camera{c_tag = "Communications Relay"; dir = 8; network = list("mine")},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"GM" = (/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"GP" = (/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/sparsegrass,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/genericbush,/turf/open/floor/grass,/area/tdome/tdomeobserve)
-"GX" = (/obj/structure/shuttle/engine/propulsion,/turf/open/space,/area/wizard_station)
-"GY" = (/obj/structure/chair/wood/wings{dir = 8},/turf/open/floor/wood,/area/centcom/holding)
-"GZ" = (/obj/machinery/light,/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel,/area/f13/tcoms)
-"Hk" = (/obj/structure/cable{icon_state = "1-2"},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"Hl" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/obj/machinery/door/airlock/engineering/glass{name = "Server Room"; req_access_txt = "61"},/obj/structure/cable{icon_state = "1-2"},/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"Hm" = (/obj/structure/flora/ausbushes/fernybush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/obj/machinery/light{dir = 4},/turf/open/floor/grass,/area/centcom/holding)
-"Hy" = (/obj/structure/sign/warning/nosmoking{pixel_y = -32},/obj/machinery/light,/turf/open/floor/plating/f13/inside/mountain,/area/f13/tcoms)
-"HH" = (/obj/machinery/light,/turf/open/floor/wood,/area/centcom/holding)
-"HL" = (/turf/open/floor/plasteel/vault,/area/tdome/tdomeobserve)
-"HN" = (/obj/structure/chair,/obj/effect/landmark/thunderdome/observe,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"HQ" = (/obj/structure/sink/kitchen{desc = "A sink used for washing one's hands and face. It looks rusty and home-made"; name = "sink"; pixel_y = 28},/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Id" = (/obj/machinery/computer/security/telescreen,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/tdome/tdomeobserve)
-"Il" = (/turf/closed/indestructible/fakeglass,/area/tdome/tdomeobserve)
-"Is" = (/obj/machinery/igniter/on,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/tdome/arena)
-"It" = (/turf/open/floor/plasteel,/area/tdome/arena)
-"Iu" = (/obj/effect/turf_decal/bot,/turf/open/floor/plasteel,/area/tdome/arena)
-"Iy" = (/obj/structure/rack,/obj/item/clothing/under/color/red,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/tdome/red,/obj/item/clothing/head/helmet/thunderdome,/obj/item/melee/baton/loaded,/obj/item/melee/transforming/energy/sword/saber/red,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena)
-"Iz" = (/obj/machinery/door/poddoor{id = "thunderdomegen"; name = "General Supply"},/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena)
-"IA" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel,/area/tdome/arena)
-"IC" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/tdome/arena)
-"ID" = (/obj/machinery/door/poddoor{id = "thunderdome"; name = "Thunderdome Blast Door"},/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena)
-"IE" = (/turf/open/floor/plasteel/red/side{dir = 8},/area/tdome/arena)
-"IF" = (/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/tdome/arena)
-"IG" = (/turf/open/floor/plasteel/neutral/side{dir = 4},/area/tdome/arena)
-"IH" = (/turf/open/floor/plasteel/neutral,/area/tdome/arena)
-"II" = (/turf/open/floor/plasteel/neutral/side{dir = 8},/area/tdome/arena)
-"IJ" = (/turf/open/floor/plasteel/green/side{dir = 4},/area/tdome/arena)
-"IL" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line{dir = 9},/turf/open/floor/plasteel,/area/tdome/arena)
-"IN" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line{dir = 5},/turf/open/floor/plasteel,/area/tdome/arena)
-"IP" = (/obj/structure/rack,/obj/item/clothing/under/color/green,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/tdome/green,/obj/item/clothing/head/helmet/thunderdome,/obj/item/melee/baton/loaded,/obj/item/melee/transforming/energy/sword/saber/green,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena)
-"IT" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena)
-"IU" = (/obj/machinery/recharger{pixel_y = 4},/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/tdome/arena)
-"IV" = (/obj/effect/landmark/thunderdome/two,/turf/open/floor/plasteel/neutral,/area/tdome/arena)
-"IW" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena)
-"IX" = (/turf/open/floor/plasteel/red/corner{dir = 1},/area/tdome/arena)
-"IY" = (/turf/open/floor/plasteel/green/corner{dir = 4},/area/tdome/arena)
-"IZ" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena)
-"Ja" = (/obj/machinery/recharger{pixel_y = 4},/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/delivery,/turf/open/floor/plasteel,/area/tdome/arena)
-"Jb" = (/obj/effect/landmark/thunderdome/one,/turf/open/floor/plasteel/neutral,/area/tdome/arena)
-"Jc" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena)
-"Jg" = (/obj/machinery/camera{c_tag = "Red Team"; network = list("thunder"); pixel_x = 11; pixel_y = -9; resistance_flags = 64},/obj/effect/landmark/thunderdome/two,/turf/open/floor/plasteel/neutral,/area/tdome/arena)
-"Jh" = (/obj/effect/turf_decal/loading_area{dir = 4},/turf/open/floor/plasteel,/area/tdome/arena)
-"Ji" = (/turf/open/floor/circuit/green,/area/tdome/arena)
-"Jk" = (/obj/effect/turf_decal/loading_area{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena)
-"Jl" = (/obj/machinery/camera{c_tag = "Green Team"; network = list("thunder"); pixel_x = 12; pixel_y = -10; resistance_flags = 64},/obj/effect/landmark/thunderdome/one,/turf/open/floor/plasteel/neutral,/area/tdome/arena)
-"Jq" = (/obj/machinery/camera{c_tag = "Arena"; network = list("thunder"); pixel_x = 10; resistance_flags = 64},/turf/open/floor/circuit/green,/area/tdome/arena)
-"Js" = (/turf/open/floor/plasteel/red/corner{dir = 8},/area/tdome/arena)
-"Jt" = (/turf/open/floor/plasteel/green/corner,/area/tdome/arena)
-"Ju" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel,/area/tdome/arena)
-"Jv" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/tdome/arena)
-"Jw" = (/obj/effect/landmark/thunderdome/two,/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/tdome/arena)
-"Jx" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line{dir = 10},/turf/open/floor/plasteel,/area/tdome/arena)
-"Jy" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/tdome/arena)
-"Jz" = (/obj/effect/landmark/thunderdome/one,/obj/effect/turf_decal/stripes/line{dir = 6},/turf/open/floor/plasteel,/area/tdome/arena)
-"JA" = (/obj/machinery/abductor/experiment{team_number = 1},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"JB" = (/obj/machinery/abductor/console{team_number = 1},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"JC" = (/obj/machinery/abductor/pad{team_number = 1},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"JD" = (/obj/machinery/door/poddoor{id = "thunderdomehea"; name = "Heavy Supply"},/obj/effect/turf_decal/loading_area,/turf/open/floor/plasteel,/area/tdome/arena)
-"JE" = (/obj/structure/sink/kitchen{desc = "A sink used for washing one's hands and face. It looks rusty and home-made"; name = "sink"; pixel_y = 28},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"JF" = (/obj/machinery/computer/camera_advanced/abductor{team_number = 1},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"JM" = (/obj/effect/landmark/abductor/scientist,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"JN" = (/obj/effect/landmark/abductor/agent,/turf/open/floor/plating/abductor,/area/abductor_ship)
-"JV" = (/turf/closed/wall/mineral/titanium,/area/shuttle/escape/backup)
-"JW" = (/obj/machinery/status_display,/turf/closed/wall/mineral/titanium,/area/shuttle/escape/backup)
-"Kd" = (/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"Ke" = (/turf/open/floor/mineral/plastitanium,/area/shuttle/escape/backup)
-"Kf" = (/obj/machinery/computer/emergency_shuttle{dir = 8},/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"Kk" = (/obj/machinery/door/airlock/titanium,/obj/docking_port/stationary{dir = 4; dwidth = 2; height = 8; id = "backup_away"; name = "Backup Shuttle Dock"; width = 8},/obj/docking_port/mobile/emergency/backup,/turf/open/floor/plating,/area/shuttle/escape/backup)
-"Kl" = (/obj/structure/chair/office/light{dir = 4},/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"Km" = (/obj/structure/table/wood,/obj/item/paper/fluff/stations/centcom/broken_evac,/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"Kz" = (/obj/structure/table/wood,/obj/item/book/manual/random,/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"KE" = (/obj/machinery/light{dir = 8},/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"KF" = (/obj/machinery/light{dir = 4},/turf/open/floor/mineral/titanium,/area/shuttle/escape/backup)
-"KH" = (/turf/closed/wall/mineral/titanium,/area/centcom/evac)
-"KI" = (/obj/structure/shuttle/engine/propulsion/right{dir = 1},/turf/open/floor/plating/airless,/area/centcom/evac)
-"KJ" = (/obj/structure/shuttle/engine/propulsion{dir = 1},/turf/open/floor/plating/airless,/area/centcom/evac)
-"KK" = (/obj/structure/shuttle/engine/propulsion/left{dir = 1},/turf/open/floor/plating/airless,/area/centcom/evac)
-"KL" = (/obj/structure/window/reinforced{dir = 1},/turf/closed/indestructible/riveted,/area/f13/underground/mountain)
-"KM" = (/obj/effect/landmark/shuttle_import,/turf/open/space/basic,/area/f13/underground/mountain)
-"KN" = (/obj/structure/window/reinforced,/obj/structure/shuttle/engine/heater{dir = 1},/turf/open/floor/plating/airless,/area/centcom/evac)
-"KO" = (/obj/machinery/door/airlock/titanium,/turf/open/floor/plating,/area/centcom/evac)
-"KP" = (/obj/structure/window/shuttle,/obj/structure/grille,/turf/open/floor/plating,/area/centcom/evac)
-"KQ" = (/turf/open/floor/plating,/area/centcom/evac)
-"KR" = (/obj/machinery/light/small{dir = 4},/turf/open/floor/plating,/area/centcom/evac)
-"KS" = (/turf/closed/wall/mineral/titanium/interior,/area/centcom/evac)
-"KT" = (/obj/structure/window/reinforced{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"KU" = (/obj/structure/closet/emcloset,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"KV" = (/turf/open/floor/mineral/titanium/yellow,/area/centcom/evac)
-"KW" = (/obj/structure/table,/obj/item/storage/firstaid/toxin{pixel_x = -2; pixel_y = 4},/obj/item/storage/firstaid/toxin,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"KX" = (/obj/structure/table,/obj/item/storage/firstaid/fire,/obj/item/storage/firstaid/fire{pixel_x = -2; pixel_y = 4},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"KY" = (/obj/structure/table,/obj/item/storage/firstaid/regular{pixel_x = 2},/obj/item/storage/firstaid/regular{pixel_x = -2; pixel_y = 4},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"KZ" = (/obj/machinery/light/small{dir = 8},/turf/open/floor/plating,/area/centcom/evac)
-"La" = (/obj/machinery/light{dir = 8},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Lb" = (/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Lc" = (/obj/machinery/light{dir = 4},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Ld" = (/obj/structure/table/reinforced,/obj/item/paper_bin,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Le" = (/obj/structure/table/reinforced,/obj/item/storage/fancy/donut_box,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lf" = (/obj/structure/table/reinforced,/obj/item/pen,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lg" = (/obj/structure/table/reinforced,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lh" = (/obj/machinery/sleeper{dir = 8},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Li" = (/obj/structure/chair{dir = 8},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Lj" = (/obj/machinery/computer/secure_data{dir = 4},/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lk" = (/obj/structure/chair{dir = 1},/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Ll" = (/obj/structure/chair{dir = 4},/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lm" = (/obj/structure/table/reinforced,/obj/item/clipboard,/obj/item/stamp,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Ln" = (/obj/structure/table,/obj/item/assembly/flash/handheld,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lo" = (/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lp" = (/obj/structure/chair{dir = 4},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Lq" = (/obj/structure/table,/obj/item/storage/box/handcuffs,/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Lr" = (/obj/machinery/door/window/northright{base_state = "right"; dir = 4; icon_state = "right"; name = "Security Desk"; req_access_txt = "103"},/turf/open/floor/mineral/plastitanium,/area/centcom/evac)
-"Ls" = (/obj/docking_port/stationary{dir = 8; dwidth = 8; height = 7; id = "supply_away"; json_key = "cargo"; name = "CentCom"; width = 20},/turf/open/space,/area/f13/underground/mountain)
-"Lt" = (/turf/closed/wall/mineral/titanium/nodiagonal,/area/centcom/evac)
-"Lu" = (/obj/machinery/light{dir = 8},/turf/open/floor/mineral/titanium/yellow,/area/centcom/evac)
-"Lv" = (/obj/structure/bed,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Lw" = (/obj/effect/spawner/structure/window/shuttle,/turf/open/floor/plating,/area/centcom/evac)
-"Lx" = (/obj/structure/bed,/obj/machinery/light{dir = 8},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"Ly" = (/obj/machinery/door/airlock/titanium,/turf/open/floor/mineral/titanium/yellow,/area/centcom/evac)
-"LA" = (/obj/structure/table,/obj/structure/bedsheetbin,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LB" = (/obj/structure/table,/obj/item/hand_labeler,/obj/machinery/light,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LC" = (/obj/structure/table,/obj/item/storage/box/donkpockets,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LD" = (/obj/machinery/door/airlock/titanium{name = "Cockpit"; req_access_txt = "109"},/turf/open/floor/mineral/titanium/yellow,/area/centcom/evac)
-"LE" = (/obj/structure/table,/obj/item/radio/off,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LF" = (/obj/structure/chair{dir = 4; name = "Prosecution"},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LG" = (/obj/structure/filingcabinet,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LH" = (/obj/structure/table,/obj/item/storage/box/donkpockets,/obj/machinery/light{dir = 8},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LI" = (/obj/structure/chair,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LJ" = (/obj/structure/table,/obj/item/radio/off,/obj/machinery/light{dir = 4},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LK" = (/obj/machinery/abductor/experiment{team_number = 2},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"LL" = (/obj/machinery/abductor/console{team_number = 2},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"LM" = (/obj/machinery/abductor/pad{team_number = 2},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"LN" = (/obj/structure/table,/obj/item/storage/lockbox,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LO" = (/obj/structure/table,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LP" = (/obj/machinery/computer/shuttle{dir = 1},/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LQ" = (/obj/structure/table,/obj/item/clipboard,/obj/item/pen,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LR" = (/obj/structure/table,/obj/item/paper_bin,/turf/open/floor/mineral/titanium/blue,/area/centcom/evac)
-"LS" = (/obj/machinery/computer/camera_advanced/abductor{team_number = 2},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"LT" = (/obj/effect/landmark/abductor/scientist{team_number = 2},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"LU" = (/obj/effect/landmark/abductor/agent{team_number = 2},/turf/open/floor/plating/abductor,/area/abductor_ship)
-"LV" = (/turf/closed/indestructible/riveted,/area/awaymission/errorroom)
-"LW" = (/turf/closed/mineral/ash_rock,/area/awaymission/errorroom)
-"LX" = (/obj/structure/speaking_tile,/turf/closed/mineral/ash_rock,/area/awaymission/errorroom)
-"LY" = (/obj/item/rupee,/turf/open/floor/plating/ashplanet/wateryrock{initial_gas_mix = "o2=22;n2=82;TEMP=293.15"; planetary_atmos = 0},/area/awaymission/errorroom)
-"LZ" = (/turf/open/floor/plating/ashplanet/wateryrock{initial_gas_mix = "o2=22;n2=82;TEMP=293.15"; planetary_atmos = 0},/area/awaymission/errorroom)
-"Ma" = (/obj/effect/landmark/error,/turf/open/floor/plating/ashplanet/wateryrock{initial_gas_mix = "o2=22;n2=82;TEMP=293.15"; planetary_atmos = 0},/area/awaymission/errorroom)
-"Mb" = (/obj/structure/signpost/salvation{icon = 'icons/obj/structures.dmi'; icon_state = "ladder10"; invisibility = 100},/turf/open/floor/plating/ashplanet/wateryrock{initial_gas_mix = "o2=22;n2=82;TEMP=293.15"; planetary_atmos = 0},/area/awaymission/errorroom)
-"Mh" = (/obj/machinery/door/poddoor{id = "thunderdome"; name = "Thunderdome Blast Door"},/obj/effect/turf_decal/loading_area{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena)
-"Mi" = (/obj/machinery/door/poddoor{id = "thunderdomegen"; name = "General Supply"},/obj/effect/turf_decal/loading_area{dir = 8},/turf/open/floor/plasteel,/area/tdome/arena)
-"Mm" = (/turf/open/floor/grass,/area/centcom/holding)
-"Mu" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Mx" = (/obj/machinery/light{dir = 4},/obj/structure/rack,/obj/item/nullrod/claymore/saber/red{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"MB" = (/turf/open/indestructible/binary,/area/fabric_of_reality)
-"ME" = (/obj/machinery/computer/camera_advanced{dir = 4},/turf/open/floor/wood,/area/wizard_station)
-"MG" = (/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/window/eastright{dir = 8; name = "Animal Pen"},/turf/open/floor/grass,/area/centcom/holding)
-"MH" = (/obj/structure/ladder/unbreakable/binary/unlinked,/turf/open/indestructible/airblock,/area/fabric_of_reality)
-"MM" = (/obj/structure/window/reinforced,/turf/open/floor/carpet/black,/area/centcom/holding)
-"MR" = (/obj/machinery/light{dir = 4},/turf/open/floor/carpet/black,/area/centcom/holding)
-"MT" = (/obj/machinery/processor,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"MX" = (/turf/open/floor/plasteel,/area/centcom/evac)
-"Nd" = (/turf/closed/indestructible{icon = 'icons/turf/walls/wood_wall.dmi'; icon_state = "wood"; smooth = 1},/area/centcom/holding)
-"Nm" = (/obj/structure/closet/crate,/obj/item/vending_refill/autodrobe,/obj/item/stack/sheet/paperframes/fifty,/obj/item/stack/sheet/paperframes/fifty,/obj/item/storage/fancy/candle_box,/obj/item/storage/fancy/candle_box,/obj/item/storage/fancy/candle_box,/turf/open/floor/wood,/area/centcom/holding)
-"Nn" = (/obj/structure/closet/secure_closet/hydroponics{locked = 0},/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Nq" = (/mob/living/simple_animal/bot/medbot/mysterious{desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway."; faction = list("neutral","silicon","creature"); name = "Nobody's Perfect"},/turf/open/floor/carpet/black,/area/centcom/holding)
-"Nv" = (/obj/structure/table,/turf/open/floor/plasteel/cafeteria{dir = 2},/area/centcom/holding)
-"Nw" = (/obj/machinery/recharge_station,/turf/open/floor/plasteel/white,/area/centcom/holding)
-"Ny" = (/obj/machinery/modular_computer/console/preset/research,/obj/machinery/light{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"NF" = (/obj/structure/ladder/unbreakable/binary,/turf/open/indestructible/airblock,/area/fabric_of_reality)
-"NJ" = (/obj/structure/table,/obj/item/book/manual/hydroponics_pod_people,/obj/item/seeds/pumpkin/blumpkin,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"NR" = (/obj/machinery/light{dir = 8},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"NT" = (/obj/structure/window/paperframe{CanAtmosPass = 0},/turf/open/floor/wood,/area/centcom/holding)
-"Op" = (/obj/structure/sink{dir = 8; pixel_x = -12; pixel_y = 2},/obj/machinery/button/door{id = "lmrestroom"; name = "Lock Control"; pixel_y = -28},/turf/open/floor/plasteel/white,/area/centcom/holding)
-"OG" = (/obj/structure/dresser,/obj/machinery/light{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"OU" = (/obj/item/clothing/under/jabroni,/obj/item/clothing/under/geisha,/obj/item/clothing/under/kilt,/obj/structure/closet,/turf/open/floor/wood,/area/centcom/holding)
-"Pa" = (/obj/machinery/washing_machine,/turf/open/floor/plasteel/white,/area/centcom/holding)
-"Ph" = (/obj/structure/closet/crate/bin,/turf/open/floor/wood,/area/centcom/holding)
-"Pl" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/turf/open/floor/carpet/black,/area/centcom/holding)
-"Po" = (/obj/structure/window/reinforced{dir = 8},/turf/open/floor/carpet/black,/area/centcom/holding)
-"Pr" = (/obj/structure/table,/obj/item/book/manual/chef_recipes,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Px" = (/obj/machinery/vr_sleeper,/turf/open/floor/wood,/area/centcom/holding)
-"PA" = (/obj/structure/window/reinforced{dir = 4},/turf/open/floor/carpet/black,/area/centcom/holding)
-"PF" = (/obj/machinery/vr_sleeper{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"PI" = (/obj/machinery/biogenerator,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"PL" = (/obj/machinery/autolathe,/turf/open/floor/wood,/area/centcom/holding)
-"PO" = (/obj/machinery/hydroponics/constructable,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"PX" = (/obj/machinery/computer/arcade/battle,/turf/open/floor/wood,/area/centcom/holding)
-"PY" = (/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Qe" = (/turf/open/ai_visible,/area/ai_multicam_room)
-"Qk" = (/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/turf/open/floor/grass,/area/centcom/holding)
-"Qm" = (/obj/singularity/wizard/mapped,/turf/open/indestructible/binary,/area/fabric_of_reality)
-"Qu" = (/obj/machinery/vr_sleeper{dir = 8},/obj/machinery/light{dir = 4},/turf/open/floor/wood,/area/centcom/holding)
-"QA" = (/obj/machinery/deepfryer,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"QC" = (/obj/docking_port/stationary{dir = 8; dwidth = 2; height = 13; id = "ferry_away"; json_key = "ferry"; name = "CentCom Ferry Dock"; width = 5},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"QH" = (/obj/machinery/chem_master/condimaster{desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments."; name = "BrewMaster 2199"; pixel_x = -4},/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"QI" = (/obj/structure/toilet{dir = 4},/turf/open/floor/plasteel/white,/area/centcom/holding)
-"QL" = (/obj/structure/flora/ausbushes/fernybush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/turf/open/floor/grass,/area/centcom/holding)
-"QT" = (/obj/machinery/chem_dispenser/drinks,/turf/closed/indestructible{icon = 'icons/turf/walls/wood_wall.dmi'; icon_state = "wood"; smooth = 1},/area/centcom/holding)
-"QW" = (/obj/structure/closet/secure_closet/freezer/kitchen{locked = 0},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Rd" = (/obj/machinery/light,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Re" = (/obj/structure/mineral_door/paperframe,/turf/open/floor/wood,/area/centcom/holding)
-"Rh" = (/obj/structure/window/reinforced{dir = 1},/turf/open/floor/grass,/area/centcom/holding)
-"Ri" = (/obj/structure/chair/wood/normal{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"Rj" = (/obj/machinery/vending/hydroseeds,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Rm" = (/obj/structure/chair/wood/wings{dir = 3},/turf/open/floor/wood,/area/centcom/holding)
-"RL" = (/turf/closed/wall/r_wall/f13superstore{icon_state = "supermart0"},/area/f13/tcoms)
-"RM" = (/turf/closed/wall/r_wall,/area/f13/tcoms)
-"RS" = (/obj/machinery/light{dir = 8},/obj/structure/rack,/obj/item/nullrod/claymore/glowing{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"RT" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable{icon_state = "0-2"},/turf/open/floor/plating,/area/f13/tcoms)
-"RU" = (/obj/structure/table,/turf/open/floor/plasteel/yellow/side{dir = 9},/area/f13/tcoms)
-"RV" = (/obj/item/radio/intercom{dir = 8; freerange = 1; name = "Station Intercom (Telecomms)"; pixel_y = 26},/turf/open/floor/plasteel,/area/f13/tcoms)
-"RW" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/f13/tcoms)
-"Sb" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable{icon_state = "0-2"},/obj/structure/cable,/turf/open/floor/plating,/area/f13/tcoms)
-"Sc" = (/obj/machinery/computer/message_monitor{dir = 4},/turf/open/floor/plasteel/yellow/side{dir = 8},/area/f13/tcoms)
-"Sd" = (/turf/open/floor/carpet/black,/area/centcom/holding)
-"Se" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel,/area/f13/tcoms)
-"Sf" = (/turf/open/floor/plasteel,/area/f13/tcoms)
-"Sg" = (/obj/structure/table,/obj/item/paper_bin,/turf/open/floor/plasteel,/area/f13/tcoms)
-"Sj" = (/obj/machinery/computer/telecomms/server{dir = 4; network = "tcommsat"},/turf/open/floor/plasteel/yellow/side{dir = 10},/area/f13/tcoms)
-"Sk" = (/obj/structure/table,/obj/item/folder/blue,/obj/item/pen/blue,/turf/open/floor/plasteel,/area/f13/tcoms)
-"Sp" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable{icon_state = "0-4"},/obj/structure/cable{icon_state = "0-2"},/turf/open/floor/plating,/area/f13/tcoms)
-"Sq" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable{icon_state = "0-8"},/obj/structure/cable,/turf/open/floor/plating,/area/f13/tcoms)
-"Sr" = (/obj/machinery/status_display,/turf/closed/wall,/area/f13/tcoms)
-"Ss" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/f13/tcoms)
-"St" = (/obj/machinery/door/airlock/command/glass{name = "Control Room"; req_access_txt = "19; 61"},/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,/turf/open/floor/plasteel,/area/f13/tcoms)
-"Su" = (/turf/open/floor/plasteel/dark,/area/f13/tcoms)
-"Sw" = (/obj/machinery/hydroponics/constructable,/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Sz" = (/turf/open/floor/plasteel/vault{dir = 5},/area/f13/tcoms)
-"SA" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/obj/machinery/door/airlock/engineering/glass{name = "Server Room"; req_access_txt = "61"},/turf/open/floor/plasteel/vault{dir = 5},/area/f13/tcoms)
-"SB" = (/obj/structure/curtain,/obj/structure/window/reinforced/tinted{dir = 8},/obj/machinery/shower{pixel_y = 12},/turf/open/floor/plasteel/white,/area/centcom/holding)
-"SC" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/f13/tcoms)
-"SD" = (/obj/structure/closet/emcloset,/turf/open/floor/plasteel,/area/f13/tcoms)
-"SE" = (/obj/effect/turf_decal/bot_white/right,/turf/open/floor/plasteel/vault{dir = 1},/area/f13/tcoms)
-"SF" = (/obj/effect/turf_decal/bot_white,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/tcoms)
-"SG" = (/obj/structure/table,/obj/machinery/microwave{pixel_x = -3; pixel_y = 6},/turf/open/floor/plasteel/cafeteria{dir = 2},/area/centcom/holding)
-"SH" = (/obj/effect/turf_decal/bot_white/left,/turf/open/floor/plasteel/vault{dir = 4},/area/f13/tcoms)
-"SI" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable{icon_state = "0-4"},/obj/structure/cable,/turf/open/floor/plating,/area/f13/tcoms)
-"SJ" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable{icon_state = "0-2"},/obj/structure/cable{icon_state = "0-8"},/turf/open/floor/plating,/area/f13/tcoms)
-"SK" = (/obj/structure/sign/warning/securearea{desc = "A warning sign which reads 'SERVER ROOM'."; name = "SERVER ROOM"},/turf/closed/wall,/area/f13/tcoms)
-"SL" = (/obj/machinery/requests_console{announcementConsole = 1; department = "Telecomms Admin"; departmentType = 5; name = "Telecomms RC"; pixel_x = 30},/turf/open/floor/plasteel,/area/f13/tcoms)
-"SM" = (/obj/structure/table,/obj/item/multitool,/turf/open/floor/plasteel/yellow/side{dir = 9},/area/f13/tcoms)
-"SN" = (/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"SR" = (/obj/machinery/light_switch{pixel_x = 27},/turf/open/floor/plasteel,/area/f13/tcoms)
-"SS" = (/obj/machinery/gravity_generator/main/station,/obj/effect/turf_decal/bot_white,/turf/open/floor/plasteel/vault{dir = 8},/area/f13/tcoms)
-"ST" = (/obj/machinery/computer/telecomms/monitor{dir = 4; network = "tcommsat"},/turf/open/floor/plasteel/yellow/side{dir = 8},/area/f13/tcoms)
-"SU" = (/obj/structure/table/wood,/obj/item/camera/detective{desc = "A polaroid camera with extra capacity for social media marketing."; name = "Professional camera"},/obj/item/camera_film,/obj/item/wallframe/newscaster,/obj/item/paper_bin,/obj/item/pen/fountain,/turf/open/floor/wood,/area/centcom/holding)
-"SW" = (/obj/machinery/seed_extractor,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"Tb" = (/obj/item/clothing/under/roman,/obj/structure/closet,/turf/open/floor/wood,/area/centcom/holding)
-"Te" = (/obj/effect/spawner/structure/window/reinforced,/obj/structure/cable,/turf/open/floor/plating,/area/f13/tcoms)
-"Tg" = (/obj/structure/table,/obj/item/radio/off,/turf/open/floor/plasteel/yellow/side{dir = 10},/area/f13/tcoms)
-"Th" = (/obj/item/radio/intercom{name = "Station Intercom (General)"; pixel_y = -35},/turf/open/floor/plasteel,/area/f13/tcoms)
-"Tj" = (/obj/structure/rack,/obj/item/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/turf/open/floor/plasteel,/area/f13/tcoms)
-"Tn" = (/obj/structure/table/wood/fancy,/obj/item/candle/infinite{pixel_y = 6},/turf/open/floor/wood,/area/centcom/holding)
-"To" = (/turf/open/indestructible/airblock,/area/fabric_of_reality)
-"Tq" = (/obj/structure/table/wood/bar,/obj/item/stack/sheet/glass/fifty,/obj/item/stack/sheet/metal/fifty,/obj/item/storage/toolbox/mechanical,/turf/open/floor/wood,/area/centcom/holding)
-"Tr" = (/obj/structure/closet/chefcloset,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Tu" = (/obj/structure/flora/ausbushes/fernybush,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/turf/open/floor/grass,/area/centcom/holding)
-"TB" = (/obj/structure/reagent_dispensers/cooking_oil,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"TK" = (/obj/structure/table/wood/bar,/obj/structure/mirror{pixel_y = 28},/turf/open/floor/wood,/area/centcom/holding)
-"Ud" = (/obj/effect/landmark/holding_facility,/turf/open/floor/wood,/area/centcom/holding)
-"Uh" = (/obj/machinery/light{dir = 4},/obj/structure/rack,/obj/item/nullrod/claymore/darkblade{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"Um" = (/obj/structure/closet/crate/hydroponics,/turf/open/floor/plasteel/whitegreen,/area/centcom/holding)
-"UE" = (/obj/structure/chair/stool/bar,/turf/open/floor/wood,/area/centcom/holding)
-"UH" = (/obj/machinery/door/airlock/wood{req_one_access_txt = "28"},/turf/open/floor/wood,/area/centcom/holding)
-"UT" = (/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/wood,/area/centcom/holding)
-"UV" = (/obj/machinery/computer/arcade,/turf/open/floor/wood,/area/centcom/holding)
-"Vm" = (/obj/machinery/gibber,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Vu" = (/obj/structure/flora/ausbushes/fernybush,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/obj/machinery/light,/turf/open/floor/grass,/area/centcom/holding)
-"Vv" = (/obj/structure/table,/obj/machinery/reagentgrinder,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Vz" = (/obj/machinery/vending/wallmed{name = "Emergency NanoMed"; pixel_y = 28; use_power = 0},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"VA" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/white,/area/centcom/holding)
-"VD" = (/obj/effect/landmark/thunderdome/two,/turf/open/floor/plasteel,/area/tdome/arena)
-"VE" = (/obj/effect/landmark/thunderdome/one,/turf/open/floor/plasteel,/area/tdome/arena)
-"VF" = (/obj/structure/rack,/obj/item/nullrod/scythe/vibro{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"Wh" = (/obj/effect/turf_decal/caution/stand_clear,/turf/open/floor/plating/f13/outside/desert,/area/syndicate_mothership)
-"Wx" = (/obj/structure/rack,/obj/item/clothing/under/color/red,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/vest,/obj/item/clothing/head/helmet/swat,/obj/item/gun/energy/laser,/turf/open/floor/plasteel,/area/tdome/arena)
-"Wy" = (/obj/structure/rack,/obj/item/clothing/under/color/green,/obj/item/clothing/shoes/sneakers/brown,/obj/item/clothing/suit/armor/vest,/obj/item/clothing/head/helmet/swat,/obj/item/gun/energy/laser,/turf/open/floor/plasteel,/area/tdome/arena)
-"Xd" = (/obj/structure/flora/ausbushes/fernybush,/obj/structure/flora/ausbushes/fullgrass,/obj/structure/flora/ausbushes/palebush,/obj/structure/window/reinforced/fulltile,/turf/open/floor/grass,/area/centcom/holding)
-"Xe" = (/obj/machinery/vending/autodrobe{req_access_txt = "0"},/turf/open/floor/wood,/area/centcom/holding)
-"Xk" = (/turf/open/floor/wood,/area/centcom/holding)
-"Xn" = (/obj/machinery/door/airlock/wood{req_one_access_txt = "0"},/turf/open/floor/wood,/area/centcom/holding)
-"Xo" = (/obj/machinery/vending/dinnerware,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Xx" = (/obj/machinery/light{dir = 4},/turf/open/floor/wood,/area/centcom/holding)
-"XL" = (/obj/machinery/door/airlock/wood,/turf/open/floor/wood,/area/centcom/holding)
-"XM" = (/obj/structure/chair/wood/wings{dir = 4},/turf/open/floor/wood,/area/centcom/holding)
-"Yf" = (/obj/structure/table/wood/bar,/turf/open/floor/wood,/area/centcom/holding)
-"Yh" = (/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/open/floor/wood,/area/centcom/holding)
-"Yk" = (/obj/structure/flora/wasteplant/wild_mutfruit,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Yl" = (/obj/structure/flora/tree/cactus,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Ym" = (/obj/machinery/computer/arcade/orion_trail,/turf/open/floor/wood,/area/centcom/holding)
-"Yo" = (/obj/machinery/light{dir = 8},/turf/open/floor/wood,/area/centcom/holding)
-"Yp" = (/obj/structure/flora/wasteplant/wild_broc,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Yu" = (/obj/structure/closet/secure_closet/freezer/fridge{locked = 0},/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"Yv" = (/obj/structure/flora/tree/joshua,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Yw" = (/obj/structure/flora/tree/wasteland,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Yx" = (/obj/structure/flora/wasteplant/wild_feracactus,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"Yy" = (/obj/structure/flora/wasteplant/wild_xander,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"YE" = (/obj/structure/flora/wasteplant/wild_agave,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"YF" = (/obj/structure/flora/tree/tall,/turf/open/indestructible/ground/outside/desert,/area/f13/underground/mountain)
-"YJ" = (/obj/item/reagent_containers/food/condiment/enzyme,/obj/item/reagent_containers/food/drinks/shaker,/obj/item/book/manual/barman_recipes,/obj/item/book/granter/action/drink_fling,/obj/structure/closet/crate,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"YL" = (/obj/machinery/vending/clothing,/turf/open/floor/wood,/area/centcom/holding)
-"YQ" = (/obj/structure/table,/obj/item/reagent_containers/glass/beaker,/turf/open/floor/plasteel/cafeteria,/area/centcom/holding)
-"YV" = (/obj/machinery/light{dir = 8},/obj/structure/rack,/obj/item/nullrod/claymore/saber{damtype = "stamina"; force = 30},/turf/open/floor/wood,/area/centcom/holding)
-"Za" = (/obj/machinery/door/airlock/wood{id_tag = "lmrestroom"},/turf/open/floor/wood,/area/centcom/holding)
-"Zt" = (/obj/machinery/vr_sleeper{dir = 1},/obj/machinery/light,/turf/open/floor/wood,/area/centcom/holding)
-"Zx" = (/mob/living/simple_animal/bot/medbot,/turf/open/floor/wood,/area/centcom/holding)
-"ZN" = (/obj/structure/fluff/rails,/obj/docking_port/stationary{dir = 2; dwidth = 25; height = 50; id = "emergency_away"; json_key = "emergency"; name = "CentCom Emergency Shuttle Dock"; width = 50},/turf/open/indestructible/ground/inside/subway,/area/f13/underground/mountain)
-"ZU" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/turf/open/floor/carpet/black,/area/centcom/holding)
-"ZW" = (/turf/open/floor/plasteel/white,/area/centcom/holding)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/open/space/basic,
+/area/f13/underground/mountain)
+"ab" = (
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"ac" = (
+/obj/structure/window/reinforced,
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"ad" = (
+/turf/open/space,
+/area/f13/underground/mountain)
+"ae" = (
+/turf/open/space/transit,
+/area/f13/underground/mountain)
+"af" = (
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"ag" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"ah" = (
+/obj/structure/foamedmetal,
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"ai" = (
+/obj/structure/foamedmetal,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"aj" = (
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"ak" = (
+/obj/structure/table,
+/obj/item/stack/medical/ointment{
+	heal_burn = 10
+	},
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"al" = (
+/obj/structure/table/wood{
+	layer = 3.3
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05";
+	pixel_y = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"am" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"an" = (
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"ao" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	layer = 3.3
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"ap" = (
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/wildlife)
+"aq" = (
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/offline)
+"ar" = (
+/turf/open/floor/holofloor/plating/burnmix,
+/area/holodeck/rec_center/burn)
+"as" = (
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/court)
+"at" = (
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/court)
+"au" = (
+/turf/open/floor/holofloor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/court)
+"av" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"aw" = (
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"ax" = (
+/obj/effect/holodeck_effect/mobspawner/penguin,
+/obj/effect/holodeck_effect/mobspawner/penguin,
+/obj/item/toy/snowball{
+	pixel_y = 6
+	},
+/obj/item/toy/snowball{
+	pixel_x = 5
+	},
+/obj/item/toy/snowball{
+	pixel_x = -4
+	},
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"ay" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"az" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aA" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aB" = (
+/obj/effect/holodeck_effect/mobspawner,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/wildlife)
+"aC" = (
+/obj/effect/holodeck_effect/sparks,
+/turf/open/floor/holofloor/plating/burnmix,
+/area/holodeck/rec_center/burn)
+"aD" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/court)
+"aE" = (
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/court)
+"aF" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/court)
+"aG" = (
+/obj/structure/flora/grass/wasteland,
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"aH" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"aI" = (
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aJ" = (
+/obj/structure/table/wood/poker,
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aK" = (
+/obj/structure/table/wood/poker,
+/obj/structure/table/wood/poker,
+/obj/effect/holodeck_effect/cards,
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aL" = (
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aM" = (
+/obj/structure/statue/snow/snowman{
+	anchored = 1
+	},
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"aN" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aO" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"aP" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aQ" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aR" = (
+/obj/effect/holodeck_effect/mobspawner/penguin_baby,
+/obj/structure/flora/tree/pine,
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"aS" = (
+/obj/structure/chair/wood,
+/turf/open/floor/holofloor/snow,
+/area/holodeck/rec_center/winterwonderland)
+"aT" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05";
+	pixel_y = 10
+	},
+/turf/open/floor/holofloor{
+	icon_state = "wood";
+	dir = 9
+	},
+/area/holodeck/rec_center/lounge)
+"aU" = (
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "stairs-l"
+	},
+/area/holodeck/rec_center/lounge)
+"aV" = (
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "stairs-r"
+	},
+/area/holodeck/rec_center/lounge)
+"aW" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/court)
+"aX" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/court)
+"aY" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 4
+	},
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"aZ" = (
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"ba" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"bb" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"bc" = (
+/obj/structure/table,
+/obj/item/stack/medical/bruise_pack{
+	heal_brute = 10
+	},
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/bunker)
+"bd" = (
+/obj/structure/table/wood,
+/obj/item/instrument/violin,
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"be" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	dir = 1
+	},
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"bf" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/barman_recipes,
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/holofloor/carpet,
+/area/holodeck/rec_center/lounge)
+"bg" = (
+/turf/open/floor/holofloor{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/court)
+"bh" = (
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/court)
+"bi" = (
+/turf/open/floor/holofloor{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/court)
+"bj" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"bk" = (
+/obj/effect/holodeck_effect/mobspawner/bee,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/anthophila)
+"bl" = (
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bm" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bn" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bo" = (
+/obj/structure/table/glass,
+/obj/item/surgicaldrill,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bp" = (
+/obj/structure/table/glass,
+/obj/item/hemostat,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bq" = (
+/obj/structure/table/glass,
+/obj/item/scalpel{
+	pixel_y = 10
+	},
+/obj/item/circular_saw,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"br" = (
+/obj/structure/table/glass,
+/obj/item/retractor,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bs" = (
+/obj/structure/table/glass,
+/obj/item/stack/medical/gauze,
+/obj/item/cautery,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bt" = (
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"bu" = (
+/obj/structure/holohoop{
+	layer = 3.9
+	},
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"bv" = (
+/turf/open/floor/holofloor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"bw" = (
+/turf/open/floor/holofloor/beach,
+/area/holodeck/rec_center/beach)
+"bx" = (
+/obj/structure/table,
+/obj/machinery/readybutton,
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"by" = (
+/obj/structure/table,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/clothing/suit/armor/tdome/red,
+/obj/item/clothing/under/color/red,
+/obj/item/holo/esword/red,
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"bz" = (
+/obj/structure/table,
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"bA" = (
+/obj/machinery/readybutton,
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"bB" = (
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"bC" = (
+/turf/open/floor/holofloor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"bD" = (
+/obj/effect/holodeck_effect/mobspawner/pet,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bE" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bF" = (
+/obj/effect/holodeck_effect/mobspawner/pet,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bG" = (
+/obj/structure/table/glass,
+/obj/item/surgical_drapes,
+/obj/item/razor,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bH" = (
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bI" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"bJ" = (
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/basketball)
+"bK" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"bL" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/holofloor/beach,
+/area/holodeck/rec_center/beach)
+"bM" = (
+/obj/effect/overlay/palmtree_l,
+/obj/effect/overlay/coconut,
+/turf/open/floor/holofloor/beach,
+/area/holodeck/rec_center/beach)
+"bN" = (
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"bO" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"bP" = (
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/dodgeball)
+"bQ" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"bR" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"bS" = (
+/obj/item/storage/bag/easterbasket{
+	name = "picnic basket";
+	pixel_y = 6
+	},
+/turf/open/floor/holofloor{
+	icon_state = "redbluefull"
+	},
+/area/holodeck/rec_center/pet_lounge)
+"bT" = (
+/obj/item/trash/plate,
+/turf/open/floor/holofloor{
+	icon_state = "redbluefull"
+	},
+/area/holodeck/rec_center/pet_lounge)
+"bU" = (
+/obj/structure/table/optable,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bV" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bW" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"bX" = (
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"bY" = (
+/obj/effect/holodeck_effect/mobspawner/monkey,
+/turf/open/floor/holofloor/beach,
+/area/holodeck/rec_center/beach)
+"bZ" = (
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"ca" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cb" = (
+/obj/effect/holodeck_effect/mobspawner/pet,
+/turf/open/floor/holofloor{
+	icon_state = "redbluefull"
+	},
+/area/holodeck/rec_center/pet_lounge)
+"cc" = (
+/obj/item/shovel/spade{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/floor/holofloor{
+	icon_state = "redbluefull"
+	},
+/area/holodeck/rec_center/pet_lounge)
+"cd" = (
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"ce" = (
+/obj/effect/holodeck_effect/mobspawner/bee,
+/obj/item/clothing/head/beekeeper_head,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/anthophila)
+"cf" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cg" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/beakers,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"ch" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"ci" = (
+/turf/open/floor/holofloor{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"cj" = (
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"ck" = (
+/turf/open/floor/holofloor{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/basketball)
+"cl" = (
+/obj/item/clothing/under/color/rainbow,
+/obj/item/clothing/glasses/sunglasses,
+/turf/open/floor/holofloor/beach,
+/area/holodeck/rec_center/beach)
+"cm" = (
+/obj/structure/window,
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"cn" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/holofloor{
+	dir = 10;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"co" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cp" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/holofloor{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cq" = (
+/obj/effect/holodeck_effect/mobspawner/bee,
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/beekeeper_suit,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/anthophila)
+"cr" = (
+/obj/effect/holodeck_effect/mobspawner/bee,
+/obj/item/melee/flyswatter,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/anthophila)
+"cs" = (
+/obj/machinery/chem_master,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"ct" = (
+/obj/structure/table/glass,
+/obj/item/healthanalyzer,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cu" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cv" = (
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"cw" = (
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"cx" = (
+/turf/open/floor/holofloor{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"cy" = (
+/obj/item/toy/beach_ball,
+/turf/open/floor/holofloor/beach,
+/area/holodeck/rec_center/beach)
+"cz" = (
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"cA" = (
+/obj/structure/window,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/holofloor{
+	dir = 9;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cB" = (
+/obj/structure/window,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cC" = (
+/obj/structure/window,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/turf/open/floor/holofloor{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cD" = (
+/obj/structure/sink/puddle,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cE" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cF" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"cG" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/basketball)
+"cH" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"cI" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cJ" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cK" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cL" = (
+/obj/machinery/hydroponics/soil,
+/obj/item/cultivator,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cM" = (
+/obj/machinery/hydroponics/soil,
+/obj/effect/holodeck_effect/mobspawner/pet,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cN" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cO" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cP" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cQ" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/computer/pandemic,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cR" = (
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"cS" = (
+/turf/open/floor/holofloor/beach/coast_t,
+/area/holodeck/rec_center/beach)
+"cT" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/holofloor/beach/coast_t,
+/area/holodeck/rec_center/beach)
+"cU" = (
+/obj/item/shovel/spade,
+/turf/open/floor/holofloor/beach/coast_t,
+/area/holodeck/rec_center/beach)
+"cV" = (
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"cW" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/pet_lounge)
+"cX" = (
+/obj/machinery/door/window/westleft,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"cY" = (
+/turf/open/floor/holofloor/beach/coast_b,
+/area/holodeck/rec_center/beach)
+"cZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"da" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"db" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/sleeper{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"dc" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"dd" = (
+/obj/machinery/sleeper{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/medical)
+"de" = (
+/turf/open/floor/holofloor{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"df" = (
+/obj/structure/holohoop{
+	dir = 1;
+	layer = 4.1
+	},
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"dg" = (
+/turf/open/floor/holofloor{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/basketball)
+"dh" = (
+/turf/open/floor/holofloor/beach/water,
+/area/holodeck/rec_center/beach)
+"di" = (
+/obj/structure/table,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/clothing/suit/armor/tdome/green,
+/obj/item/clothing/under/color/green,
+/obj/item/holo/esword/green,
+/turf/open/floor/holofloor/basalt,
+/area/holodeck/rec_center/thunderdome)
+"dj" = (
+/turf/open/floor/holofloor{
+	dir = 10;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"dk" = (
+/turf/open/floor/holofloor{
+	dir = 2;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"dl" = (
+/obj/machinery/readybutton,
+/turf/open/floor/holofloor{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/dodgeball)
+"dm" = (
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/refuel)
+"dn" = (
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/spacechess)
+"do" = (
+/obj/item/banner/blue,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"dp" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/suit/armor/riot/knight/blue,
+/obj/item/clothing/head/helmet/knight/blue,
+/obj/item/claymore,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"dq" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/crown/fancy{
+	pixel_y = 6
+	},
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"dr" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/suit/armor/riot/knight/red,
+/obj/item/clothing/head/helmet/knight/red,
+/obj/item/claymore,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"ds" = (
+/obj/item/banner/red,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"dt" = (
+/turf/open/floor/holofloor/hyperspace,
+/area/holodeck/rec_center/kobayashi)
+"du" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor/hyperspace,
+/area/holodeck/rec_center/kobayashi)
+"dv" = (
+/obj/structure/closet{
+	density = 0
+	},
+/obj/item/clothing/suit/judgerobe,
+/obj/item/clothing/head/powdered_wig,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dw" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/suit/nun,
+/obj/item/clothing/head/nun_hood,
+/obj/item/clothing/suit/holidaypriest,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dx" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/book/bible,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dy" = (
+/obj/structure/table/wood/fancy,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dz" = (
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dA" = (
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"dB" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/firingrange)
+"dC" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/firingrange)
+"dD" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/firingrange)
+"dE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/firingrange)
+"dF" = (
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/firingrange)
+"dG" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/refuel)
+"dH" = (
+/obj/item/cardboard_cutout/adaptive{
+	color = "#9999BB";
+	icon_state = "cutout_viva";
+	name = "Black Rook"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"dI" = (
+/obj/item/cardboard_cutout/adaptive{
+	color = "#9999BB";
+	icon_state = "cutout_mime";
+	name = "Black Queen"
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"dJ" = (
+/obj/item/cardboard_cutout/adaptive{
+	color = "#9999BB";
+	icon_state = "cutout_clown";
+	name = "Black King"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"dK" = (
+/obj/item/cardboard_cutout/adaptive{
+	color = "#9999BB";
+	icon_state = "cutout_ian";
+	name = "Black Knight"
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"dL" = (
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"dM" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"dN" = (
+/obj/structure/window/reinforced,
+/obj/machinery/mass_driver{
+	dir = 1;
+	icon_state = "mass_driver";
+	id = "trektorpedo1";
+	name = "photon torpedo tube"
+	},
+/obj/item/toy/minimeteor{
+	color = "";
+	desc = "A primitive long-range weapon, inferior to Nanotrasen's perfected bluespace artillery.";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "impact_laser";
+	name = "photon torpedo"
+	},
+/turf/open/floor/holofloor/hyperspace,
+/area/holodeck/rec_center/kobayashi)
+"dO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "A test for cadets";
+	events = list("Raiders" = 3, "Interstellar Flux" = 1, "Illness" = 3, "Breakdown" = 2, "Malfunction" = 2, "Collision" = 1, "Spaceport" = 2);
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_state = "control_boxp";
+	name = "Kobayashi Maru control computer";
+	prizes = list(/obj/item/paper/fluff/holodeck/trek_diploma = 1);
+	settlers = list("Kirk","Worf","Gene")
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"dP" = (
+/obj/machinery/button/massdriver{
+	id = "trektorpedo1";
+	layer = 3.9;
+	name = "photon torpedo button";
+	pixel_x = -16;
+	pixel_y = -5
+	},
+/obj/machinery/button/massdriver{
+	id = "trektorpedo2";
+	layer = 3.9;
+	name = "photon torpedo button";
+	pixel_x = 16;
+	pixel_y = -5
+	},
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "A test for cadets";
+	events = list("Raiders" = 3, "Interstellar Flux" = 1, "Illness" = 3, "Breakdown" = 2, "Malfunction" = 2, "Collision" = 1, "Spaceport" = 2);
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_state = "control_boxp";
+	name = "Kobayashi Maru control computer";
+	prizes = list(/obj/item/paper/fluff/holodeck/trek_diploma = 1);
+	settlers = list("Kirk","Worf","Gene")
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"dQ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "A test for cadets";
+	events = list("Raiders" = 3, "Interstellar Flux" = 1, "Illness" = 3, "Breakdown" = 2, "Malfunction" = 2, "Collision" = 1, "Spaceport" = 2);
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_state = "control_boxp";
+	name = "Kobayashi Maru control computer";
+	prizes = list(/obj/item/paper/fluff/holodeck/trek_diploma = 1);
+	settlers = list("Kirk","Worf","Gene")
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"dR" = (
+/obj/structure/window/reinforced,
+/obj/machinery/mass_driver{
+	dir = 1;
+	icon_state = "mass_driver";
+	id = "trektorpedo2";
+	name = "photon torpedo tube"
+	},
+/obj/item/toy/minimeteor{
+	color = "";
+	desc = "A primitive long-range weapon, inferior to Nanotrasen's perfected bluespace artillery.";
+	icon = 'icons/effects/effects.dmi';
+	icon_state = "impact_laser";
+	name = "photon torpedo"
+	},
+/turf/open/floor/holofloor/hyperspace,
+/area/holodeck/rec_center/kobayashi)
+"dS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 1
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dT" = (
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 4
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dU" = (
+/obj/structure/chair,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dV" = (
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 1
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 4
+	},
+/area/holodeck/rec_center/chapelcourt)
+"dX" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/melee/classic_baton/telescopic,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"dY" = (
+/obj/structure/table/wood,
+/obj/item/toy/crayon/white,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"dZ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"ea" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white";
+	dir = 8
+	},
+/area/holodeck/rec_center/firingrange)
+"eb" = (
+/obj/structure/target_stake,
+/obj/machinery/magnetic_module,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/firingrange)
+"ec" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white";
+	dir = 4
+	},
+/area/holodeck/rec_center/firingrange)
+"ed" = (
+/obj/item/cardboard_cutout/adaptive{
+	color = "#9999BB";
+	icon_state = "cutout_greytide";
+	name = "Black Pawn"
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"ee" = (
+/obj/item/cardboard_cutout/adaptive{
+	color = "#9999BB";
+	icon_state = "cutout_greytide";
+	name = "Black Pawn"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"ef" = (
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	icon_state = "right"
+	},
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"eg" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"eh" = (
+/obj/machinery/door/window/westleft{
+	dir = 2
+	},
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"ei" = (
+/obj/structure/table/glass,
+/obj/machinery/recharger,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"ej" = (
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"ek" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"el" = (
+/obj/structure/table/glass,
+/obj/item/gun/energy/e_gun/mini/practice_phaser,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"em" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"en" = (
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 2
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eo" = (
+/obj/item/gavelblock,
+/obj/item/gavelhammer,
+/obj/structure/table/wood,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"ep" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eq" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 2
+	},
+/area/holodeck/rec_center/chapelcourt)
+"er" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white";
+	dir = 10
+	},
+/area/holodeck/rec_center/firingrange)
+"es" = (
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/firingrange)
+"et" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white";
+	dir = 6
+	},
+/area/holodeck/rec_center/firingrange)
+"eu" = (
+/obj/item/weldingtool,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/refuel)
+"ev" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"ew" = (
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"ex" = (
+/turf/open/floor/holofloor{
+	icon_state = "stairs-old";
+	dir = 8
+	},
+/area/holodeck/rec_center/thunderdome1218)
+"ey" = (
+/obj/structure/table/wood,
+/obj/item/melee/chainofcommand{
+	name = "chain whip"
+	},
+/obj/item/twohanded/spear,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/thunderdome1218)
+"ez" = (
+/obj/structure/table/wood,
+/obj/item/scythe,
+/obj/item/twohanded/spear,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/thunderdome1218)
+"eA" = (
+/obj/structure/table/wood,
+/obj/item/tailclub,
+/obj/item/twohanded/spear,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/thunderdome1218)
+"eB" = (
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eC" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eD" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/green,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/firingrange)
+"eF" = (
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/firingrange)
+"eG" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/firingrange)
+"eH" = (
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/thunderdome1218)
+"eI" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eJ" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eK" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eL" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eM" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 1
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eN" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 4
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eO" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eP" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eQ" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eR" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eS" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	icon_state = "chapel";
+	dir = 2
+	},
+/area/holodeck/rec_center/chapelcourt)
+"eT" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/orange,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eU" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl/red,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"eV" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"eW" = (
+/obj/item/cardboard_cutout/adaptive{
+	icon_state = "cutout_greytide";
+	name = "White Pawn"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"eX" = (
+/obj/item/cardboard_cutout/adaptive{
+	icon_state = "cutout_greytide";
+	name = "White Pawn"
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"eY" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/thunderdome1218)
+"eZ" = (
+/obj/machinery/door/window/westleft{
+	dir = 2
+	},
+/turf/open/floor/holofloor/asteroid,
+/area/holodeck/rec_center/thunderdome1218)
+"fa" = (
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	icon_state = "right"
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"fb" = (
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen/blue,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/holodeck/rec_center/kobayashi)
+"fc" = (
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/holodeck/rec_center/kobayashi)
+"fd" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/folder,
+/obj/item/pen/red,
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/holodeck/rec_center/kobayashi)
+"fe" = (
+/obj/machinery/door/window/westleft{
+	dir = 2
+	},
+/turf/open/floor/holofloor/plating,
+/area/holodeck/rec_center/kobayashi)
+"ff" = (
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/obj/item/clothing/under/schoolgirl,
+/obj/item/toy/katana,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/school)
+"fg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/firingrange)
+"fh" = (
+/obj/item/paper/guides/jobs/security/range,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/firingrange)
+"fi" = (
+/obj/structure/table/reinforced,
+/obj/machinery/magnetic_controller{
+	autolink = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/holofloor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/holodeck/rec_center/firingrange)
+"fj" = (
+/obj/item/cardboard_cutout/adaptive{
+	icon_state = "cutout_viva";
+	name = "White Rook"
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"fk" = (
+/obj/item/cardboard_cutout/adaptive{
+	icon_state = "cutout_mime";
+	name = "White Queen"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"fl" = (
+/obj/item/cardboard_cutout/adaptive{
+	icon_state = "cutout_clown";
+	name = "White King"
+	},
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
+"fm" = (
+/obj/item/cardboard_cutout/adaptive{
+	icon_state = "cutout_ian";
+	name = "White Knight"
+	},
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"fn" = (
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/holodeck/rec_center/kobayashi)
+"fo" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/kobayashi)
+"fp" = (
+/turf/open/floor/holofloor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/holodeck/rec_center/firingrange)
+"fq" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/holofloor/grass,
+/area/holodeck/rec_center/thunderdome1218)
+"fr" = (
+/obj/structure/rack,
+/obj/item/clothing/under/trek/medsci,
+/obj/item/clothing/under/trek/medsci,
+/obj/item/clothing/under/trek/command,
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/holodeck/rec_center/kobayashi)
+"fs" = (
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 2
+	},
+/area/holodeck/rec_center/kobayashi)
+"ft" = (
+/obj/structure/rack,
+/obj/item/clothing/under/trek/engsec,
+/obj/item/clothing/under/trek/engsec,
+/turf/open/floor/holofloor{
+	icon_state = "neutral";
+	dir = 1
+	},
+/area/holodeck/rec_center/kobayashi)
+"fu" = (
+/obj/item/target,
+/obj/item/target/clown,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/firingrange)
+"fv" = (
+/obj/item/target,
+/obj/item/target/syndicate,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/firingrange)
+"fw" = (
+/obj/structure/rack,
+/obj/item/gun/energy/laser/practice,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/holofloor,
+/area/holodeck/rec_center/firingrange)
+"fx" = (
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 1;
+	height = 4;
+	id = "pod4_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space,
+/area/f13/underground/mountain)
+"fy" = (
+/obj/machinery/igniter/on,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fz" = (
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fA" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fB" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/red,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/transforming/energy/sword/saber/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fC" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomegen";
+	name = "General Supply"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/arena_source)
+"fD" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fE" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/tdome/arena_source)
+"fF" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fG" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/tdome/arena_source)
+"fH" = (
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena_source)
+"fI" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/tdome/arena_source)
+"fJ" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/tdome/arena_source)
+"fK" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/green,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/transforming/energy/sword/saber/green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fL" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/tdome/arena_source)
+"fM" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/tdome/arena_source)
+"fN" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fO" = (
+/turf/open/floor/circuit/green,
+/area/tdome/arena_source)
+"fP" = (
+/obj/machinery/flasher{
+	id = "tdomeflash";
+	name = "Thunderdome Flash"
+	},
+/turf/open/floor/circuit/green,
+/area/tdome/arena_source)
+"fQ" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fR" = (
+/turf/open/floor/plasteel/blue/corner,
+/area/centcom/evac)
+"fS" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/tdome/arena_source)
+"fT" = (
+/turf/open/floor/plasteel/green/corner,
+/area/tdome/arena_source)
+"fU" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomehea";
+	name = "Heavy Supply"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/arena_source)
+"fV" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fW" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/turf/open/floor/plasteel,
+/area/tdome/arena_source)
+"fX" = (
+/turf/closed/indestructible/riveted,
+/area/start)
+"fY" = (
+/obj/effect/landmark/start/new_player,
+/turf/open/floor/plating,
+/area/start)
+"fZ" = (
+/turf/closed/indestructible/riveted,
+/area/ctf)
+"ga" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 9
+	},
+/area/ctf)
+"gb" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 1
+	},
+/area/ctf)
+"gc" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 5
+	},
+/area/ctf)
+"gd" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/ctf)
+"ge" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/ctf)
+"gf" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
+	},
+/area/ctf)
+"gg" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 8
+	},
+/area/ctf)
+"gh" = (
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"gi" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 4
+	},
+/area/ctf)
+"gj" = (
+/turf/open/floor/plasteel/blue,
+/area/ctf)
+"gk" = (
+/turf/open/floor/plasteel/darkblue,
+/area/ctf)
+"gl" = (
+/obj/structure/barricade/security/ctf,
+/turf/open/floor/circuit,
+/area/ctf)
+"gm" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/bluespace,
+/area/ctf)
+"gn" = (
+/obj/structure/barricade/security/ctf,
+/turf/open/floor/plasteel/bluespace,
+/area/ctf)
+"go" = (
+/turf/open/floor/plasteel/bluespace,
+/area/ctf)
+"gp" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/ctf)
+"gq" = (
+/obj/structure/barricade/security/ctf,
+/turf/open/floor/circuit/red,
+/area/ctf)
+"gr" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/ctf)
+"gs" = (
+/turf/open/floor/plasteel/red,
+/area/ctf)
+"gt" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"gu" = (
+/turf/closed/indestructible/splashscreen,
+/area/start)
+"gv" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 10
+	},
+/area/ctf)
+"gw" = (
+/turf/open/floor/plasteel/darkblue/side,
+/area/ctf)
+"gx" = (
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 6
+	},
+/area/ctf)
+"gy" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/ctf)
+"gz" = (
+/turf/open/floor/plasteel/darkred/side,
+/area/ctf)
+"gA" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/ctf)
+"gB" = (
+/obj/structure/window/reinforced/fulltile{
+	obj_integrity = 5000;
+	max_integrity = 5000;
+	name = "hardened window"
+	},
+/turf/open/floor/plating,
+/area/ctf)
+"gC" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"gD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/darkblue/corner,
+/area/ctf)
+"gE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"gF" = (
+/obj/machinery/light,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"gG" = (
+/obj/structure/closet/syndicate/personal,
+/turf/open/floor/plasteel/dark,
+/area/syndicate_mothership/control)
+"gH" = (
+/obj/structure/table,
+/obj/item/gun/energy/ionrifle{
+	pin = /obj/item/firing_pin
+	},
+/turf/open/floor/plasteel/dark,
+/area/syndicate_mothership/control)
+"gI" = (
+/obj/machinery/power/emitter/energycannon,
+/turf/open/floor/plating,
+/area/ctf)
+"gJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"gK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 4
+	},
+/area/ctf)
+"gL" = (
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 8
+	},
+/area/ctf)
+"gM" = (
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 4
+	},
+/area/ctf)
+"gN" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/ctf)
+"gO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"gP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ctf)
+"gQ" = (
+/turf/open/floor/plating,
+/area/ctf)
+"gR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	luminosity = 2
+	},
+/area/ctf)
+"gS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue/corner,
+/area/ctf)
+"gT" = (
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 1
+	},
+/area/ctf)
+"gU" = (
+/turf/open/floor/plasteel/darkblue/corner,
+/area/ctf)
+"gV" = (
+/turf/closed/indestructible/fakedoor{
+	name = "CentCom Warehouse"
+	},
+/area/f13/underground/mountain)
+"gW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 4
+	},
+/area/ctf)
+"gX" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 1
+	},
+/area/ctf)
+"gY" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkblue/corner{
+	dir = 4
+	},
+/area/ctf)
+"gZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"ha" = (
+/obj/machinery/power/emitter/energycannon{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ctf)
+"hb" = (
+/obj/structure/trap/ctf/blue,
+/turf/open/floor/plasteel/blue,
+/area/ctf)
+"hc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hd" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"he" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hf" = (
+/turf/open/floor/plasteel/darkred,
+/area/ctf)
+"hg" = (
+/obj/structure/trap/ctf/red,
+/turf/open/floor/plasteel/darkred,
+/area/ctf)
+"hh" = (
+/turf/closed/indestructible/rock/snow,
+/area/syndicate_mothership)
+"hi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hj" = (
+/turf/open/floor/circuit,
+/area/ctf)
+"hk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hl" = (
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership;
+	dir = 1;
+	dwidth = 25;
+	height = 50;
+	id = "emergency_syndicate";
+	name = "Syndicate Auxillary Shuttle Dock";
+	width = 50
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"hm" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hn" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit,
+/area/ctf)
+"ho" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/circuit,
+/area/ctf)
+"hp" = (
+/obj/structure/barricade/security/ctf,
+/turf/open/floor/circuit/green/off,
+/area/ctf)
+"hq" = (
+/obj/structure/trap/ctf/red,
+/turf/open/floor/plasteel/red,
+/area/ctf)
+"hr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 9
+	},
+/area/ctf)
+"hs" = (
+/obj/effect/landmark/prisonwarp,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ht" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/evac)
+"hu" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"hv" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"hw" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"hx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
+	},
+/area/ctf)
+"hy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 8
+	},
+/area/ctf)
+"hz" = (
+/turf/open/floor/circuit/green/off,
+/area/ctf)
+"hA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/ctf)
+"hB" = (
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hC" = (
+/turf/open/floor/circuit/green/anim,
+/area/ctf)
+"hD" = (
+/obj/machinery/capture_the_flag/blue,
+/turf/open/floor/circuit/green/anim,
+/area/ctf)
+"hE" = (
+/obj/item/twohanded/ctf/blue,
+/turf/open/floor/circuit/green/anim,
+/area/ctf)
+"hF" = (
+/obj/item/twohanded/ctf/red,
+/turf/open/floor/circuit/green/anim,
+/area/ctf)
+"hG" = (
+/obj/machinery/capture_the_flag/red,
+/turf/open/floor/circuit/green/anim,
+/area/ctf)
+"hH" = (
+/turf/closed/indestructible/rock,
+/area/f13/brotherhood)
+"hI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 10
+	},
+/area/ctf)
+"hJ" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkblue/side,
+/area/ctf)
+"hK" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 6
+	},
+/area/ctf)
+"hL" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit/green/off,
+/area/ctf)
+"hM" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/ctf)
+"hN" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/side,
+/area/ctf)
+"hO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/ctf)
+"hP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hQ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"hR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hV" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/circuit/red,
+/area/ctf)
+"hX" = (
+/turf/closed/indestructible/fakedoor{
+	name = "CentCom Cell"
+	},
+/area/centcom/evac)
+"hY" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"hZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"ia" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/ctf)
+"ib" = (
+/turf/open/floor/plasteel/darkred/corner,
+/area/ctf)
+"ic" = (
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/ctf)
+"id" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/ctf)
+"ie" = (
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
+	},
+/area/ctf)
+"if" = (
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/ctf)
+"ig" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/ctf)
+"ih" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ctf)
+"ii" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
+	},
+/area/ctf)
+"ij" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/ctf)
+"ik" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/ctf)
+"il" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"im" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"in" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"io" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"ip" = (
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iq" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"ir" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"is" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"it" = (
+/obj/structure/barricade/security,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"iu" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"iv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"ix" = (
+/turf/closed/wall/f13/vault,
+/area/tdome/tdomeobserve)
+"iy" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05";
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"iz" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
+/obj/structure/sign/plaques/golden{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"iA" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"iB" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"iC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"iD" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iE" = (
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"iF" = (
+/obj/machinery/status_display{
+	name = "cargo display";
+	supply_display = 1
+	},
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"iG" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"iH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iI" = (
+/obj/machinery/manned_turret/ultimate,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iK" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"iL" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"iM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"iN" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"iO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/f13/underground/mountain)
+"iP" = (
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/f13/underground/mountain)
+"iQ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 5
+	},
+/area/f13/underground/mountain)
+"iR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/f13/underground/mountain)
+"iS" = (
+/turf/open/floor/plasteel/neutral,
+/area/f13/underground/mountain)
+"iT" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Thunderdome Admin"
+	},
+/area/centcom/evac)
+"iU" = (
+/obj/machinery/status_display,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"iV" = (
+/obj/machinery/computer/prisoner,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iW" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"iX" = (
+/turf/open/floor/plasteel/brown{
+	dir = 4
+	},
+/area/f13/underground/mountain)
+"iY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external,
+/turf/open/floor/plating,
+/area/f13/underground/mountain)
+"iZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "XCCQMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"ja" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/security,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jb" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "XCCQMLoad2";
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"jc" = (
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/f13/underground/mountain)
+"jd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 4
+	},
+/area/f13/underground/mountain)
+"je" = (
+/obj/machinery/door/poddoor{
+	density = 1;
+	id = "XCCQMLoaddoor2";
+	name = "Supply Dock Loading Door"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "XCCQMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jf" = (
+/obj/structure/plasticflaps,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "XCCQMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jg" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	opacity = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"ji" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"jj" = (
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jk" = (
+/obj/machinery/door/poddoor{
+	density = 1;
+	id = "XCCQMLoaddoor2";
+	name = "Supply Dock Loading Door"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "XCCQMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jl" = (
+/obj/effect/turf_decal/stripes/end,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "XCCQMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jn" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jo" = (
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/structure/table,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jp" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Shuttle";
+	req_access_txt = "106"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jq" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"js" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jt" = (
+/obj/machinery/button/door{
+	id = "XCCQMLoaddoor";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = -27;
+	pixel_y = -5
+	},
+/obj/machinery/button/door{
+	dir = 2;
+	id = "XCCQMLoaddoor2";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = -27;
+	pixel_y = 5
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"ju" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jv" = (
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jw" = (
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"jx" = (
+/obj/structure/flora/tree/palm,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"jy" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"jz" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"jA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jC" = (
+/obj/docking_port/stationary{
+	dir = 1;
+	dwidth = 1;
+	height = 4;
+	id = "pod3_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space,
+/area/f13/underground/mountain)
+"jD" = (
+/obj/machinery/door/poddoor{
+	density = 1;
+	id = "XCCQMLoaddoor";
+	name = "Supply Dock Loading Door"
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "XCCQMLoad"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jE" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "XCCQMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jF" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"jG" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jH" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/flashlight/seclite,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jI" = (
+/obj/machinery/door/poddoor{
+	density = 1;
+	id = "XCCQMLoaddoor";
+	name = "Supply Dock Loading Door"
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "XCCQMLoad"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jJ" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 6;
+	id = "XCCQMLoad2"
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jL" = (
+/obj/structure/closet/wardrobe/cargotech,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jM" = (
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "XCCQMLoad";
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"jN" = (
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"jO" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/brotherhood)
+"jP" = (
+/turf/open/floor/plasteel/brown{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"jQ" = (
+/turf/open/floor/plasteel/yellowsiding,
+/area/f13/underground/mountain)
+"jR" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"jS" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jT" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
+/obj/item/crowbar/power,
+/obj/item/storage/belt/security/full,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"jU" = (
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"jV" = (
+/turf/open/floor/plasteel/stairs/left,
+/area/centcom/evac)
+"jW" = (
+/turf/open/floor/plasteel/stairs/right,
+/area/centcom/evac)
+"jX" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/machinery/camera{
+	c_tag = "Arena";
+	light_power = 25;
+	light_range = 25;
+	name = "thunderdome 1";
+	network = list("thunder");
+	pixel_x = 10;
+	resistance_flags = 64
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"jY" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/machinery/camera{
+	c_tag = "Arena";
+	light_power = 25;
+	light_range = 25;
+	name = "Thunderdome 2";
+	network = list("thunder");
+	pixel_x = 10;
+	resistance_flags = 64
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"jZ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"ka" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"kb" = (
+/obj/machinery/flasher{
+	id = "tdomeflash";
+	light_power = 25;
+	light_range = 25;
+	name = "Thunderdome Flash"
+	},
+/turf/open/floor/circuit/green,
+/area/tdome/arena)
+"kc" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/space/hardsuit/deathsquad{
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kd" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/loyalty,
+/obj/item/gun/ballistic/automatic/ar,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ke" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
+/obj/item/crowbar/power,
+/obj/item/storage/belt/security/full,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kf" = (
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kg" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/space/hardsuit/deathsquad{
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kh" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"ki" = (
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"kj" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/brown,
+/area/f13/underground/mountain)
+"kk" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"kl" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"km" = (
+/turf/closed/wall/f13/tunnel,
+/area/centcom/evac)
+"kn" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ko" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien20"
+	},
+/area/abductor_ship)
+"kp" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien21"
+	},
+/area/abductor_ship)
+"kq" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien22"
+	},
+/area/abductor_ship)
+"kr" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien23"
+	},
+/area/abductor_ship)
+"ks" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien24"
+	},
+/area/abductor_ship)
+"kt" = (
+/obj/structure/flora/grass/wasteland,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"ku" = (
+/turf/closed/indestructible/riveted,
+/area/syndicate_mothership/control)
+"kv" = (
+/obj/machinery/door/poddoor/shuttledock{
+	checkdir = 1;
+	name = "syndicate blast door";
+	turftype = /turf/open/floor/plating/asteroid/snow
+	},
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"kw" = (
+/turf/open/floor/plasteel/brown,
+/area/f13/underground/mountain)
+"kx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ky" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"kz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/evac)
+"kA" = (
+/obj/machinery/newscaster/security_unit,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"kB" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"kC" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain,
+/obj/machinery/door/window/brigdoor/southleft{
+	name = "Shower"
+	},
+/obj/item/soap/deluxe,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"kD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kE" = (
+/obj/structure/closet/emcloset,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kG" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kH" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kI" = (
+/obj/item/gun/energy/pulse/carbine/loyalpin,
+/obj/item/flashlight/seclite,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kJ" = (
+/obj/item/storage/box/emps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashbangs,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kK" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien16"
+	},
+/area/abductor_ship)
+"kL" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien17"
+	},
+/area/abductor_ship)
+"kM" = (
+/obj/machinery/abductor/experiment{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"kN" = (
+/obj/machinery/abductor/console{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"kO" = (
+/obj/machinery/abductor/pad{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"kP" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien18"
+	},
+/area/abductor_ship)
+"kQ" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien19"
+	},
+/area/abductor_ship)
+"kR" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kS" = (
+/obj/item/storage/box/emps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashbangs,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kT" = (
+/obj/structure/sign/warning/nosmoking,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"kU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"kV" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"kW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kX" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kY" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Auxillary Dock";
+	opacity = 1;
+	req_access_txt = ""
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"kZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"la" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lb" = (
+/obj/item/gun/energy/pulse/carbine/loyalpin,
+/obj/item/flashlight/seclite,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lc" = (
+/obj/item/storage/box/emps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashbangs,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"le" = (
+/obj/item/storage/box/emps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashbangs,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/item/grenade/plastic/x4,
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lf" = (
+/obj/machinery/door/airlock/silver{
+	name = "Bathroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"lg" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien14"
+	},
+/area/abductor_ship)
+"lh" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"li" = (
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lj" = (
+/obj/structure/closet/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lk" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien15"
+	},
+/area/abductor_ship)
+"ll" = (
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"lm" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"ln" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/brown,
+/area/f13/underground/mountain)
+"lo" = (
+/turf/open/floor/plasteel/brown{
+	dir = 6
+	},
+/area/f13/underground/mountain)
+"lp" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Shuttle Control Office";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"lq" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supply";
+	req_access_txt = "106"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"lr" = (
+/obj/machinery/ai_status_display,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"ls" = (
+/obj/machinery/status_display,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"lt" = (
+/obj/machinery/door/airlock/external{
+	name = "Ferry Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lu" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lv" = (
+/obj/machinery/door/airlock/external{
+	name = "Ferry Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lx" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ly" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lz" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"lB" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien12"
+	},
+/area/abductor_ship)
+"lC" = (
+/obj/item/retractor/alien,
+/obj/item/hemostat/alien,
+/obj/structure/table/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lD" = (
+/obj/effect/landmark/abductor/scientist{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lE" = (
+/obj/structure/table/optable/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lF" = (
+/obj/effect/landmark/abductor/agent{
+	team_number = 4
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lG" = (
+/obj/structure/table/abductor,
+/obj/item/storage/box/alienhandcuffs,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lH" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien13"
+	},
+/area/abductor_ship)
+"lI" = (
+/turf/open/indestructible/binary,
+/area/f13/underground/mountain)
+"lJ" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"lK" = (
+/obj/machinery/computer/auxillary_base{
+	pixel_y = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"lL" = (
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/item/storage/box/handcuffs,
+/obj/item/flashlight/seclite,
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"lM" = (
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/obj/item/camera,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"lN" = (
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-15";
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 6
+	},
+/area/centcom/evac)
+"lO" = (
+/obj/structure/fireplace,
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"lP" = (
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 10
+	},
+/area/centcom/evac)
+"lQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"lR" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"lS" = (
+/obj/machinery/computer/card/centcom,
+/obj/item/card/id/centcom,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"lT" = (
+/obj/machinery/computer/communications,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"lU" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 32;
+	use_power = 0
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"lV" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/folder/blue,
+/obj/item/melee/chainofcommand,
+/obj/item/stamp/captain,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"lW" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/obj/item/storage/secure/safe{
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"lX" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien10"
+	},
+/area/abductor_ship)
+"lY" = (
+/obj/item/surgical_drapes,
+/obj/item/paper/guides/antag/abductor,
+/obj/item/scalpel/alien,
+/obj/structure/table/abductor,
+/obj/item/cautery/alien,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"lZ" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien11"
+	},
+/area/abductor_ship)
+"ma" = (
+/obj/structure/flora/grass/wasteland,
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"mb" = (
+/obj/machinery/computer/shuttle/labor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"mc" = (
+/obj/machinery/computer/shuttle/mining,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"md" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"me" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"mf" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"mg" = (
+/turf/open/floor/plasteel/brown{
+	dir = 9
+	},
+/area/f13/underground/mountain)
+"mh" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 5
+	},
+/area/f13/underground/mountain)
+"mi" = (
+/obj/machinery/ai_status_display,
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"mj" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"mk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ml" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/space/hardsuit/deathsquad{
+	pixel_y = 5
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/combat/swat,
+/obj/item/clothing/mask/gas/sechailer/swat,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"mm" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/loyalty,
+/obj/item/gun/ballistic/automatic/ar,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"mn" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs,
+/obj/item/crowbar/red,
+/obj/item/crowbar/power,
+/obj/item/storage/belt/security/full,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"mo" = (
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"mp" = (
+/obj/effect/landmark/thunderdome/admin,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"mq" = (
+/obj/structure/chair/comfy/brown{
+	color = "#66b266";
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkgreen,
+/area/tdome/tdomeobserve)
+"mr" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien6"
+	},
+/area/abductor_ship)
+"ms" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien7"
+	},
+/area/abductor_ship)
+"mt" = (
+/obj/machinery/abductor/gland_dispenser,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"mu" = (
+/obj/structure/table/abductor,
+/obj/item/surgicaldrill/alien,
+/obj/item/circular_saw/alien,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"mv" = (
+/obj/structure/bed/abductor,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"mw" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien8"
+	},
+/area/abductor_ship)
+"mx" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien9"
+	},
+/area/abductor_ship)
+"my" = (
+/obj/structure/flora/tree/wasteland,
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"mz" = (
+/obj/item/disk/data,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"mA" = (
+/obj/item/toy/figure/syndie,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"mB" = (
+/obj/effect/baseturf_helper/asteroid/snow,
+/turf/closed/indestructible/rock/snow,
+/area/syndicate_mothership)
+"mC" = (
+/obj/structure/flora/tree/wasteland,
+/obj/effect/light_emitter{
+	set_cap = 1;
+	set_luminosity = 4
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"mD" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 9
+	},
+/area/f13/underground/mountain)
+"mE" = (
+/obj/machinery/button/flasher{
+	id = "tdomeflash"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"mF" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 1
+	},
+/area/f13/underground/mountain)
+"mG" = (
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 5
+	},
+/area/f13/underground/mountain)
+"mH" = (
+/obj/machinery/computer/security/mining{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"mI" = (
+/turf/open/floor/plasteel/brown{
+	dir = 10
+	},
+/area/f13/underground/mountain)
+"mJ" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/brown,
+/area/f13/underground/mountain)
+"mK" = (
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"mL" = (
+/turf/open/floor/wood,
+/area/centcom/evac)
+"mM" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mN" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mO" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"mQ" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mR" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mT" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"mU" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"mV" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"mW" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"mX" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"mY" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"mZ" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/vault{
+	name = "Vault Door";
+	req_access_txt = "53"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"na" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"nb" = (
+/turf/closed/indestructible/abductor,
+/area/abductor_ship)
+"nc" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien2"
+	},
+/area/abductor_ship)
+"nd" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien3"
+	},
+/area/abductor_ship)
+"ne" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien4"
+	},
+/area/abductor_ship)
+"nf" = (
+/turf/closed/indestructible/abductor{
+	icon_state = "alien5"
+	},
+/area/abductor_ship)
+"ng" = (
+/obj/effect/baseturf_helper/asteroid/snow,
+/turf/closed/indestructible/riveted,
+/area/syndicate_mothership/control)
+"nh" = (
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership;
+	dheight = 1;
+	dir = 8;
+	dwidth = 12;
+	height = 17;
+	id = "syndicate_away";
+	name = "syndicate recon outpost";
+	roundstart_template = /datum/map_template/shuttle/infiltrator/basic;
+	width = 23
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"ni" = (
+/turf/open/floor/plasteel/grimy,
+/area/tdome/tdomeobserve)
+"nj" = (
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 1
+	},
+/area/tdome/tdomeobserve)
+"nk" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"nl" = (
+/obj/structure/plasticflaps/opaque,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"nm" = (
+/obj/item/clipboard,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"nn" = (
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/stack/cable_coil/white,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"no" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -32
+	},
+/obj/machinery/computer/cargo{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"np" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"nq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"nr" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ns" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nt" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nu" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nv" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Commander's Office APC";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nx" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'FOURTH WALL'.";
+	name = "\improper FOURTH WALL";
+	pixel_x = -32
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"ny" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"nz" = (
+/turf/closed/indestructible/fakeglass,
+/area/syndicate_mothership/control)
+"nA" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nB" = (
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nC" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"nD" = (
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/f13/underground/mountain)
+"nE" = (
+/obj/machinery/light,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/underground/mountain)
+"nF" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/crate/bin,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 4
+	},
+/area/f13/underground/mountain)
+"nG" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/brown{
+	dir = 6
+	},
+/area/f13/underground/mountain)
+"nH" = (
+/obj/vehicle/ridden/atv,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"nI" = (
+/obj/structure/decoration/clock/active,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"nJ" = (
+/turf/open/space/basic,
+/area/centcom/evac)
+"nK" = (
+/obj/machinery/power/smes/magical,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"nL" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"nM" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Commander's Office APC";
+	pixel_x = 26
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/stack/sheet/rglass{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil/white,
+/obj/item/screwdriver/power,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"nN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration";
+	opacity = 1;
+	req_access_txt = "102"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeobserve)
+"nO" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"nP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"nQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"nR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"nS" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nT" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nU" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/clothing/under/rank/curator/treasure_hunter,
+/obj/item/clothing/under/skirt/black,
+/obj/item/clothing/under/shorts/black,
+/obj/item/clothing/under/pants/track,
+/obj/item/clothing/accessory/armband/deputy,
+/obj/item/clothing/accessory/waistcoat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/neck/stripedredscarf,
+/obj/item/clothing/neck/tie/red,
+/obj/item/clothing/head/helmet/space/beret,
+/obj/item/clothing/suit/curator,
+/obj/item/clothing/suit/space/officer,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/eyepatch,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"nV" = (
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"nW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"nX" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"nY" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"nZ" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oa" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/weldingtool/experimental,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ob" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"oc" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"od" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"oe" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/radio/headset/headset_cent,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"of" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"og" = (
+/obj/machinery/button/door{
+	id = "thunderdomehea";
+	name = "Heavy Supply Control";
+	req_access_txt = "102"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"oh" = (
+/obj/machinery/button/door{
+	id = "thunderdome";
+	name = "Main Blast Doors Control";
+	req_access_txt = "102"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"oi" = (
+/obj/machinery/button/door{
+	id = "thunderdomegen";
+	name = "General Supply Control";
+	req_access_txt = "102"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"oj" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"ok" = (
+/obj/item/storage/briefcase{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"ol" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"om" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"on" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"oo" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"op" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"oq" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"or" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"os" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/toy/figure/dsquad,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ot" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"ou" = (
+/obj/structure/table/wood,
+/obj/item/storage/secure/briefcase{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/lockbox/medal,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ov" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"ow" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ox" = (
+/obj/structure/dresser,
+/obj/structure/sign/plaques/golden/captain{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"oy" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/vault{
+	name = "Vault Door";
+	req_access_txt = "53"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oz" = (
+/obj/machinery/ai_status_display,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"oA" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oB" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oC" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"oD" = (
+/obj/machinery/computer/auxillary_base{
+	pixel_y = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/radio/headset/headset_cent,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"oE" = (
+/obj/machinery/computer/shuttle/labor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oF" = (
+/obj/machinery/computer/shuttle/mining,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"oH" = (
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"oI" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/filingcabinet/filingcabinet,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"oJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oK" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oM" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oO" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCFerry";
+	name = "XCC Ferry Hangar"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oQ" = (
+/obj/machinery/button/door{
+	id = "XCCFerry";
+	name = "Hanger Bay Shutters";
+	pixel_y = 24;
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"oR" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oS" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oT" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oU" = (
+/obj/docking_port/stationary/bos,
+/turf/closed/mineral/random/low_chance,
+/area/f13/brotherhood)
+"oV" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"oW" = (
+/obj/item/toy/figure/syndie,
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"oX" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05";
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oY" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-15";
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"oZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pa" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCsec1";
+	name = "XCC Checkpoint 1 Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pd" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/weldingtool/experimental,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pe" = (
+/obj/machinery/power/smes/magical,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pf" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Commander's Office APC";
+	pixel_x = 26
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/stack/sheet/rglass{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil/white,
+/obj/item/screwdriver/power,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pg" = (
+/obj/machinery/computer/shuttle/white_ship{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ph" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pi" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pj" = (
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pk" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: BLAST DOORS"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pm" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/centcom/evac)
+"pn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"po" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ps" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pu" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Equipment Room";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"pw" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"px" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"py" = (
+/obj/machinery/smartfridge,
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding)
+"pz" = (
+/obj/machinery/computer/shuttle/ferry{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pA" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pB" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pC" = (
+/obj/structure/sign/plaques/thunderdome{
+	icon_state = "nanotrasen_sign1"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/centcom/evac)
+"pD" = (
+/obj/structure/sign/plaques/thunderdome{
+	icon_state = "nanotrasen_sign2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/centcom/evac)
+"pE" = (
+/obj/machinery/plantgenes/seedvault,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"pF" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Auxillary Dock";
+	opacity = 1;
+	req_access_txt = ""
+	},
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"pG" = (
+/obj/structure/statue/uranium/nuke,
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"pH" = (
+/obj/structure/sign/plaques/thunderdome{
+	icon_state = "nanotrasen_sign3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/centcom/evac)
+"pI" = (
+/obj/structure/sign/plaques/thunderdome{
+	icon_state = "nanotrasen_sign4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/centcom/evac)
+"pJ" = (
+/obj/structure/sign/plaques/thunderdome{
+	icon_state = "nanotrasen_sign5"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
+/area/centcom/evac)
+"pK" = (
+/obj/machinery/button/door{
+	id = "XCCsec1";
+	name = "CC Shutter 1 Control";
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"pM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pN" = (
+/obj/machinery/computer/monitor/secret{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pO" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pP" = (
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/button/door{
+	id = "XCCFerry";
+	name = "Hanger Bay Shutters";
+	pixel_y = -38
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"pQ" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 1
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pR" = (
+/obj/machinery/computer/communications{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"pS" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"pT" = (
+/obj/machinery/light,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"pU" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/crate/bin,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 4
+	},
+/area/centcom/evac)
+"pV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"pW" = (
+/obj/effect/landmark/ai_multicam_room,
+/turf/open/ai_visible,
+/area/ai_multicam_room)
+"pX" = (
+/obj/item/storage/crayons,
+/obj/structure/table,
+/obj/item/storage/crayons,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"pY" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"pZ" = (
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/centcom{
+	name = "Administrative Office";
+	opacity = 1;
+	req_access_txt = "109"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"qd" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"qe" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Briefing Room";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"qf" = (
+/obj/machinery/ai_status_display,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"qg" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"qh" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"qi" = (
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"qj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"qk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ql" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"qm" = (
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 4.5
+	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"qn" = (
+/obj/structure/target_stake,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"qo" = (
+/turf/closed/indestructible/rock,
+/area/centcom/evac)
+"qp" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"qq" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"qr" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"qs" = (
+/obj/structure/closet/secure_closet/ertEngi,
+/obj/structure/sign/directions/engineering{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qt" = (
+/obj/structure/closet/secure_closet/ertEngi,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qu" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/seclite,
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/gun/energy/laser/wattz/magneto,
+/obj/item/gun/energy/laser/wattz/magneto,
+/obj/item/gun/energy/laser/wattz/magneto,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qv" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/plastic/c4{
+	pixel_x = 6
+	},
+/obj/item/grenade/plastic/c4{
+	pixel_x = -4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qw" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/energy/laser/aer9,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qx" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"qy" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"qA" = (
+/obj/structure/closet/secure_closet/ertCom,
+/obj/structure/sign/directions/command{
+	dir = 2;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"qB" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"qC" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"qD" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 9
+	},
+/area/centcom/evac)
+"qE" = (
+/turf/closed/indestructible/riveted/uranium,
+/area/wizard_station)
+"qF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/whitered/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"qG" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/plasteel/whitered/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"qH" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 5
+	},
+/area/centcom/evac)
+"qI" = (
+/obj/item/twohanded/required/kirbyplants,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"qJ" = (
+/obj/machinery/computer/shuttle/syndicate/recall,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qK" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qL" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qM" = (
+/obj/machinery/vending/cigarette{
+	products = list(/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 7, /obj/item/storage/fancy/cigarettes/cigpack_uplift = 3, /obj/item/storage/fancy/cigarettes/cigpack_robust = 2, /obj/item/storage/fancy/cigarettes/cigpack_carp = 3, /obj/item/storage/fancy/cigarettes/cigpack_midori = 1, /obj/item/storage/box/matches = 10, /obj/item/lighter/greyscale = 4, /obj/item/storage/fancy/rollingpapers = 5)
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qN" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qO" = (
+/obj/item/soap/syndie,
+/obj/structure/mopbucket,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qP" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/item/mop,
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"qQ" = (
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
+/obj/item/retractor{
+	pixel_x = 4
+	},
+/obj/item/hemostat{
+	pixel_x = -4
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"qR" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"qS" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"qT" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"qU" = (
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"qV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"qW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/key,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"qX" = (
+/obj/item/flashlight/lamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"qY" = (
+/obj/machinery/computer/card/centcom,
+/obj/item/card/id/centcom,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
+	name = "Research Monitor";
+	network = list("rd","minisat");
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"qZ" = (
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"ra" = (
+/obj/machinery/computer/shuttle,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"rb" = (
+/turf/closed/indestructible/rock,
+/area/f13/underground/mountain)
+"rc" = (
+/turf/closed/mineral/random,
+/area/f13/underground/mountain)
+"rd" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"re" = (
+/obj/item/paper/fluff/stations/centcom/disk_memo,
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"rf" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"rg" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/holding)
+"rh" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Restroom";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"ri" = (
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"rj" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"rk" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"rl" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/ert_spawn,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rm" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"rn" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ro" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"rp" = (
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"rq" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"rr" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"rs" = (
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"rt" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ru" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"rv" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"rw" = (
+/obj/item/clipboard,
+/obj/structure/table/reinforced,
+/obj/item/detective_scanner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"rx" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ry" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Commander's Office APC";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"rz" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"rA" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/folder/blue{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lighter,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"rB" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"rC" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"rD" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen/blue,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"rE" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"rF" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/ert_spawn,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rG" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"rH" = (
+/obj/machinery/door/poddoor/ert,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rI" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rJ" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/radio,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rK" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rL" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/structure/guncase/shotgun,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rN" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"rO" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"rP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/goonplaque{
+	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
+	},
+/area/centcom/evac)
+"rQ" = (
+/obj/structure/table/wood,
+/obj/structure/sign/plaques/golden{
+	pixel_y = 32
+	},
+/obj/item/clothing/accessory/lawyers_badge{
+	desc = "A badge of upmost glory.";
+	name = "thunderdome badge"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"rR" = (
+/obj/structure/table/wood,
+/obj/structure/sign/plaques/golden{
+	pixel_y = 32
+	},
+/obj/item/clothing/accessory/medal/silver{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"rS" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"rT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/goonplaque{
+	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
+	},
+/area/centcom/evac)
+"rU" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"rV" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"rW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"rX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"rY" = (
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"rZ" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"sa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"sb" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sc" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/gun/energy/pulse/pistol/m1911,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sd" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"se" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"sf" = (
+/obj/structure/table/wood,
+/obj/item/paicard,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"sg" = (
+/obj/structure/table/wood,
+/obj/item/pizzabox,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"sh" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/nukeop,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"si" = (
+/obj/machinery/computer/telecrystals/uplinker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/syndicate_mothership/control)
+"sj" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	name = "Tactical Toilet";
+	icon_state = "right";
+	dir = 8;
+	opacity = 1
+	},
+/turf/open/floor/plasteel/freezer{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"sk" = (
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sl" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"so" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sp" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"sq" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"sr" = (
+/obj/item/storage/fancy/donut_box,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ss" = (
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"st" = (
+/obj/machinery/door/airlock/external{
+	name = "Backup Emergency Escape Shuttle"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"su" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sv" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/m72,
+/obj/item/ammo_box/magazine/m2mm,
+/obj/item/ammo_box/magazine/m2mm,
+/obj/item/ammo_box/magazine/m2mm,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sw" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/seclite,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"sx" = (
+/obj/machinery/shuttle_manipulator,
+/turf/open/floor/circuit/green,
+/area/centcom/evac)
+"sy" = (
+/turf/open/floor/circuit/green,
+/area/centcom/evac)
+"sz" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"sA" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"sB" = (
+/obj/machinery/door/poddoor/ert,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"sC" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"sD" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/zipties,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"sE" = (
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"sF" = (
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"sG" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"sH" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Briefing Area APC";
+	pixel_x = 26
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"sI" = (
+/obj/structure/sign/barsign,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"sJ" = (
+/obj/machinery/door/airlock/silver{
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"sK" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sL" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sM" = (
+/obj/machinery/door/airlock/silver{
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"sN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/key,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sO" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sP" = (
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sQ" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sR" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sS" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"sT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"sU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"sV" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"sW" = (
+/obj/structure/showcase{
+	desc = "A strange machine supposedly from another world. The Wizard Federation has been meddling with it for years.";
+	icon = 'icons/obj/machines/telecomms.dmi';
+	icon_state = "processor";
+	name = "byond random number generator"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"sX" = (
+/obj/structure/showcase{
+	desc = "A historical figure of great importance to the wizard federation. He spent his long life learning magic, stealing artifacts, and harassing idiots with swords. May he rest forever, Rodney.";
+	icon = 'icons/mob/mob.dmi';
+	icon_state = "nim";
+	name = "wizard of yendor showcase"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"sY" = (
+/obj/machinery/computer/card/centcom{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"sZ" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/taperecorder,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ta" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tb" = (
+/obj/structure/table/reinforced,
+/obj/item/crowbar/red,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tc" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/underground/mountain)
+"td" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/underground/mountain)
+"te" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"tf" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/toy/cards/deck/syndicate{
+	icon_state = "deck_syndicate_full";
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"tg" = (
+/obj/machinery/computer/telecrystals/uplinker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/syndicate_mothership/control)
+"th" = (
+/obj/structure/closet/cardboard,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"ti" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"tj" = (
+/obj/structure/fluff/rails,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"tk" = (
+/turf/closed/wall/f13,
+/area/f13/underground/mountain)
+"tl" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"tm" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/underground/mountain)
+"tn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"to" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tp" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"tq" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/loyalty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"tr" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ts" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/obj/structure/guncase/ecase,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"tt" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/plasteel/red,
+/area/centcom/evac)
+"tu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"tv" = (
+/turf/open/floor/plasteel/red,
+/area/centcom/evac)
+"tw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/goonplaque,
+/area/centcom/evac)
+"tx" = (
+/obj/structure/table/wood,
+/obj/item/clothing/accessory/medal/gold{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/medal/gold,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ty" = (
+/obj/structure/table/wood,
+/obj/item/clothing/accessory/medal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"tz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/goonplaque,
+/area/centcom/evac)
+"tA" = (
+/obj/item/defibrillator/loaded,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"tB" = (
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"tC" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"tD" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"tE" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tF" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tG" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 6
+	},
+/area/centcom/evac)
+"tH" = (
+/obj/structure/cable/white,
+/turf/open/floor/plasteel/vault,
+/area/centcom/evac)
+"tI" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 10
+	},
+/area/centcom/evac)
+"tJ" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tK" = (
+/obj/structure/table/wood,
+/obj/item/dice/d20{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/dice/d10{
+	pixel_x = -3
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tL" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/radio/headset/headset_cent,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tM" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"tN" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/ert_spawn,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"tO" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"tP" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"tQ" = (
+/obj/structure/displaycase/captain,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"tR" = (
+/obj/machinery/ai_status_display,
+/turf/closed/indestructible/riveted,
+/area/centcom/evac)
+"tS" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"tT" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"tU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"tV" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"tW" = (
+/obj/structure/rack,
+/obj/item/nullrod/claymore{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"tX" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Cockpit"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"tY" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"tZ" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ua" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ub" = (
+/obj/structure/filingcabinet/medical,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"uc" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ud" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "nukeop_ready";
+	name = "shuttle dock"
+	},
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"ue" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"uf" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ug" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "Briefing Room APC";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"uh" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ui" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"uj" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light,
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"uk" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ul" = (
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"um" = (
+/obj/structure/closet/secure_closet/ertMed,
+/obj/structure/sign/directions/medical{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"un" = (
+/obj/structure/closet/secure_closet/ertMed,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = -32;
+	use_power = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uo" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/emps,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"up" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/obj/item/gun/syringe/rapidsyringe,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uq" = (
+/obj/structure/closet/secure_closet/ertSec,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"ur" = (
+/obj/structure/closet/secure_closet/ertSec,
+/obj/structure/sign/directions/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"us" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/red,
+/area/centcom/evac)
+"ut" = (
+/obj/structure/displaycase/trophy,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"uu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"uv" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"uw" = (
+/obj/structure/table/wood,
+/obj/item/clothing/accessory/lawyers_badge{
+	desc = "A badge of upmost glory.";
+	name = "thunderdome badge"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"ux" = (
+/obj/structure/table/wood,
+/obj/item/clothing/accessory/medal/silver{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"uy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/evac)
+"uz" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uA" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"uB" = (
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"uC" = (
+/obj/machinery/computer/camera_advanced,
+/turf/open/floor/wood,
+/area/wizard_station)
+"uD" = (
+/obj/structure/table/wood/fancy,
+/obj/item/radio/intercom{
+	desc = "Talk smack through this.";
+	syndie = 1
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"uE" = (
+/turf/open/floor/carpet,
+/area/wizard_station)
+"uF" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"uG" = (
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"uH" = (
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"uI" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uJ" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"uK" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/barman_recipes,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"uL" = (
+/obj/machinery/button/door{
+	id = "nukeop_ready";
+	name = "mission launch control";
+	pixel_x = -26;
+	req_access_txt = "151"
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"uM" = (
+/obj/machinery/computer/telecrystals/uplinker,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/syndicate_mothership/control)
+"uN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"uO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"uP" = (
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"uQ" = (
+/obj/structure/table/wood,
+/obj/structure/sign/plaques/thunderdome{
+	pixel_y = -32
+	},
+/obj/item/clothing/accessory/medal/gold{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/medal/gold,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"uR" = (
+/obj/structure/table/wood,
+/obj/structure/sign/plaques/thunderdome{
+	pixel_y = -32
+	},
+/obj/item/clothing/accessory/medal{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"uS" = (
+/obj/structure/sign/departments/medbay/alt,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uT" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uU" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/flashlight/seclite,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uV" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uW" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/flashlight/seclite,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"uX" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/carrot,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"uY" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/obj/item/reagent_containers/food/snacks/grown/cherries,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
+/turf/open/floor/plasteel/red,
+/area/centcom/evac)
+"uZ" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/obj/item/reagent_containers/food/snacks/carpmeat,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"va" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/bear,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet,
+/turf/open/floor/plasteel/red,
+/area/centcom/evac)
+"vb" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"vc" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/red,
+/area/centcom/evac)
+"vd" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"ve" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 1;
+	height = 4;
+	id = "pod2_away";
+	name = "recovery ship";
+	width = 3
+	},
+/turf/open/space,
+/area/f13/underground/mountain)
+"vf" = (
+/turf/open/floor/plasteel/blue/side,
+/area/centcom/evac)
+"vg" = (
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/centcom/evac)
+"vh" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/mint,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"vi" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"vj" = (
+/turf/open/floor/wood,
+/area/wizard_station)
+"vk" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"vl" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"vm" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/figure/wizard,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"vn" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"vo" = (
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"vp" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	opacity = 1
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vr" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/bundle/costume/waiter,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"vs" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"vt" = (
+/obj/structure/rack,
+/obj/item/nullrod/claymore/katana{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"vu" = (
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/drinks/bottle/rum,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vv" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vw" = (
+/obj/structure/table/wood,
+/obj/item/syndicatedetonator{
+	desc = "This gaudy button can be used to instantly detonate syndicate bombs that have been activated on the station. It is also fun to press."
+	},
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vx" = (
+/obj/structure/table/wood,
+/obj/item/toy/nuke,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"vy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"vz" = (
+/obj/structure/guncase/ecase,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"vA" = (
+/obj/structure/guncase/shotgun,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"vB" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"vC" = (
+/obj/machinery/computer/card/centcom,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/centcom/evac)
+"vD" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vE" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vF" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vG" = (
+/obj/machinery/computer/card/centcom,
+/turf/open/floor/plasteel/darkred/corner,
+/area/centcom/evac)
+"vH" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 8
+	},
+/area/centcom/evac)
+"vI" = (
+/obj/item/cardboard_cutout{
+	desc = "They seem to be ignoring you... Typical.";
+	dir = 1;
+	icon_state = "cutout_ntsec";
+	name = "Private Security Officer"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"vJ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vK" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vL" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vM" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vN" = (
+/obj/item/cardboard_cutout{
+	desc = "They seem to be ignoring you... Typical.";
+	dir = 1;
+	icon_state = "cutout_ntsec";
+	name = "Private Security Officer"
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"vO" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/centcom/evac)
+"vP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"vQ" = (
+/obj/item/cardboard_cutout{
+	desc = "They seem to be ignoring you... Typical.";
+	icon_state = "cutout_ntsec";
+	name = "Private Security Officer"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"vR" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"vS" = (
+/obj/machinery/door/window/brigdoor{
+	name = "CentCom Customs";
+	icon_state = "rightsecure";
+	dir = 4;
+	req_access_txt = "109";
+	base_state = "rightsecure"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vT" = (
+/obj/machinery/door/window/brigdoor{
+	name = "CentCom Customs";
+	icon_state = "rightsecure";
+	dir = 8;
+	req_access_txt = "109";
+	base_state = "rightsecure"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"vU" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"vV" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/turf/open/space/basic,
+/area/centcom/evac)
+"vW" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"vX" = (
+/turf/open/floor/plasteel/blue,
+/area/centcom/evac)
+"vY" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"vZ" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"wa" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 6
+	},
+/area/centcom/evac)
+"wb" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Observation Room"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wc" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Game Room"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wd" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"we" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"wf" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"wg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"wh" = (
+/obj/machinery/recharger,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wi" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wj" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"wk" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wl" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wm" = (
+/obj/effect/landmark/start/nukeop_leader,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wn" = (
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wo" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Uplink Management Control";
+	req_access_txt = "151"
+	},
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wp" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"wq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wr" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"ws" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"wt" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"wu" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/vehicle/ridden/atv,
+/obj/item/key,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wv" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"ww" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"wx" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"wy" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wz" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/storage/belt/security/full,
+/obj/item/gun/ballistic/automatic/wt550,
+/obj/item/clothing/head/helmet/swat/nanotrasen,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wA" = (
+/obj/structure/sign/departments/security,
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"wB" = (
+/obj/structure/vault_door/old{
+	max_integrity = 1000;
+	obj_integrity = 1000
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wC" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wD" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wE" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wF" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 9
+	},
+/area/centcom/evac)
+"wG" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security";
+	opacity = 1;
+	req_access_txt = "101"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wH" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 5
+	},
+/area/centcom/evac)
+"wI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/vehicle/ridden/atv,
+/obj/item/key,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"wJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom";
+	opacity = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"wL" = (
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"wM" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"wN" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"wP" = (
+/obj/structure/table/wood/fancy,
+/obj/item/camera/spooky,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"wQ" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"wR" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitegreen/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"wS" = (
+/turf/closed/wall/f13/vault,
+/area/f13/underground/mountain)
+"wT" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"wU" = (
+/obj/machinery/door/airlock/silver{
+	name = "Shower"
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"wV" = (
+/obj/machinery/computer/telecrystals/boss{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/syndicate_mothership/control)
+"wW" = (
+/obj/structure/sign/map/left{
+	pixel_y = -32
+	},
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar_left";
+	name = "skeletal minibar"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wX" = (
+/obj/structure/sign/map/right{
+	pixel_y = -32
+	},
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar_right";
+	name = "skeletal minibar"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/gin,
+/turf/open/floor/wood,
+/area/syndicate_mothership/control)
+"wY" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Equipment Room";
+	opacity = 1;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/bar{
+	dir = 2
+	},
+/area/syndicate_mothership/control)
+"wZ" = (
+/obj/structure/fluff/arc,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xa" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitered/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"xb" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 2;
+	height = 7;
+	id = "pod1_away";
+	name = "recovery ship";
+	width = 5
+	},
+/turf/open/space,
+/area/f13/underground/mountain)
+"xc" = (
+/obj/machinery/door/airlock/silver{
+	name = "Shower"
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xd" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"xe" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"xf" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"xg" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/whitegreen/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"xh" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"xi" = (
+/obj/structure/safe,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"xj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/chalkboard,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"xk" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/whitegreen/corner,
+/area/centcom/evac)
+"xl" = (
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"xm" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xn" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xo" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xp" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/shotgun/toy/crossbow,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xq" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: BLAST DOORS"
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"xs" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05";
+	pixel_y = 10
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xt" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xu" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/wizard_station)
+"xv" = (
+/obj/item/statuebust{
+	pixel_y = 12
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/wizard_station)
+"xw" = (
+/obj/machinery/vending/magivend,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"xx" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"xy" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/pill_bottle/dice{
+	icon_state = "magicdicebag"
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"xz" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/photo_album,
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"xA" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xB" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"xC" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 32;
+	use_power = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"xD" = (
+/turf/open/floor/plasteel/stairs/medium,
+/area/centcom/evac)
+"xE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xF" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xG" = (
+/turf/open/floor/plasteel/dark,
+/area/syndicate_mothership/control)
+"xH" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"xI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/syndicate_mothership/control)
+"xJ" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/plating,
+/area/syndicate_mothership/control)
+"xK" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/dark,
+/area/syndicate_mothership/control)
+"xL" = (
+/obj/structure/closet/cardboard/metal,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xN" = (
+/obj/docking_port/stationary{
+	area_type = /area/syndicate_mothership/control;
+	dir = 1;
+	dwidth = 3;
+	height = 7;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/assault_pod/default;
+	width = 7
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"xQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xR" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xS" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xU" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xV" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xX" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xY" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"xZ" = (
+/turf/open/floor/plasteel/blue/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"ya" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Study"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yb" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Break Room"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yc" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yd" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/centcom/holding)
+"ye" = (
+/obj/structure/chalkboard,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"yf" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yg" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yh" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yi" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/syndicate_mothership/control)
+"yl" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"ym" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yn" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yo" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yp" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yq" = (
+/obj/machinery/telecomms/relay/preset/mining,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"yr" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"ys" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yt" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yv" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yw" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yx" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yz" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 32;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"yA" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yB" = (
+/turf/open/floor/plasteel/blue/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"yC" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yD" = (
+/obj/structure/table/wood,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yE" = (
+/obj/structure/table/wood,
+/obj/item/retractor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yF" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/wizrobe/magusblue,
+/obj/item/clothing/head/wizard/magus,
+/obj/item/staff,
+/obj/structure/mirror/magic{
+	pixel_y = 28
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yG" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/wizrobe/magusred,
+/obj/item/clothing/head/wizard/magus,
+/obj/item/staff,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"yH" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yI" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yJ" = (
+/obj/effect/decal/remains/xeno/larva,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yK" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/grass,
+/area/wizard_station)
+"yL" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yM" = (
+/obj/structure/table/wood/bar,
+/obj/structure/safe/floor,
+/obj/item/seeds/cherry/bomb,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"yN" = (
+/obj/structure/flora/stump,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yO" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yP" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yQ" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yR" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"yS" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yT" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yU" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yV" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yW" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yX" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/dark,
+/area/syndicate_mothership/control)
+"yY" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"yZ" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"za" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zb" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zc" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zd" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"ze" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zf" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zg" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zh" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zi" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zj" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zk" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/tree/palm,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zl" = (
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"zm" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/tree/palm,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zn" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zo" = (
+/obj/structure/destructible/cult/tome,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zp" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/clothing/suit/wizrobe/red,
+/obj/item/clothing/head/wizard/red,
+/obj/item/staff,
+/obj/item/clothing/shoes/sandal/magic,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zq" = (
+/turf/open/floor/grass,
+/area/wizard_station)
+"zr" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/corgi,
+/turf/open/floor/grass,
+/area/wizard_station)
+"zs" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zt" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zu" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zw" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zx" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"zy" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zA" = (
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"zB" = (
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"zC" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innershade"
+	},
+/area/centcom/evac)
+"zD" = (
+/turf/open/indestructible/ground/outside/desert,
+/area/centcom/evac)
+"zE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zF" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/tree/palm,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zG" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zH" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zI" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zJ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zK" = (
+/turf/open/floor/plating/f13/outside/road,
+/area/centcom/evac)
+"zL" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zM" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zN" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zO" = (
+/obj/structure/destructible/cult/talisman{
+	desc = "An altar dedicated to the Wizards' Federation"
+	},
+/obj/item/kitchen/knife/ritual,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zP" = (
+/obj/item/clothing/shoes/sandal/marisa,
+/obj/item/clothing/suit/wizrobe/marisa,
+/obj/item/clothing/head/wizard/marisa,
+/obj/item/staff/broom,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"zQ" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/netherworld{
+	name = "Experiment 35b"
+	},
+/turf/open/floor/grass,
+/area/wizard_station)
+"zR" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zS" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zT" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zU" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/tree/palm,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"zV" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	locked = 0
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"zW" = (
+/obj/vehicle/ridden/atv,
+/obj/item/key,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/centcom/evac)
+"zX" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"zY" = (
+/obj/vehicle/ridden/atv,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"zZ" = (
+/obj/vehicle/ridden/bicycle,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Aa" = (
+/obj/vehicle/ridden/janicart/upgraded,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Ab" = (
+/obj/vehicle/ridden/lavaboat/dragon,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Ac" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
+	},
+/area/centcom/evac)
+"Ad" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"Ae" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"Af" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"Ag" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"Ah" = (
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Ai" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Aj" = (
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Ak" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"Al" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"Am" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"An" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"Ao" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"Ap" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"Aq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/tac,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"Ar" = (
+/obj/structure/closet/secure_closet/armory2,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"As" = (
+/obj/structure/closet/secure_closet/armory3,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"At" = (
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "cross1"
+	},
+/area/centcom/evac)
+"Au" = (
+/obj/machinery/abductor/experiment{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Av" = (
+/obj/machinery/abductor/console{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Aw" = (
+/obj/machinery/abductor/pad{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Ax" = (
+/turf/closed/indestructible/fakeglass{
+	color = "#008000"
+	},
+/area/wizard_station)
+"Ay" = (
+/obj/effect/landmark/start/wizard,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Az" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/grass,
+/area/wizard_station)
+"AA" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
+/turf/open/floor/grass,
+/area/wizard_station)
+"AB" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/grass,
+/area/wizard_station)
+"AC" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"AD" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supply";
+	req_access_txt = "106"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"AE" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"AF" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"AG" = (
+/obj/structure/ladder/unbreakable/binary/space,
+/turf/open/indestructible/airblock,
+/area/fabric_of_reality)
+"AH" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"AI" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supply";
+	req_access_txt = "106"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"AJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"AK" = (
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"AL" = (
+/obj/vehicle/ridden/space/speedwagon,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innershade"
+	},
+/area/centcom/evac)
+"AM" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
+	},
+/area/centcom/evac)
+"AN" = (
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"AO" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supply";
+	req_access_txt = "106"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"AP" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/centcom/evac)
+"AQ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/secure/briefcase,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"AR" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/clipboard,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"AS" = (
+/obj/structure/closet/gimmick/tacticool,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"AT" = (
+/obj/structure/closet/gimmick/russian,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"AU" = (
+/obj/machinery/light,
+/obj/structure/closet/syndicate/resources/everything,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"AV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"AW" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"AX" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/clothing_legend,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"AY" = (
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"AZ" = (
+/obj/structure/closet/secure_closet/warden,
+/turf/open/floor/wood,
+/area/centcom/evac)
+"Ba" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Bb" = (
+/obj/structure/closet/secure_closet/armory1,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"Bc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Bd" = (
+/obj/vehicle/ridden/scooter,
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
+	},
+/area/centcom/evac)
+"Be" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"Bf" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Bg" = (
+/mob/living/simple_animal/bot/medbot/mysterious{
+	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
+	faction = list("neutral","silicon","creature");
+	name = "Nobody's Perfect"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Bh" = (
+/obj/machinery/light,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Bi" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+/turf/open/floor/grass,
+/area/wizard_station)
+"Bj" = (
+/obj/vehicle/ridden/scooter/skateboard,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"Bk" = (
+/obj/vehicle/ridden/space/speedbike,
+/obj/machinery/light,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"Bl" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"Bm" = (
+/obj/vehicle/ridden/space/speedbike/red,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"Bn" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"Bo" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Bp" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/grimy,
+/area/centcom/evac)
+"Bq" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/spawner/bundle/costume/plaguedoctor,
+/turf/open/floor/plasteel/cmo,
+/area/centcom/evac)
+"Br" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/doorButtons/wornvaultButton,
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"Bs" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Bt" = (
+/obj/structure/tank_dispenser/plasma,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"Bu" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"Bv" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerturn"
+	},
+/area/centcom/evac)
+"Bw" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/centcom/evac)
+"Bx" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerturn"
+	},
+/area/centcom/evac)
+"By" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/centcom/evac)
+"Bz" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "transition3"
+	},
+/area/centcom/evac)
+"BA" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/centcom/evac)
+"BB" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "transition4"
+	},
+/area/centcom/evac)
+"BC" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2"
+	},
+/area/centcom/evac)
+"BD" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/centcom/evac)
+"BE" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/indestructible/ground/outside/desert,
+/area/centcom/evac)
+"BF" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2bottom"
+	},
+/area/centcom/evac)
+"BG" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft3"
+	},
+/area/centcom/evac)
+"BH" = (
+/obj/vehicle/ridden/secway,
+/obj/machinery/button/door{
+	id = "nukeop_ready";
+	name = "mission launch control";
+	pixel_x = -26;
+	req_access_txt = "151"
+	},
+/turf/open/floor/plasteel/darkred/corner,
+/area/centcom/evac)
+"BI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "XCCFerry";
+	name = "Hanger Bay Shutters";
+	pixel_y = 24;
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/darkred/side,
+/area/centcom/evac)
+"BJ" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "transition1"
+	},
+/area/centcom/evac)
+"BK" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "transition2"
+	},
+/area/centcom/evac)
+"BL" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerturn"
+	},
+/area/centcom/evac)
+"BM" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/centcom/evac)
+"BN" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerturn"
+	},
+/area/centcom/evac)
+"BO" = (
+/obj/machinery/button/door{
+	dir = 2;
+	id = "XCCQMLoaddoor2";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = -27;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "XCCQMLoaddoor";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = -27;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"BP" = (
+/turf/closed/indestructible/opshuttle,
+/area/f13/underground/mountain)
+"BQ" = (
+/obj/effect/landmark/abductor/scientist{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"BR" = (
+/obj/effect/landmark/abductor/agent{
+	team_number = 3
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"BS" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Observation Deck"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"BT" = (
+/turf/open/floor/plasteel/dark,
+/area/f13/underground/mountain)
+"BU" = (
+/turf/open/floor/plasteel/stairs,
+/area/f13/underground/mountain)
+"BV" = (
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding)
+"BW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"BX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"BY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"BZ" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Ca" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Cb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"Cc" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Cd" = (
+/obj/vehicle/ridden/secway,
+/obj/machinery/button/door{
+	id = "lmrestroom";
+	name = "Lock Control";
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"Ce" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Cf" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Cg" = (
+/obj/machinery/button/door{
+	id = "XCCsec1";
+	name = "CC Shutter 1 Control";
+	pixel_y = -24
+	},
+/obj/machinery/button/door{
+	id = "XCCFerry";
+	name = "Hanger Bay Shutters";
+	pixel_y = -38
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Ch" = (
+/obj/machinery/button/door{
+	id = "thunderdomegen";
+	name = "General Supply Control";
+	req_access_txt = "102"
+	},
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"Ci" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"Cj" = (
+/obj/machinery/button/door{
+	id = "thunderdomehea";
+	name = "Heavy Supply Control";
+	req_access_txt = "102"
+	},
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"Ck" = (
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"Cl" = (
+/obj/machinery/button/door{
+	id = "thunderdome";
+	name = "Main Blast Doors Control";
+	req_access_txt = "102"
+	},
+/turf/closed/wall/f13/vault,
+/area/centcom/evac)
+"Cm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"Cn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Co" = (
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Cp" = (
+/turf/open/space/basic,
+/area/syndicate_mothership)
+"Cq" = (
+/turf/closed/indestructible/opshuttle,
+/area/centcom/evac)
+"Cr" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Cs" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/delivery,
+/obj/item/banhammer,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Ct" = (
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/centcom/evac)
+"Cu" = (
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plasteel/blue/corner,
+/area/centcom/evac)
+"Cv" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/whitered/side{
+	dir = 9
+	},
+/area/centcom/evac)
+"Cw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/molten_object/large,
+/turf/open/floor/plasteel/whitered/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"Cx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Cy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Cz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue,
+/area/centcom/evac)
+"CA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"CB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"CC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"CD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"CE" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 1
+	},
+/area/centcom/evac)
+"CF" = (
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"CG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"CH" = (
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"CI" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/spawner/bundle/costume/sexyclown,
+/turf/open/floor/plasteel/whitegreen/corner{
+	dir = 4
+	},
+/area/centcom/evac)
+"CJ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/spawner/bundle/costume/nyangirl,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"CK" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/molten_object/large,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"CL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue,
+/area/centcom/evac)
+"CM" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"CN" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/whitered/corner{
+	dir = 8
+	},
+/area/centcom/evac)
+"CO" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"CP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/blue/side{
+	dir = 1
+	},
+/area/centcom/evac)
+"CQ" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/centcom/evac)
+"CR" = (
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/white,
+/area/centcom/evac)
+"CS" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/molten_object,
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/plasteel/whitered/side{
+	dir = 8
+	},
+/area/centcom/evac)
+"CT" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"CU" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/leaper_sludge,
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 4
+	},
+/area/centcom/evac)
+"CV" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"CW" = (
+/obj/effect/decal/cleanable/leaper_sludge,
+/turf/open/floor/plasteel/stairs/left,
+/area/centcom/evac)
+"CX" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"CY" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"CZ" = (
+/obj/structure/billboard/cola/pristine,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Da" = (
+/obj/structure/billboard/ritas/pristine,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Db" = (
+/obj/structure/wreck/trash/two_barrels,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dc" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dd" = (
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"De" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Df" = (
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dg" = (
+/obj/structure/wreck/trash/secway,
+/obj/effect/decal/waste,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dh" = (
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/stamp/denied{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stamp,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"Di" = (
+/turf/closed/indestructible/riveted,
+/area/ai_multicam_room)
+"Dj" = (
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Dk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dl" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dm" = (
+/obj/structure/wreck/car/bike,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dn" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Do" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dp" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dq" = (
+/obj/effect/decal/waste{
+	icon_state = "goo10"
+	},
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Dr" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"Ds" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Dt" = (
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Du" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Dv" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Dw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/wreck/trash/one_tire,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Dx" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Dy" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Dz" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"DA" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/taperecorder,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/centcom/evac)
+"DB" = (
+/turf/open/indestructible/ground/inside/subway,
+/area/centcom/evac)
+"DC" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Storage"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"DD" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Personal Quarters"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"DE" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Bathroom"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"DF" = (
+/turf/open/floor/plating/snowed/temperatre,
+/area/f13/underground/mountain)
+"DG" = (
+/turf/open/floor/plating/foam,
+/area/f13/underground/mountain)
+"DH" = (
+/obj/machinery/door/airlock/freezer,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/mountain)
+"DI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DJ" = (
+/obj/structure/wreck/trash/secway,
+/turf/open/floor/plasteel/neutral,
+/area/centcom/evac)
+"DK" = (
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/mountain)
+"DL" = (
+/obj/item/clothing/suit/wizrobe/black,
+/obj/item/clothing/head/wizard/black,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"DM" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"DN" = (
+/obj/item/cardboard_cutout,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"DO" = (
+/obj/structure/table/wood,
+/obj/item/dice/d20,
+/obj/item/dice,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"DP" = (
+/obj/structure/punching_bag,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"DQ" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"DR" = (
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"DS" = (
+/obj/structure/mirror/magic{
+	pixel_y = 28
+	},
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"DT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DU" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DV" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DW" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DX" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DY" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"DZ" = (
+/obj/item/cautery/alien,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ea" = (
+/obj/item/coin/antagtoken,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Eb" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Ec" = (
+/obj/structure/bed,
+/obj/item/bedsheet/wiz,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Ed" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Ee" = (
+/obj/item/soap/homemade,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Ef" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Eg" = (
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Eh" = (
+/obj/structure/closet/cardboard,
+/obj/item/banhammer,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ei" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ej" = (
+/obj/vehicle/ridden/scooter/skateboard{
+	icon_state = "skateboard";
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/wizard_station)
+"Ek" = (
+/obj/structure/dresser,
+/obj/item/storage/backpack/satchel,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"El" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/snacks/burger/spell,
+/turf/open/floor/carpet,
+/area/wizard_station)
+"Em" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"En" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Eo" = (
+/obj/structure/table/wood/fancy,
+/obj/item/skub{
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/white,
+/area/wizard_station)
+"Ep" = (
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"Eq" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/leaper_sludge,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Er" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/grass,
+/area/centcom/evac)
+"Es" = (
+/turf/open/lava/plasma,
+/area/f13/underground/mountain)
+"Et" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/mountain)
+"Eu" = (
+/obj/effect/spawner/lootdrop/organ_spawner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Ev" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/tdome/tdomeobserve)
+"Ex" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	icon_state = "warningline";
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
+"EA" = (
+/turf/closed/wall/f13/ruins,
+/area/f13/underground/mountain)
+"EB" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/wood/f13/old/ruinedcornerbl,
+/area/f13/underground/mountain)
+"EC" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
+	name = "Engine Room"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"ED" = (
+/obj/machinery/vending/boozeomat{
+	req_access_txt = "0"
+	},
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding)
+"EE" = (
+/turf/open/floor/wood/f13/old,
+/area/f13/underground/mountain)
+"EF" = (
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
+/turf/open/floor/wood/f13,
+/area/f13/underground/mountain)
+"EG" = (
+/turf/open/floor/wood/f13,
+/area/f13/underground/mountain)
+"EH" = (
+/obj/structure/flora/wasteplant/wild_mutfruit,
+/turf/open/floor/wood/f13,
+/area/f13/underground/mountain)
+"EI" = (
+/obj/structure/window/fulltile/ruins/broken,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EJ" = (
+/obj/structure/simple_door/house,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EK" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/riveted,
+/area/tdome/tdomeobserve)
+"EL" = (
+/obj/structure/window/fulltile/ruins,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EM" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EN" = (
+/obj/structure/table/reinforced,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EO" = (
+/obj/structure/simple_door/dirtyglass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EP" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EQ" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"ER" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
+/turf/open/floor/wood/f13/old,
+/area/f13/underground/mountain)
+"ES" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"ET" = (
+/obj/structure/flora/wasteplant/wild_xander,
+/turf/open/floor/wood/f13/old/ruinedstraighteast,
+/area/f13/underground/mountain)
+"EU" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EV" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/obj/effect/spawner/lootdrop/food,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"EW" = (
+/obj/structure/table/wood,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"EX" = (
+/obj/structure/table/wood,
+/obj/item/gun/magic/wand{
+	desc = "Used in emergencies to reignite magma engines.";
+	max_charges = 0;
+	name = "wand of emergency engine ignition"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"EY" = (
+/obj/structure/table/wood,
+/obj/item/bikehorn/golden{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"EZ" = (
+/obj/structure/simple_door/brokenglass,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Fa" = (
+/obj/structure/table/wood,
+/obj/item/instrument/piano_synth,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Fb" = (
+/obj/structure/piano,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Fc" = (
+/obj/structure/sign/barsign{
+	pixel_y = 32
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Fd" = (
+/turf/open/floor/wood/f13/old/ruinedstraighteast,
+/area/f13/underground/mountain)
+"Fe" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Ff" = (
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Fg" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
+/turf/open/floor/wood/f13/old,
+/area/f13/underground/mountain)
+"Fh" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Fi" = (
+/obj/structure/chair/wood/wings{
+	dir = 3
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Fj" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Fk" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/wood/f13/old/ruinedstraightwest,
+/area/f13/underground/mountain)
+"Fl" = (
+/obj/effect/spawner/lootdrop/f13/cash_ncr_low,
+/turf/open/floor/wood/f13/old/ruinedstraighteast,
+/area/f13/underground/mountain)
+"Fm" = (
+/obj/structure/rack,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Fn" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Fo" = (
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/structure/rack,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Fp" = (
+/obj/effect/spawner/lootdrop/three_course_meal,
+/turf/closed/mineral/random,
+/area/f13/underground/mountain)
+"Fq" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/food,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"FT" = (
+/obj/structure/destructible/cult/forge{
+	desc = "An engine used in powering the wizard's ship";
+	name = "magma engine"
+	},
+/turf/open/floor/engine/cult,
+/area/wizard_station)
+"FU" = (
+/obj/structure/speaking_tile/tragedy,
+/turf/closed/mineral/ash_rock,
+/area/f13/underground/mountain)
+"FW" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"FX" = (
+/turf/open/floor/plasteel/stairs,
+/area/centcom/holding)
+"FZ" = (
+/obj/structure/speaking_tile/tragedy,
+/turf/closed/mineral/ash_rock,
+/area/syndicate_mothership/control)
+"Ga" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"Gr" = (
+/obj/structure/window/reinforced{
+	resistance_flags = 3;
+	color = "#008000";
+	dir = 1
+	},
+/turf/open/lava,
+/area/wizard_station)
+"Gs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Gt" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"Gz" = (
+/obj/structure/shuttle/engine/heater{
+	resistance_flags = 3
+	},
+/obj/structure/window/reinforced{
+	resistance_flags = 3;
+	color = "#008000";
+	dir = 1
+	},
+/turf/open/lava/airless,
+/area/wizard_station)
+"GA" = (
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"GB" = (
+/obj/machinery/camera{
+	c_tag = "Communications Relay";
+	dir = 8;
+	network = list("mine")
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"GM" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"GP" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/tdome/tdomeobserve)
+"GX" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/space,
+/area/wizard_station)
+"GY" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"GZ" = (
+/obj/machinery/light,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Hk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"Hl" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"Hm" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Hy" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/tcoms)
+"HH" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"HL" = (
+/turf/open/floor/plasteel/vault,
+/area/tdome/tdomeobserve)
+"HN" = (
+/obj/structure/chair,
+/obj/effect/landmark/thunderdome/observe,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"HQ" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Id" = (
+/obj/machinery/computer/security/telescreen,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/tdome/tdomeobserve)
+"Il" = (
+/turf/closed/indestructible/fakeglass,
+/area/tdome/tdomeobserve)
+"Is" = (
+/obj/machinery/igniter/on,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"It" = (
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Iu" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Iy" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/red,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/transforming/energy/sword/saber/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Iz" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomegen";
+	name = "General Supply"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IA" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IC" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"ID" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IE" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/tdome/arena)
+"IF" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IG" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 4
+	},
+/area/tdome/arena)
+"IH" = (
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"II" = (
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8
+	},
+/area/tdome/arena)
+"IJ" = (
+/turf/open/floor/plasteel/green/side{
+	dir = 4
+	},
+/area/tdome/arena)
+"IL" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IN" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IP" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/tdome/green,
+/obj/item/clothing/head/helmet/thunderdome,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/transforming/energy/sword/saber/green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IT" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IU" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IV" = (
+/obj/effect/landmark/thunderdome/two,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"IW" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"IX" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/tdome/arena)
+"IY" = (
+/turf/open/floor/plasteel/green/corner{
+	dir = 4
+	},
+/area/tdome/arena)
+"IZ" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Ja" = (
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jb" = (
+/obj/effect/landmark/thunderdome/one,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"Jc" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jg" = (
+/obj/machinery/camera{
+	c_tag = "Red Team";
+	network = list("thunder");
+	pixel_x = 11;
+	pixel_y = -9;
+	resistance_flags = 64
+	},
+/obj/effect/landmark/thunderdome/two,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"Jh" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Ji" = (
+/turf/open/floor/circuit/green,
+/area/tdome/arena)
+"Jk" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jl" = (
+/obj/machinery/camera{
+	c_tag = "Green Team";
+	network = list("thunder");
+	pixel_x = 12;
+	pixel_y = -10;
+	resistance_flags = 64
+	},
+/obj/effect/landmark/thunderdome/one,
+/turf/open/floor/plasteel/neutral,
+/area/tdome/arena)
+"Jq" = (
+/obj/machinery/camera{
+	c_tag = "Arena";
+	network = list("thunder");
+	pixel_x = 10;
+	resistance_flags = 64
+	},
+/turf/open/floor/circuit/green,
+/area/tdome/arena)
+"Js" = (
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/tdome/arena)
+"Jt" = (
+/turf/open/floor/plasteel/green/corner,
+/area/tdome/arena)
+"Ju" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jv" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jw" = (
+/obj/effect/landmark/thunderdome/two,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jx" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jy" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Jz" = (
+/obj/effect/landmark/thunderdome/one,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"JA" = (
+/obj/machinery/abductor/experiment{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JB" = (
+/obj/machinery/abductor/console{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JC" = (
+/obj/machinery/abductor/pad{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JD" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomehea";
+	name = "Heavy Supply"
+	},
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"JE" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "sink";
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"JF" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 1
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JM" = (
+/obj/effect/landmark/abductor/scientist,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JN" = (
+/obj/effect/landmark/abductor/agent,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"JV" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape/backup)
+"JW" = (
+/obj/machinery/status_display,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape/backup)
+"Kd" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"Ke" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape/backup)
+"Kf" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"Kk" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 2;
+	height = 8;
+	id = "backup_away";
+	name = "Backup Shuttle Dock";
+	width = 8
+	},
+/obj/docking_port/mobile/emergency/backup,
+/turf/open/floor/plating,
+/area/shuttle/escape/backup)
+"Kl" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"Km" = (
+/obj/structure/table/wood,
+/obj/item/paper/fluff/stations/centcom/broken_evac,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"Kz" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"KE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"KF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"KH" = (
+/turf/closed/wall/mineral/titanium,
+/area/centcom/evac)
+"KI" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KJ" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KK" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/closed/indestructible/riveted,
+/area/f13/underground/mountain)
+"KM" = (
+/obj/effect/landmark/shuttle_import,
+/turf/open/space/basic,
+/area/f13/underground/mountain)
+"KN" = (
+/obj/structure/window/reinforced,
+/obj/structure/shuttle/engine/heater{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/centcom/evac)
+"KO" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KP" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KQ" = (
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"KS" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/centcom/evac)
+"KT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"KU" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KV" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"KW" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KX" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KY" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"KZ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/evac)
+"La" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lb" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Ld" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Le" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lf" = (
+/obj/structure/table/reinforced,
+/obj/item/pen,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lg" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lh" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Li" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lj" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lk" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Ll" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lm" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/stamp,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Ln" = (
+/obj/structure/table,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lo" = (
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lp" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lq" = (
+/obj/structure/table,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Lr" = (
+/obj/machinery/door/window/northright{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Security Desk";
+	req_access_txt = "103"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/evac)
+"Ls" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 8;
+	height = 7;
+	id = "supply_away";
+	json_key = "cargo";
+	name = "CentCom";
+	width = 20
+	},
+/turf/open/space,
+/area/f13/underground/mountain)
+"Lt" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/centcom/evac)
+"Lu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"Lv" = (
+/obj/structure/bed,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Lw" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/centcom/evac)
+"Lx" = (
+/obj/structure/bed,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"Ly" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"LA" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LB" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LC" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LD" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Cockpit";
+	req_access_txt = "109"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/centcom/evac)
+"LE" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LF" = (
+/obj/structure/chair{
+	dir = 4;
+	name = "Prosecution"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LG" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LH" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LI" = (
+/obj/structure/chair,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LJ" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LK" = (
+/obj/machinery/abductor/experiment{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LL" = (
+/obj/machinery/abductor/console{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LM" = (
+/obj/machinery/abductor/pad{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LN" = (
+/obj/structure/table,
+/obj/item/storage/lockbox,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LO" = (
+/obj/structure/table,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LP" = (
+/obj/machinery/computer/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LQ" = (
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/pen,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LR" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
+"LS" = (
+/obj/machinery/computer/camera_advanced/abductor{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LT" = (
+/obj/effect/landmark/abductor/scientist{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LU" = (
+/obj/effect/landmark/abductor/agent{
+	team_number = 2
+	},
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
+"LV" = (
+/turf/closed/indestructible/riveted,
+/area/awaymission/errorroom)
+"LW" = (
+/turf/closed/mineral/ash_rock,
+/area/awaymission/errorroom)
+"LX" = (
+/obj/structure/speaking_tile,
+/turf/closed/mineral/ash_rock,
+/area/awaymission/errorroom)
+"LY" = (
+/obj/item/rupee,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"LZ" = (
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"Ma" = (
+/obj/effect/landmark/error,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"Mb" = (
+/obj/structure/signpost/salvation{
+	icon = 'icons/obj/structures.dmi';
+	icon_state = "ladder10";
+	invisibility = 100
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/awaymission/errorroom)
+"Mh" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdome";
+	name = "Thunderdome Blast Door"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Mi" = (
+/obj/machinery/door/poddoor{
+	id = "thunderdomegen";
+	name = "General Supply"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Mm" = (
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Mu" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Mx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/nullrod/claymore/saber/red{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"MB" = (
+/turf/open/indestructible/binary,
+/area/fabric_of_reality)
+"ME" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/wizard_station)
+"MG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Animal Pen"
+	},
+/turf/open/floor/grass,
+/area/centcom/holding)
+"MH" = (
+/obj/structure/ladder/unbreakable/binary/unlinked,
+/turf/open/indestructible/airblock,
+/area/fabric_of_reality)
+"MM" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"MR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"MT" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"MX" = (
+/turf/open/floor/plasteel,
+/area/centcom/evac)
+"Nd" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding)
+"Nm" = (
+/obj/structure/closet/crate,
+/obj/item/vending_refill/autodrobe,
+/obj/item/stack/sheet/paperframes/fifty,
+/obj/item/stack/sheet/paperframes/fifty,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Nn" = (
+/obj/structure/closet/secure_closet/hydroponics{
+	locked = 0
+	},
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Nq" = (
+/mob/living/simple_animal/bot/medbot/mysterious{
+	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
+	faction = list("neutral","silicon","creature");
+	name = "Nobody's Perfect"
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Nv" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 2
+	},
+/area/centcom/holding)
+"Nw" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
+"Ny" = (
+/obj/machinery/modular_computer/console/preset/research,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"NF" = (
+/obj/structure/ladder/unbreakable/binary,
+/turf/open/indestructible/airblock,
+/area/fabric_of_reality)
+"NJ" = (
+/obj/structure/table,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/seeds/pumpkin/blumpkin,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"NR" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"NT" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Op" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/button/door{
+	id = "lmrestroom";
+	name = "Lock Control";
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
+"OG" = (
+/obj/structure/dresser,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"OU" = (
+/obj/item/clothing/under/jabroni,
+/obj/item/clothing/under/geisha,
+/obj/item/clothing/under/kilt,
+/obj/structure/closet,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Pa" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
+"Ph" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Pl" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Po" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Pr" = (
+/obj/structure/table,
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Px" = (
+/obj/machinery/vr_sleeper,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"PA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"PF" = (
+/obj/machinery/vr_sleeper{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"PI" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"PL" = (
+/obj/machinery/autolathe,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"PO" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"PX" = (
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"PY" = (
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Qe" = (
+/turf/open/ai_visible,
+/area/ai_multicam_room)
+"Qk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Qm" = (
+/obj/singularity/wizard/mapped,
+/turf/open/indestructible/binary,
+/area/fabric_of_reality)
+"Qu" = (
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"QA" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"QC" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 13;
+	id = "ferry_away";
+	json_key = "ferry";
+	name = "CentCom Ferry Dock";
+	width = 5
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"QH" = (
+/obj/machinery/chem_master/condimaster{
+	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
+	name = "BrewMaster 2199";
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"QI" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
+"QL" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"QT" = (
+/obj/machinery/chem_dispenser/drinks,
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding)
+"QW" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	locked = 0
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Rd" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Re" = (
+/obj/structure/mineral_door/paperframe,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Rh" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Ri" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Rj" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Rm" = (
+/obj/structure/chair/wood/wings{
+	dir = 3
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"RL" = (
+/turf/closed/wall/r_wall/f13superstore{
+	icon_state = "supermart0"
+	},
+/area/f13/tcoms)
+"RM" = (
+/turf/closed/wall/r_wall,
+/area/f13/tcoms)
+"RS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/nullrod/claymore/glowing{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"RT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"RU" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/f13/tcoms)
+"RV" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"RW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Sb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"Sc" = (
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/f13/tcoms)
+"Sd" = (
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Se" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Sf" = (
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Sg" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Sj" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 4;
+	network = "tcommsat"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
+/area/f13/tcoms)
+"Sk" = (
+/obj/structure/table,
+/obj/item/folder/blue,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Sp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"Sq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"Sr" = (
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/f13/tcoms)
+"Ss" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"St" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Control Room";
+	req_access_txt = "19; 61"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Su" = (
+/turf/open/floor/plasteel/dark,
+/area/f13/tcoms)
+"Sw" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Sz" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/f13/tcoms)
+"SA" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/f13/tcoms)
+"SB" = (
+/obj/structure/curtain,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
+"SC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"SD" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"SE" = (
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plasteel/vault{
+	dir = 1
+	},
+/area/f13/tcoms)
+"SF" = (
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/tcoms)
+"SG" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 2
+	},
+/area/centcom/holding)
+"SH" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/plasteel/vault{
+	dir = 4
+	},
+/area/f13/tcoms)
+"SI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"SJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"SK" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM"
+	},
+/turf/closed/wall,
+/area/f13/tcoms)
+"SL" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"SM" = (
+/obj/structure/table,
+/obj/item/multitool,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
+/area/f13/tcoms)
+"SN" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"SR" = (
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"SS" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/f13/tcoms)
+"ST" = (
+/obj/machinery/computer/telecomms/monitor{
+	dir = 4;
+	network = "tcommsat"
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/f13/tcoms)
+"SU" = (
+/obj/structure/table/wood,
+/obj/item/camera/detective{
+	desc = "A polaroid camera with extra capacity for social media marketing.";
+	name = "Professional camera"
+	},
+/obj/item/camera_film,
+/obj/item/wallframe/newscaster,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"SW" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"Tb" = (
+/obj/item/clothing/under/roman,
+/obj/structure/closet,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Te" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/f13/tcoms)
+"Tg" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
+/area/f13/tcoms)
+"Th" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -35
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Tj" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel,
+/area/f13/tcoms)
+"Tn" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"To" = (
+/turf/open/indestructible/airblock,
+/area/fabric_of_reality)
+"Tq" = (
+/obj/structure/table/wood/bar,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Tr" = (
+/obj/structure/closet/chefcloset,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Tu" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"TB" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"TK" = (
+/obj/structure/table/wood/bar,
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Ud" = (
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Uh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/nullrod/claymore/darkblade{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Um" = (
+/obj/structure/closet/crate/hydroponics,
+/turf/open/floor/plasteel/whitegreen,
+/area/centcom/holding)
+"UE" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"UH" = (
+/obj/machinery/door/airlock/wood{
+	req_one_access_txt = "28"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"UT" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"UV" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Vm" = (
+/obj/machinery/gibber,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Vu" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Vv" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Vz" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_y = 28;
+	use_power = 0
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"VA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
+"VD" = (
+/obj/effect/landmark/thunderdome/two,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"VE" = (
+/obj/effect/landmark/thunderdome/one,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"VF" = (
+/obj/structure/rack,
+/obj/item/nullrod/scythe/vibro{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Wh" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plating/f13/outside/desert,
+/area/syndicate_mothership)
+"Wx" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/red,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Wy" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/green,
+/obj/item/clothing/shoes/sneakers/brown,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/head/helmet/swat,
+/obj/item/gun/energy/laser,
+/turf/open/floor/plasteel,
+/area/tdome/arena)
+"Xd" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Xe" = (
+/obj/machinery/vending/autodrobe{
+	req_access_txt = "0"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Xk" = (
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Xn" = (
+/obj/machinery/door/airlock/wood{
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Xo" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Xx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"XL" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"XM" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Yf" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Yh" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Yk" = (
+/obj/structure/flora/wasteplant/wild_mutfruit,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Yl" = (
+/obj/structure/flora/tree/cactus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Ym" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Yo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Yp" = (
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Yu" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	locked = 0
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"Yv" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Yw" = (
+/obj/structure/flora/tree/wasteland,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Yx" = (
+/obj/structure/flora/wasteplant/wild_feracactus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"Yy" = (
+/obj/structure/flora/wasteplant/wild_xander,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"YE" = (
+/obj/structure/flora/wasteplant/wild_agave,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"YF" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/underground/mountain)
+"YJ" = (
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/book/manual/barman_recipes,
+/obj/item/book/granter/action/drink_fling,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"YL" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"YQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker,
+/turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"YV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/nullrod/claymore/saber{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Za" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "lmrestroom"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Zt" = (
+/obj/machinery/vr_sleeper{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Zx" = (
+/mob/living/simple_animal/bot/medbot,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"ZN" = (
+/obj/structure/fluff/rails,
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 25;
+	height = 50;
+	id = "emergency_away";
+	json_key = "emergency";
+	name = "CentCom Emergency Shuttle Dock";
+	width = 50
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/underground/mountain)
+"ZU" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"ZW" = (
+/turf/open/floor/plasteel/white,
+/area/centcom/holding)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaamBhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiaaabacacacacacabacacacacacabacacacacacabacacacacacabacacacacacabacacacacacabacacacacacab
-aaadaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafafafafafavahaiajajakavalamananaoavapapapapapavaqaqaqaqaqavarararararavasatatataubj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafaGaxaxafavahaiajajayavazanaAaAanavapaBapaBapavaqaqaqaqaqavaraCaraCaravaDaEaEaEaFbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKIKJKKKHaafxaaaaaajCaaKHKIKJKKKHaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafafafaGafavahaiajajaHavanaIaJaKaLavapapapapapavaqaqaqaqaqavarararararavaDaEaEaEaFbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKNKNKNKHKHKOKHKPKHKOKHKHKNKNKNKHaaaaaaaaaelIaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaelIlIaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafafafaMafavahaiajajajavananaNaNanavapapapapapavaqaqaqaqaqavararaCararavaDaEaEaEaFbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKQKRKSKSKUKVKWKXKYKVKUKSKSKZKQKHaaaaaaaaaelIaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaelIlIlIlIaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafaOafafafavahaiajajaHavaPaQananaQavapapaBapapavaqaqaqaqaqavarararararavaDaEaEaEaFbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKQKQKHLaLbKVLbLbLbKVLbLcKHKQKQKHaaaaaaaaaelIlIaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafaRafaSaGavahaiajajaHavaPaTaUaVaTavapapaBapapavaqaqaqaqaqavarararararavaWaEaEaEaXbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKHKQKOLbKVKVKVKVKVKVKVLbKOKQKHKHaaaaaaaaaelIlIaeaeaeaeaeaeaeaeaeaeaeFUaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafaGafafafavahaiajajajavaPaYaZaZaZavapapapapapavaqaqaqaqaqavararaCararavaWaEaEaEaXbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKHKHLdLeLfLgKVLhLbKVLiKHKHKHaaaaaaaaaaaeaelIaeaeaeaeMBToToToToToMBToNFToToToToMBToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfYfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafafafafafavahaiajajaHavaPbaaZaZbbavapapapapapavaqaqaqaqaqavarararararavaWaEaEaEaXbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLjLkLlLmKVLbLbKVLiKHaaaaaaaaaaaaaaaeaeaeaelIaeaeMBToToToToToMBMBToToToToMBMBToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafaxaxaGafavahaiajajayavaPbaaZaZbbavapaBapaBapavaqaqaqaqaqavaraCaraCaravaWaEaEaEaXbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLnLoLoLgKVLiLpKVLiKHaaaaaaaaaaaaaaaeaeaeaeaelIaeMBMBToToToToToToToToToMBMBToToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagafafafafafavahaiajajbcavaPbdbebebfavapapapapapavaqaqaqaqaqavarararararavbgbhbhbhbibj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLqLoLoLrKVLiLpKVKVKOveaaaaaaaaaaaaaeaeaeaeaeaeaeToMBMBToToToToToToToMBMBToToMBMBMBaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQepWQeQeQeQeQeQeQeQeQeQeDiaaabviviviviviabviviviviviabviviviviviabviviviviviabviviviviviabviviviviviabviviviviviab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKHKHKHLtLuLbLbKVLiKHaaaaaaaaaaaaaaaeaeaeaeaeaeaeToToMBMBToToToToToMBMBMBMBMBMBToToaeaeaeaeaelIaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavblbmblbnblavbobpbqbrbsavbtbtbubvbvavbwbwbwbwbwavbxbybybybzavbAbBbBbBbCbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLvKVLvKHKVLiLpKVLiLwaaaaaaaaaaaaaaaeaeaeaeaeaeaeToToToMBMBToToToToMBMBToToMBMBToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavbnbDbEbFblavbGbHbHbHbHavbIbIbJbKbKavbwbLbwbMbwavbNbNbNbNbNavbObPbPbPbQbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLvKVLvKHKVLiLpKVLiKHaaaaaaaaaaaaaaaeaeaeaeaeaeaeToToToToMBMBToToToMBMBToToToToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafXfXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavbDbRbSbTbDavbHbHbUbVbWavbIbXbXbXbKavbwbYbwbYbwavbNbNbNbNbNavbObZbZbZbQbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLxKVKVLyKVKVKVKVKVKOxbaaaaaaaaaaaaaeaeaeaeaeaeaeToToToToToMBMBMBMBMBToToToToToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagufXfXfXfXfXfXfXfXfXfXfXfXfXfXaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavcablcbcccaavbHbHcdcdcdavbIbJbJbJbKavbwbwbwbwbwavbNbNbNbNbNavbObPbPbPbQbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLvKVLvKHKVLbLbLbLbKHaaaaaaaaaaaaaaaeaeaeaeaeaeaeMHToToToToToToMBQmToToToToToToToToaeaeaelIaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkcebkbkavbDblblblblavcfbHcgbHchavcicjcjcjckavbwclbwbwbwavcmcmcmcmcmavcncocococpbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLvKVLvKHKVLALBLCKUKHaaaaaaaaaaaaaaaeaeaeaeaeaeaeToToToToMBMBToMBMBMBToToToToToToMBaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkcqcrbkavblbEblbmbDavcsbHctbHcuavcvcwcwcwcxavbwbwbwcybwavczczczczczavcAcBcBcBcCbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKHKHKHKHLDKHKHKHKHKHaaaaaaaaaaaaaaaeaeaeaeaeaeaeToToToToMBMBMBToToMBMBMBToToToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavcacDbRcEblavbHbHbHbHbHavcFbJcGbJcHavbwbwbwbwbwavbNbNbNbNbNavcIbPbPbPcJbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHKHLELiKVLFLGKHKHaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeToMBMBMBMBMBToToToToToMBMBToToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavbDcKcLcMcNavcOcPcQbHbHavcFcRcRcRcHavcScTcUcScSavbNbNbNbNbNavcIcVcVcVcJbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLHLbLILbLJKHaaaaaaaaaaaaaaaaaaaeaeaeaelIlIaeMBMBToToToMBToToToToToToMBToToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavbmcKcMcKcWavbHbHcXbHbHavcFcFbJcHcHavcYcYcYcYcYavbNbNbNbNbNavcIbPbPbPcJbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLNLOLPLQLRKHaaaaaaaaaaaaaaaaaaaeaelIlIlIaeaeToToToToToMBToToToToToToMBMBToToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRLRLRLRLRLRLRLRLaaDiQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeQeDiaaagbkbkbkbkbkavblcablbnblavcZdadbdcddavdededfdgdgavdhdhdhdhdhavbzdididibxavdjdkdkdkdlbj
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKHLwLwLwLwLwKHaaaaaaaaaaaaaaaaaaaeaeaelIlIaeaeToToToToMBMBToToToToToToToMBMBToToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMRMRMRMRMRMRLaaDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiDiaaabviviviviviabviviviviviabacacacacacabviviviviviabviviviviviabviviviviviabviviviviviab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaelIlIaeaeaeToToToMBMBToToToToToToToToToMBMBToaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMSuSuSuSuSuRMRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagdmdmdmdmdmavdndndndndnavdodpdqdrdsavdtdudududtavdvdwdxdydzavdAdAdAdAdAavdBdCdDdEdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaelIaeaeaeaeToToToMBToToToToAGToToToToToToMBMBaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMSuSESFSHSuRMRLaaaaaaaaaakokpkqkrksaaaaaakokpkqkrksaaaaaaaaaaaaaaagdmdGdGdGdmavdHdIdJdKdHavdLdLdMdLdLavdNdOdPdQdRavdSdTdUdVdWavdAdXdYdZdAavdBeaebecdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMSuSFSuSFSuRMRLaaaaaaaakKkLJAJBJCkPkQaakKkLAuAvAwkPkQaaaaaaaaaaaaagdmdGdGdGdmavedeeedeeedavefegegegehaveiejekejelavemeneoepeqavdAdAdAdAdAavdBeresetdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaelIaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMSuSHSSSESuRMRLaaaaaaaalgJFlilililjlkaalgBelilililjlkaaaaaaaaaaaaagdmdmeudmdmavevewevewevavexeyezeAexavejejejejejaveBeBeBeBeBavdAeCdAeDdAavdBeEeFeGdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaelIaeaeaeaeaeaeaeaeaeaeaeaelIlIaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMSuSuSuSuSuRMRLaaaaaaaalBlCJMlEJNlGlHaalBlCBQlEBRlGlHaaaaaaaaaaaaagdmdGdGdGdmavewevewevewaveHeHeHeHeHaveIeJejeKeLaveMeNeBeMeNavdAeOdAeOdAavdBeEeFeGdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaelIaeaeaeaeaeaelIlIlIlIaeaeaeaeaeaeaeaeaeaelIaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMRMRMRMRMRMRLaaaaaaaalXlYlilililjlZaalXlYlilililjlZaaaaaaaaaaaaagdmdGdGdGdmavevewevewevaveHeHeHeHeHavePeJejeKeQaveReSeBeReSavdAeTdAeUdAavdBeEeFeGdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaelIlIaeaeaeaeaeaeaelIlIlIlIlIaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRLRLRLRLRLRLRLRLaaaaaaaamrmsmtmumvmwmxaamrmsmtmumvmwmxaaaaaaaaaaaaagdmdmeudmdmavewevewevewaveHeHeHeHeHavejeVeVeVejaveMeNeBeMeNavdAeOdAeOdAavdBeEeFeGdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaelIaeaeaeaeaeaeaeaeaeaeaeaelIlIaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaanbncndnenfaaaaaanbncndnenfaaaaaaaaaaaaaaagdmdGdGdGdmaveWeXeWeXeWaveYeYeZeYeYavfafbfcfdfeaveReSeBeReSavdAeDdAffdAavdBfgfhfidFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagdmdGdGdGdmavfjfkflfmfjavdLdLdLdLdLavfnfofofofnaveMeNeBeMeNavdAeOdAeOdAavdBfpfpfpdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMRMRMRMRMRMRMRMRMRMRMRMRLRLaaaakokpkqkrksaaaaaakokpkqkrksaaaaaaaaaaaaaaagdmdmdmdmdmavdndndndndnavfqfqfqfqfqavfrfsfsfsftavepeneBepenavdAdAdAdAdAavdBfufvfwdFav
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMsEsGyqsEsERMRTRURVRWRMRMRLaakKkLLKLLLMkPkQaakKkLkMkNkOkPkQaaaaaaaaaaaaabKLKLKLKLKLabKLKLKLKLKLabKLKLKLKLKLabKLKLKLKLKLabKLKLKLKLKLabKLKLKLKLKLabKLKLKLKLKLab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawrdrdrdawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMsEGaGtGAGBRMSbScSeSfSgRMRLaalgLSlilililjlkaalglhlilililjlkaaLVLVLVLVLVLVLVLVLVLVLVLVLVLVLVabababababababababfyfzfAfzfzfzfzfzfzfzfzfzfAfzfyababababababababab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawBYhhhhhhCkawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMRMRMHkRMRMRMSbSjSfSfSkRMRLaalBlCLTlELUlGlHaalBlClDlElFlGlHaaLVLWLWLWLWLWLWLXLWLWLWLWLWLWLVabfBfCabababababfDfEfzfFfGfHfHfHfHfHfHfHfIfFfzfJfDabababababfCfKab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawBYhhCphhCkawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMsEsEsEsEsEsESpSqSrSsStSsRMRLaalXlYlilililjlZaalXlYlilililjlZaaLVLWLYLYLYLZLYLYLYLZLYLYLYLWLVabfBfCabababababfDfLfzfFfGfHfHfHfHfHfHfHfIfFfzfMfDabababababfCfKab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawBYhhhhhhCkawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMsEsEsEsEsEsEHlSzSASCSfSDRMRLaamrmsmtmumvmwmxaamrmsmtmumvmwmxaaLVLWLYLYLYLZLYLYLYLZLYLYLYLWLVabfBfCabababababfDfNfzfFfGfHfHfOfPfOfHfHfIfFfzfQfDabababababfCfKab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMsEsEsEsEsEsESISJSKSfSfSLRMRLaaaanbncndnenfaaaaaanbncndnenfaaaaLVLWLYLYLYLZLYLYLYLZLYLYLYLWLVabfBfCabababababfDfNfzfFfGfHfHfOfOfOfHfHfIfFfzfQfDabababababfCfKab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawWhawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMsEsEsEsEsEsEsESbSMSfSfSRRMRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLVLWLZLZLZLZLZLZLZLZLZLZLZLWLVabfBfCabababababfDfSfzfFfGfHfHfHfHfHfHfHfIfFfzfTfDabababababfCfKab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMsEsEsEsEsEsEsESbSTSeSfSfRMRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLVLWLYLYLYLZLZLZLZLZLYLYLYLWLVabfBfCabababababfDfEfzfFfGfHfHfHfHfHfHfHfIfFfzfJfDabababababfCfKab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMsEsEsEHysEsEsETeTgThGZTjRMRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLVLWLYLYLYLZLZMaLZLZLYLYLYLWLVabababfUfUfUfUfUabfyfzfAfzfzfzfzfzfzfzfzfzfAfzfyabfUfUfUfUfUababab
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRMRMRMRMRMRMRMRMRMRMRMRMRMRMRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLVLWLYLYLYLZLZMbLZLZLYLYLYLWLVaaaaabfVfVfVfVfVabababababababababababababababababfWfWfWfWfWabaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLVLWLWLWLWLWLWLWLWLWLWLWLWLWLVaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeqEAxAxAxqEaeaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLVLVLVLVLVLVLVLVLVLVLVLVLVLVLVaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeqEqEqZraqZqEqEaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeqErWqZqZqZrXqEaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZgagbgbgbgbgbgcfZgagbgbgbgcfZgagbgbgbgcfZgagbgbgbgcfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZgdgegegegffZgdgegegegffZgdgegegegffZgdgegegegegegffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeqEsWqZqZqZsXqEaeaeaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghghghghghgigjgggkglgkgigjgggkglgkgigjgggkglgkgigmgmgmgmgmgngngmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgngngmgmgmgmgmgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeqEqEqEqEAxtXAxqEqEqEqEaeaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghgtgtgtghgigjgggkglglgigjggglglglgigjggglglgkgigmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgngmgmgmgmgmgmgmgmgngmgmgmgmgmgmgmgmgngmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgpghgqgqgrgsgpgqgqgqgrgsgpgqgqghgrgsgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeqEqEuCuDqEqZqZqZqEuEuFqEqEaeaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghghghghghgigjgggkglgkgigjgggkglgkgigjgggkglgkgigmgmgmgmgmgngngmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgngngmgmgmgmgmgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeqEqEvjvkvjqEqZqZqZqEvlvmvnqEqEaeaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghgtgtgtghgifZgvgwgwgwgxfZgvgwgwgwgxfZgvgwgwgwgxfZghghghfZfZfZfZghghghfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZgygzgzgzgAfZgygzgzgzgAfZgygzgzgzgAfZgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeqEqEuDvjvjvjwbqZqZqZwcuEwduEuFqEqEaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghghghghghgifZfZgjgjgjfZfZfZgBgBgBfZfZfZgjgjgjfZfZgCgCgCfZfZfZfZgCgCgCfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZgsgsgsfZfZfZgBgBgBfZfZfZgsgsgsfZfZgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeqEMEwMvjvjvjqEwNqZwOqEwPuEvlwQvnqEaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghgtgtgtghgifZgagbgbgbgcfZgagbgbgbgcfZgagbgbgbgcfZgDgLghghgUgLghghgUgLghghgUgLghghgUgLghgEfZfZgIfZfZfZgIfZfZfZgIfZfZfZfZgIfZfZfZfZgIfZfZfZgIfZfZfZgIfZfZfZfZfZgdgegegegffZgdgegegegffZgdgegegegffZgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeqEvjvjvjxuxvqExwqZxxqExyxzuEwduEqEaeaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghghghghghgigjgggkglgkgigjgggkglgkgigjgggkglgkgigJgKgkgLghgMgkgLghgMgkgLghgMgkgLghgMglgLgJfZfZgNfZfZfZgNfZfZfZgNfZfZfZfZgNfZfZfZfZgNfZfZfZgNfZfZfZgNfZfZfZfZfZgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeqEqEyaqEqEqEqEqEqEybqEqEqEqEAxAxAxqEqEaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawawhlawawawawawawawawawawawawawawawawawawawawawawawawawawhhaafZggghgtgtgtghgigjgggkglglgigjggglglglgigjggglglgkgigJgOgigkghghgigkghghgigkghghgigkghghglgkgJgPgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgRgpghgqgqgrgsgpgqgqgqgrgsgpgqgqghgrgsgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeqEyCqZqZyCqEyDyEqZqZqZyFyGqEyHyIyJyKqEaeaeaeaeaeaeaahhawawawawawawawawawawawawawawawawawawawawawawawawkikukvkvkvkvkvkvkvkvkvkvkvkvkvkukiawawawawawawawawawawawawawawawhhaafZggghghghghghgigjgggkglgkgigjgggkglgkgigjgggkglgkgigJgSgkgTghgUgkgTghgUgkgTghgUgkgTghgUglgTgJfZfZgQfZgBfZgQfZgBfZgQfZfZgBfZgQfZgBfZfZgQfZgBfZgQfZgBfZgQfZfZgBfZfZgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeAxzoqZqZzoAxqZqZqZqZqZqZzpAxyKzqzrzqqEaeaeaeaeaeaeaahhhhhhawawawawawawawawawawawawawawawawawawawawawawkikullllllllllllllllllllllllllkukiawawawawawawawawawawawawawawawhhaafZgvgwgwgwgwgwgxfZgvgwgwgwgxfZgvgwgwgwgxfZgvgwgwgwgxfZgWgXgCgCgYgXgCgCgYgXgCgCgYgXgCgCgYgXgCgZfZfZhafZgBfZhafZgBfZhafZfZgBfZhafZgBfZfZhafZgBfZhafZgBfZhafZfZgBfZfZgygzgzgzgAfZgygzgzgzgAfZgygzgzgzgAfZgygzgzgzgzgzgAfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeAxzNqZqZqZAxqZqZqZzOqZqZzPAxzQyIyKyIqEaeaeaeaeaeaeaaaaaahhawawawawawawawawawawawawawawawawawawawawawawkikulllllllmlllllllllllmllllllkukiawawawawawawawawawawawawawawawhhaafZhbfZfZfZfZfZhbfZfZgjgjgjfZfZfZgkgkgkfZfZfZfZgQfZfZfZfZghfZfZfZfZfZglglglfZfZfZfZfZhchjhjhjhefZfZgBfZgBfZgBfZgBfZgBfZfZgBfZgBfZgBfZfZgBfZgBfZgBfZgBfZgBfZfZgBfZfZfZfZgQfZfZfZfZhfhfhffZfZfZgsgsgsfZfZhgfZfZfZfZfZhgfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeAxzoqZqZzoAxqZqZqZAyqZqZqZAxAzAAzqABqEaeaeaeaeaeaeaaaaaahhawawawawawawawawawawawawawawawawawawawawawawkikukukukukukukullkukukukukukukukiawawawawawawawawawawawawawawawhhaafZgkgkgkgkgkgkgkfZgagbgbgbgcfZgkgkgkgkgkfZfZfZgQfZfZfZfZghgogogogogogogogogogogogogohihjhjhjhkgogogogogogogogogogogogogoghfZfZfZghgogogogogogogogogogogogogoghfZfZfZfZgQfZfZfZhfhfhfhfhffZgdgegegegffZhfhfhfhfhfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeqEBfqZqZBfqEBgBhqZqZqZBhqZqEyKyIyKBiqEaeaeaeaeaeaeaaaaaahhawawawawawawawawawawawawawawawawawawawawawawkikikikikikikikullkukikikikiktkikiawawawawawawawawawawawawawawawhhaafZgkglglglglglgkhbgggkglgkgifZgkghghghgkfZfZfZgQfZfZfZfZghfZgBgBgBfZglglglfZgBgBgBfZhmhnhnhnhofZgBgBgBfZhphphpfZgBgBgBfZghfZfZfZghfZgBgBgBfZgqgqgqfZgBgBgBfZghfZfZfZfZgQfZfZfZhfghghghhffZgpghgqghgrhqhfgqgqgqgqgqhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaKMaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeqEqEBSqEqEqEqEqEAxBSAxqEqEqEAxAxAxqEqEaeaeaeaeaeaeaaaaaahhawawawawawawawawawawawawawawawmaawawawmymaawawawawawmyawkikullnzmzmyawawawawawawawawawawawawawawawawawawawawhhaafZgkglgkgkgkglgkhbggglglglgifZgkfZglfZgkfZgQgQgQgQgQgQghghghghghghghghghghghghghghghhrgbgbgbgchzhzhzhzhzhzhzhzhzhzhzhzhzgdgegegehxghghghghghghghghghghghghghghghgQgQgQgQgQgQfZhffZgqfZhffZgpgqgqgqgrhqhfgqhfhfhfgqhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeAxqZqZqZCiqZqZqZqZqZqZqZCiqZqZqZAxaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawawmaawawawawawawawawawawawmyawawawawawkikullnzmAawawmyawmyawawawawawawawawawawawawawawawawhhaafZgkglgkgkgkglgkhbgggkglgkgifZgkghghghgkfZfZfZgQfZgBfZghghghhjhjhjhjhjhjhjhjhjhjhjghhygkgkgkgihzhzhzhzhzfZhzfZhzhzhzhzhzgphfhfhfhAghhBhBhBhBhBhBhBhBhBhBhBghghghfZgBfZgQfZfZfZhfghghghhffZgpghgqghgrhqhfgqhfhfhfgqhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeAxqZuEqZuEqZuEqZuEqZuEqZuEqZuEqZAxaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawawawawawmaawawawawawmaawawmaawawmyawawkikunynzktawmyawawmaawmyawmaawawawawawawawawawawawawhhaafZgkgkgkgkgkgkgkfZgvgwgwgwgxfZgkgkgkgkgkfZfZfZgQgBgBgBghghghghghghghghghghghghghghghhygkglgkgihzhzhzhzhzhzfZhzhzhzhzhzhzgphfgqhfhAghghghghghghghghghghghghghghghgBgBgBgQfZfZfZhfhfhfhfhffZgygzgzgzgAfZhfhfhfhfhfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeqEqEqZqZqZqZqZqZqZqZqZqZqZqZqZqEqEaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawkiawawawawawawawawawkiawawawawawawmaawkikullkukimyawmamyawmaawawawawawawawawawawawawawawawhhaafZfZgjgjgjgjgjfZfZfZfZfZfZfZfZfZgkgkgkfZfZfZfZfZfZgBfZghghfZgkgjgkfZgBgBgBfZgkgjgkfZhygkgkgkgifZhzhjglhzhzhzhzhzgqhBhzfZgphfhfhfhAfZhfgshffZgBgBgBfZhfgshffZghghfZgBfZfZfZfZfZfZhfhfhffZfZfZfZfZfZfZfZfZhfhfhfhfhffZfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeqEqEqEDCqEqEqEDDqEqEqEDEqEqEqEaeaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawkiawawawawawawawawawkiawawawawawawawawkikullkuktawmyawawawmyawmyawmyawawawawawawawawawawawhhaafZgkgkgkgkgkgkgkfZgkgkgkgkgkfZgkgkgkgkgkfZgkgkgkgkgkfZghghfZgjgkgjglhjhjhjglgjgkgjfZhygkfZgkgifZhzhzhjglhzhzhzgqhBhzhzfZgphffZhfhAfZgshfgsgqhBhBhBgqgshfgsfZghghfZhfhfhfhfhffZhfhfhfhfhffZhfhfhfhfhffZhfhfhfhfhfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeqEDLDMDNqEDOuEDPqEDQDRDSqEaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawkiawawawawawawawawawkiawawawawmaawawawkikullkuktawawawawmaawawawmaawawawawawawawawawawawawhhaafZgkgkgkhCgkgkgkfZgkghfZghgkgkgkglhCglgkgkgkghfZghgkgkghghgBgkgjgkhjhjhjhjhjgkgjgkfZhygkglgkgifZhjhzhzhjglhzgqhBhzhzhBfZgphfgqhfhAfZhfgshfhBhBhBhBhBhfgshfgBghghhfhfghfZghhfhfhfgqhCgqhfhfhfghfZghhffZhfhfhfhChfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeqEDZDMEaqEEbEcEdqEEeDREfqEaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawkiawawawawawawawawawkimaawawawawkiktkikikullkukimyawmymyawmamymaawawawawawawawawawawawawawhhaafZgkgkhChDhCgkgkfZgkghglghgkgkgkhChEhCgkgkgkghglghgkgkghghgBgjgkgjhjhjglhjhjgjgkgjfZhygkglgkgifZglhjhzhzhjhzhBhzhzhBgqfZgphfgqhfhAfZgshfgshBhBgqhBhBgshfgsgBghghhfhfghgqghhfhfhfhChFhChfhfhfghgqghhffZhfhfhChGhChfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeqEEhEiEjqEEkuEElqEEmEnEoqEaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawkiawawawawawawawawawkiawawawawkikikukunzkupFkukiktmCkiktmCkiktawmyawawawawawawawawawawawawhhaafZgkgkgkhCgkgkgkfZgkghfZghgkgkgkglhCglgkgkgkghfZghgkgkghghgBgkgjgkhjhjhjhjhjgkgjgkfZhygkglgkgifZhjhzhzhjglhzgqhBhzhzhBfZgphfgqhfhAfZhfgshfhBhBhBhBhBhfgshfgBghghhfhfghfZghhfhfhfgqhCgqhfhfhfghfZghhffZhfhfhfhChfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeqEqEECqEqEqEAxqEqEqEqEqEqEaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawawawawkiawawawawawawawawawkiawawawawkikungpXpYpZqakukukukukukunzkuhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhaafZgkgkgkgkgkgkgkfZgkgkgkgkgkfZgkgkgkgkgkfZgkgkgkgkgkfZghghfZgjgkgjglhjhjhjglgjgkgjfZhygkfZgkgifZhzhzhjglhzhzhzgqhBhzhzfZgphffZhfhAfZgshfgsgqhBhBhBgqgshfgsfZghghfZhfhfhfhfhffZhfhfhfhfhffZhfhfhfhfhffZhfhfhfhfhfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeqEqZqEqZEWEXEWEYqEaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawkikikikiawawawawawawawawawkikikikiawkikuqJpZpZpZpZqKqLqMkuqNqOqPkuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafZfZgjgjgjgjgjfZfZfZfZfZfZfZfZfZgkgkgkfZfZfZfZfZfZgBfZghghfZgkgjgkfZgBgBgBfZgkgjgkfZhygkgkgkgifZhzhjglhzhzhzhzhzgqhBhzfZgphfhfhfhAfZhfgshffZgBgBgBfZhfgshffZghghfZgBfZfZfZfZfZfZhfhfhffZfZfZfZfZfZfZfZfZhfhfhfhfhffZfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeAxqZECqZqZqZqZqZAxaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawkiawawawawawawawawawawawawawawawkiawkikurepZrfrfpZpZpZpZrhririrjkukukukukukukukukukuFZkuaaaaaaaaaaaafZgkgkgkgkgkgkgkfZgagbgbgbgcfZgkgkgkgkgkfZfZfZgQgBgBgBghghghghghghghghghghghghghghghhygkglgkgihzhzhzhzhzhzfZhzhzhzhzhzhzgphfgqhfhAghghghghghghghghghghghghghghghgBgBgBgQfZfZfZhfhfhfhfhffZgdgegegegffZhfhfhfhfhfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeqEqEqEFTqZqZqZFTqEaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawkiawawawawawawawawawawawawawawawkikikikuserfsfsgrfpZshsikurisjkukuskskslsmsnsmsmsospskkuaaaaaaaaaaaafZgkglgkgkgkglgkhbggghglghgifZgkghghghgkfZfZfZgQfZgBfZghghghhjhjhjhjhjhjhjhjhjhjhjghhygkgkgkgihzhzhzhzhzfZhzfZhzhzhzhzhzgphfhfhfhAghhBhBhBhBhBhBhBhBhBhBhBghghghfZgBfZgQfZfZfZhfghghghhffZgphfgqhfgrhqhfgqhfhfhfgqhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeqEGrGrGrGrGrqEaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawkiawawawawawawawawawawawawawawawnznznzkupZrftetfrfpZshtgkukukukukuskthtisksksksksktnspkuaaaaaaaaaaaafZgkglgkgkgkglgkhbggglglglgifZgkfZglfZgkfZgQgQgQgQgQgQghghghghghghghghghghghghghghghhIhJhJhJhKhLhLhLhLhLhLhLhLhLhLhLhLhLhMhNhNhNhOghghghghghghghghghghghghghghghgQgQgQgQgQgQfZhffZgqfZhffZgpgqgqgqgrhqhfgqhfhfhfgqhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeqEqEGzGzGzqEqEaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawkiawawawawawawawawawawawawawawnhuJlluJudpZpZpZpZpZpZshtgkukukukukuskueskskskskskskskuikuaaaaaaaaaaaafZgkglglglglglgkhbggghglghgifZgkghghghgkfZfZfZgQfZfZfZfZghfZgBgBgBfZglglglfZgBgBgBfZghfZfZfZghfZgBgBgBfZhphphpfZgBgBgBfZhPhBhBhBhRfZgBgBgBfZgqgqgqfZgBgBgBfZghfZfZfZfZgQfZfZfZhfghghghhffZgphfgqhfgrhqhfgqgqgqgqgqhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeGXGXGXaeaeaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawawkiawawawawawawawawawawawawawawawnznznzkuuLrfrfrfpZpZshuMnznznznznznznzskskskskskskskuikuaaaaaaaaaaaafZgkgkgkgkgkgkgkfZgvgwgwgwgxfZgkgkgkgkgkfZfZfZgQfZfZfZfZghgogogogogogogogogogogogogoghfZfZfZghgogogogogogogogogogogogogohShBhBhBhTgogogogogogogogogogogogogoghfZfZfZfZgQfZfZfZhfhfhfhfhffZgygzgzgzgAfZhfhfhfhfhfhfhffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhawawawawawkikiawawawawawawawawawawawawawawawkikikikuvuvvvwvvvxpZpZpZuJlllllllllluJskskskskskskskuikuaaaaaaaaaaaafZhbfZfZfZfZfZhbfZfZgjgjgjfZfZfZgkgkgkfZfZfZfZgQfZfZfZfZgBfZfZgBfZgBfZgBfZgBfZgBfZfZgBfZfZfZgBfZfZgBfZgBfZgBfZgBfZgBfZfZhUhVhVhVhWfZfZfZfZfZgqgqgqfZfZfZfZfZgCfZfZfZfZgQfZfZfZfZhfhfhffZfZfZgsgsgsfZfZhgfZfZfZfZfZhgfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaaaaaahhnxawawawawkiawawawawawawawawawawawawawawawawawkiktkuwlwmwnwnwopZpZwpnznznznznznznzskskskskskskskuikuaaaaaaaaaaaafZgagbgbgbgbgbgcfZgagbgbgbgcfZgagbgbgbgcfZgagbgbgbgcfZfZgBfZfZgIfZgBfZgIfZgBfZgIfZfZgBfZgIfZgBfZfZgIfZgBfZgIfZgBfZgIfZfZgOghibifghghibifghghibifghghibifghghibiafZgdgegegegffZgdgegegegffZgdgegegegffZgdgegegegegegffZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkikikukusiwVwWwXkuwYkukukukukukuskueskskskskskskskuikuaaaaaaaaaaaafZggghghghghghgigjggghglghgigjggghglghgigjggghglghgifZfZgBfZfZgNfZgBfZgNfZgBfZgNfZfZgBfZgNfZgBfZfZgNfZgBfZgNfZgBfZgNfZfZgOibgqicghibhficghibhficghibhficghibhfidgOgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkikikikukukukukukuxGxGxHxIxJxKkuskxLxMskskxNskskxOxPkuaaaaaaaaaaaafZggghgtgtgtghgigjggghglglgigjggglglglgigjggglglghgigPgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgQgRgOhfgqghghhfgpghghhfgpghghhfgpghghhfgpgJgOgpghgqgqgrgsgpgqgqgqgrgsgpgqgqghgrgsgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkiawkikikikiktkikuxGxGxGxGxGxGkuskskykskgFskskskxPskkuaaaaaaaaaaaafZggghghghghghgigjggghglghgigjggghglghgigjggghglghgifZfZfZfZfZgQfZfZfZgQfZfZfZgQfZfZfZfZgQfZfZfZfZgQfZfZfZgQfZfZfZgQfZfZgOiegqifghiehfifghiehfifghiehfifghiehfiggOgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkiawawawmamyawktnzxGxGxGxGxGyXkukukukukukukukukukukukuaaaaaaaaaaaafZggghgtgtgtghgifZgvgwgwgwgxfZgvgwgwgwgxfZgvgwgwgwgxfZfZfZfZfZhafZfZfZhafZfZfZhafZfZfZfZhafZfZfZfZhafZfZfZhafZfZfZhafZfZihgCiiijgCgCiiijgCgCiiijgCgCiiijgCgCiiikfZgygzgzgzgAfZgygzgzgzgAfZgygzgzgzgAfZgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkiawawawmaawmaktkugGgGgGgGgGgHkuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafZggghghghghghgifZfZgjgjgjfZfZfZgBgBgBfZfZfZgjgjgjfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZghghghfZfZfZfZghghghfZfZgsgsgsfZfZfZgBgBgBfZfZfZgsgsgsfZfZgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkiawawawawawmykikukukukukukukukuaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafZggghgtgtgtghgifZgagbgbgbgcfZgagbgbgbgcfZgagbgbgbgcfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZghghghfZfZfZfZghghghfZgdgegegegffZgdgegegegffZgdgegegegffZgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkiawawmyawawmakihhaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafZggghghghghghgigjggghglghgigjggghglghgigjggghglghgighgmgmgmgmgngngmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgngngmgmgmgmgmgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawawawawawawawawawawawawawkiawawawawawawawhhaaNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdaaaafZggghgtgtgtghgigjggghglglgigjggglglglgigjggglglghgighgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgngmgmgmgmgmgmgmgmgngmgmgmgmgmgmgmgmgngmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgmgpghgqgqgrgsgpgqgqgqgrgsgpgqgqghgrgsgpghgtgtgtghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkiawawawawawkikikikikikikiawawawawawkiawawawawoWawawhhaaNdPOHQMuPYpENdPLTqXkXkNdyMOGTKYLXeNyBsSUNdaaaafZggghghghghghgigjggghglghgigjggghglghgigjggghglghgighgmgmgmgmgngngmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgmgogmgmgmgmgmgmgmgmgmgogmgmgmgmgmgmgngngmgmgmgmgmgpghgqghgrgsgpghgqghgrgsgpghgqghgrgsgpghghghghghgrfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawkikikikikikikiawawawawawkikikikikikikiawawawoWpGoWawhhaaNdPOPYQHPYNJNdXkXkXkXkXLXkXkXkXkXkXkRiXkNdaaaafZgvgwgwgwgwgwgxfZgvgwgwgwgxfZgvgwgwgwgxfZgvgwgwgwgxfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZgygzgzgzgAfZgygzgzgzgAfZgygzgzgzgAfZgygzgzgzgzgzgAfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhawawawawawawawawawawawawawawawawawawawawawawawawawawawawoWawawhhaaNdPOPYBoPYSWNdYoMGRhRhNdYoXkXkXkXkXkXkXxNdaaaafZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZfZaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhaaNdSwPYvsPYPYXLXkrgMmMmNdXkXkXkXkXkXkXkNmNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdPOPYRjPYUmNdXkNdNdNdNdNdNdNdNdNdNdXLNdNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdPOPYPIPYNnNdXkVmMTPrJESGzXQAXoTBVzFhSNNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdPOPYRdPYPYpyXkFhFhFhFhFhFhFhFhFhFhFhpVNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdNdNdNdNdNdNdYhzVYuQWYQVvpSNvFhFhYJFhTrNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdQIZWPaSBNdXkXkNdNdNdNdNdNdEDpyBVQTUHNdNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdVAZWZWZWNdYoNdNdFbFcMRNdNdYoXkXkXkXkFjNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdOpZWZWNwNdXkNdFaSdSdSdSdNdYfYfYfYfYfNdNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdNdZaNdNdNdXnNdKTKTKTFWFXNdUEUEUEUEUENdNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdRmXkXkXkXkXkGsXkXkXkXkXkGsXkXkXkXkXkFiNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdTnXkXkXkXkXkXkXkXkXkXkXkXkXkXkXkXkXkTnNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdUTXkXkXkXMTnGYXkSdSdSdXkXMTnGYXkXkXkUTNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdydTuXkPhQLTuTuXkSdSdSdXkTuXdTuPhXkTuHmNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdXkXkXkXkXkXkXkXkSdSdSdXkXkXkXkXkXkXkXkNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdXkXkXkTuXkXkXkXkSdSdSdXkXkXkXkQkXkXkXkNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdXMTnGYVuXMTnGYHHSdSdSdHHXMTnGYVuXMTnGYNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdNTNTNTNdNTNTNTNdReNdReNdNTNTNTNdNTNTNTNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdUVXkUVGsPXXkYmXkXkGsXkXkXkXkXkGsXkXkXkNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababgVgVabgVgVababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdCVXkCVXkCVXkCVXkXkZxXkUdUdUdUdUdXkXkXkNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiFiGiNiOiPiPiPiPiPiQabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadaaaaNdXkXkXkXkXkXkXkXkXkXkXkUdUdUdUdUdXkXkXkNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiGiNiSiSiSiSiSiSiXiFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdNTNTNTReNTNTNTNdNTReNTNTNTNTNTNTNTReNTNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiYiRiZjbiSjcjcjcjciSjdabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdCTXkXkXkXkXkDjNdvtXkXMPoSdSdSdPAGYXkvtNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaajejfjkjljmiSiGjnjnjniSjoabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdoVXkPFPFPFXkQuNdYVXkXMPoSdSdSdPAGYXkMxNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaajpjqjpiNjriSiSiSiSiSiSjsabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdCTXkXkXkXkXkDjNdOUXkXkSdSdNqSdSdXkXkOUNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiRiRjtjriSiGjnjnjniSjsabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdCTXkPxPxPxXkDjNdTbXkXMPoSdSdSdPAGYXkTbNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaLsjpjqjpjujriSiSiSiSiSiSiXjyaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdoVXkXkXkXkXkQuNdRSXkXMZUMMMMMMPlGYXkUhNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaajDjEjIjJjKiSiGjnjnjniSjLabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdCTXkZtPFZtXkDjNdVFXkXkXkXkXkXkXkXkXktWNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiYiRiZjMiSiSiSiSiSiSjNabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdNdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiZjPiSiGjnjnjniSjLabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiZjPiSjQjQjQjQiSjdabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiGjuiSiSiSiSiSiSiXiFaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiFiGjukjkwkwkwlnkwloabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRiRabiRiRiFlpabjyablqababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiRlJlKmbmcmdmemfabmgiPmhabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaamimjmDiPmFiPiPmGabjPiSjdabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaajymHmImJkwkwkwlolpjPiSiXnlaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabnmnnnonDnEmenFabmIkwnGabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababmijylpabiFablqababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxqxqxqxrShdtRhdrSqxqxqxqxrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQhshthuhvCchwhQhthsCQqxrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQCQhXCcCcCcCcCchXCQCQqxrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxqxhdhYhZMXMXMXilhYhdqxqxrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQhshtwKMXMXMXtUhthsCQqxrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQCQhXwKMXMXMXtUhXCQCQqxrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxqxhdqximMXMXMXinqxhdqxqxrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQhshtwKMXMXMXtUhthsCQqxrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQCQhXwKMXMXMXtUhXCQCQqxrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxqxhdqxioMXMXMXipqxhdqxqxrbqxqxqxqxqxqxqxqxqxqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQhshtwKMXMXMXtUhthsCQqxrbqxCQqnCQqnCQqnCQCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQCQhXwKMXMXMXtUhXCQCQqxrbqxiqCQqnCQqnCQqnCOqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxqxhdqxirMXMXMXisqxhdqxqxrbqxCQititititititCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQhshtwKMXMXMXtUhthsCQqxrbqxCQCQCQCQCQCQCQCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQCQhXwKMXMXMXtUhXCQCQqxrbqxiqiuiuiuiuiuiuCOqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxqxhdhYivMXMXMXiwhYhdqxqxrbqxCQCQCQCQCQCQCQCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbqxCQhshtAVAWAWAWBchthsCQqxrbqxCQCQCQCQCQCQCQCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbqxCQCQhXCcCcCcCcCchXCQCQqxrbqxCQCQCQCQCQCQCQCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbqxqxqxqxqxqxqxCcqxCcqxqxqxqxqxqxqxCQCQCQCQCQCQCQCQqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbixGMiyiziAiBiCGMGMGMiCiBiAiziyGMqxnHiDiDiDiDiDiDnHqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbixiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEqxqWMXiIMXMXiIMXsNqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixixixixixixixixixixixixixixixiKiEiEiEiEiEiEiEiEiEiEiEiEiEiLqxMXMXMXMXMXMXMXMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiEiEiEiEiEiMiEiEiEiEiMiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiTMXqVqViUqVqVqVMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEqxMXqViViWjajgqVMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEiTMXjhCcCcCcCcjhMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiKiLixjijijijijijijijijijiixiKHNHNIdHNHNHNHLHNHNHNIdHNHNiLqxMXqVjjCcCcjvqVMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiEiEixjwjwjwjxjwjwjwjzjwjwixiEiEiEiEiEiEiEiEiEiEiEiEiEiEiEqxMXrSjACcCcjBrSMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiEiEixjwjzjwjwjwjxjwjwjFjwixiEHNHNIdHNHNHNHNHNHNHNIdHNHNiEqxMXqVjGCcCcjHqVMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbixiKiLixGPGPjRGPGPGPGPjRGPGPEpIlIlIlIlIlIlIlIlIlIlIlIlIlIlIlEpMXqVjSCcCcjTqVMXqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbjUMXMXjUjUjUEpEpEpEpEpEpEpEpEpIsItIuItItItItItItItItItIuItIsEpEpEpEpEpEpEpEpEpqxrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbjUjUjVjWjUjUrbEpIyIzIAVDjXVDICIDIEItIFIGIHIHIHIHIHIHIHIIIFItIJMhILVEjYVEINMiIPEprbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbjUjZMXMXkajUrbEpIyIzITIUIVIUIWIDIXItIFIGIHIHIHIHIHIHIHIIIFItIYMhIZJaJbJaJcMiIPEprbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUjUjUjUjUjUjUjUjUrbjUjZMXMXkajUrbEpIyIzITIVJgIVIWIDJhItIFIGIHIHJikbJiIHIHIIIFItJkMhIZJbJlJbJcMiIPEprbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUkckdkekfkgkdkejUrbjUkhMXMXkkjUrbEpIyIzITIVIVIVIWIDJhItIFIGIHIHJiJqJiIHIHIIIFItJkMhIZJbJbJbJcMiIPEprbrbrbrbrbrbrbjUkljUjUrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtctctctctctctctctctctctctctctctctctctckmjUjUjUjUjUjUrbrbrbrbrbjUknkfkfkfkfkfkxjUrbjUkyMXMXkzjUrbEpIyIzITIUIVIUIWIDJsItIFIGIHIHIHIHIHIHIHIIIFItJtMhIZJaJbJaJcMiIPEprbrbrbrbrbrbrbkAkBkCjUrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtcNRtltltltltltltltltltltltltltltltltlkmkDkEkFkfkGjUjUjUjUjUrbjUkHkIkJkfkRkIkSjUrbjUjZMXMXkajUrbEpIyIzJuJvJvJvJwIDIEItIFIGIHIHIHIHIHIHIHIIIFItIJMhJxJyJyJyJzMiIPEprbrbrbrbrbrbrbkTkUkVjUrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtctjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjkWkWkWkXkfkxkYkZkfkfjUrbjUlalblckfldlblejUrbjUjZMXMXkajUrbEpEpEpJDJDJDJDJDEpIsItIuItItItItItItItItItIuItIsEpJDJDJDJDJDEpEpEprbrbjUjUjUjUjUjUlfjUlrlsjUjUjUjUjUrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtktltltltltltltltltltltltltltltltltlQCltlulvlwlxlykWlzkflAjUrbjUknkfkfkfkfkfkxjUrbjUkyMXMXkzjUrbrbrbEpWxWxWxWxWxEpIlIlIlIlIlIlIlIlIlIlIlIlIlIlIlEpWyWyWyWyWyEpjUjUrbrbjUlLlMlNlOlPlQlRlSlTjUlUlVlWlrrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtctjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjkWkWkWkXkfkxkYmkkfkfjUrbjUmlmmkekfkgmmmnjUrbjUjZMXMXkajUrbrbrbEpEpEpEpEpEpEpmompmpIdmpmpIdmqmEmpmpIdmpmpmoEpEpEpEpEpEpEpjUrbrbrbjUmKmLmMmNmOmPmQmRmSmTmSmUmVlsrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtcNRtltltltltltltltltltltltltltltltltlkmkWkEmWmXmYjUkfkfkfjUrbjUjUjUjUmZjUjUjUjUrbjUkhMXMXkkjUrbrbrbrbrbrbjUMXMXEpnaniniGMniniGMnjGMniniGMnininkEpMXMXjUjUjUjUjUrbrbrbjUnpnqnrnsntmPnunvnwjUnAnBnCjUrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbtctctctctctctctctctctctctctctctctckmkmkmkWkWkWkWkWjUkfkfkfjUrbrbrbjUnKnLnMjUrbrbrbjUkyMXMXkzjUrbrbrbrbrbrbjUMXMXnNGMHLHLHLHLHLHLHLHLHLHLHLHLHLGMnNMXMXjUrbrbrbrbrbrbrbjUnOmLmLnPnQnRmSnSnTjUnUnBnVjUrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUjUqyqyqyqyqyqyjUnWnXkZjUrbrbrbjUnYnZoajUrbrbrbjUjZMXMXkajUrbrbrbrbrbrbjUMXMXEpobocodoeofnkogohoinkojokolomobEpMXMXjUrbrbrbrbrbrbrbjUonooopmPoqorosotoujUovowoxjUrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUjUjUkWkWkWkWkWjUkYjUkYjUjUjUjUjUjUoyjUjUjUjUjUjUjUjVjWjUjUjUjUjUjUjUjUjUMXiJEpEpEKEvEvEpEvEvozEvEvEpEvEvEKEpEpiHMXjUjUjUjUjUjUjUjUjUjUjUlsoAjUlskloBjUjUlsoClrjUjUjUjUjUjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbjUDAoDoEoFoGoHoIjUoJoKmkkfoLkfkfoLoJoMmkoLkfkfkfoLkfkfkfoNoOoPoQkfkfkfkfoRMXMXMXoSoTMXMXoXMXMXoYMXMXoXMXMXoToSMXMXMXoRkfkfkfnWoZpawJkfkfkfoLpbkfoLkfpcoLkfkfoLkfkfjUpdpepfjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbjUpgphkfpikfkfpjjUkfkfkfkfkfkfkfkfkfpkkfkfkfkfkfkfkfkfkfploOpllzkfkfkflAjUMXMXMXMXMXMXMXpmpmpmpmpmpmpmMXMXMXMXMXMXMXjUpnkfkflzxrpaxrkfkfpopppqppprpsptpspspspspspspupvpwpxjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbjUpzkfpAkfkfkfkfkYkfkfkfkfkfkfkfkfkfpkkfkfkfkfkfpBkfkfkfoNoOoPmkkfkfkfkfoRMXMXMXMXMXMXMXpmpCpDpHpIpJpmMXMXMXMXMXMXMXoRkfkfkfpKoZpawJkfkfpbpBkfkfpLkfkfkfkfkfkfkfkfjUpMpNpOjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbjUDhpPpQpRpTCcpUjUpBkfkfkfpBkfkfpBnWoMkZpBkfjUjUjUjUjUjUjUjUjUjUkfkfkfkfjUMXMXMXMXMXMXMXpmpmpmpmpmpmpmMXMXMXMXMXMXMXjUkfkfkfjUjUjUjUjUjUqbjUjUjUqcjUjUiTiTjUpnlAjUjUjUjUjUjUrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbjUjUjUjUjUjUjUjUjUjUjUjUjUjUoClsqdqeqfqeqdjUoCqxqxqxqxqxqxqxqxjUjUqgqhjUjUjUjUjUjUjUjUMXMXMXMXMXMXMXMXMXjUjUjUjUjUjUjUjUqgqhjUrbrbrbjUqiqjqUuynBqkjUjUrbrbjUkfkfjUrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUqyqyjUqlqmuGuHqpCcqqCcqrqpnOtRqsqtquqvqwqAtRjUnWqBqCkZjUqDqFqGqFqHjUMXMXqIAWBaAWqIMXMXjUqQqRqSqRqQjUnWqBqCkZjUrbrbjUqTqjmLopqXqkqYjUrbrbjUkfkfjUJVJWJVJVJVJVJWJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBPBPBPBPrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUqzqzqVrknBnBnBkfCQrlrmrnCQkfhYpnkfkfkfkflAhYjUknqBqCkxjUrorprprprqjUMXtUjUjUjUjUjUwKMXjUrrvXrsvXrrjUknqBqCkxjUrbrbjUrtrunQrvrwrxryjUrbrbjUpnlAjUJVKdKdKeKeKdKfJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBTBTBTBPrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUqyqyqVmKnBrzrACQrBrCrDrErFrGrHrIrIrJrKrLrMqxjUrNqBqCkxjUrorprprprOjUiHrPkWrQqyrRkWrTiJjUrUrVvXrVrZjUknqBqCsajUrbrbjUsbscmLsdsqsrssjUrbrbjUkfkfstKkKdKdKeKeKlKmJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBPBUBPBPrbrYrYrYrYrYBTBTBTBTBTBTrYrYrYrYrYrbrbjUqzqzlsqpnBsusvkfswsxsyszsAkfsBkfkfsCsDsFsHqxjUknqBqCkxjUsIjUsJsIjUjUMXtUkWsKqysLkWwKMXjUjUjUsMjUjUjUknqBqCkxjUrbrbjUsQsRmLsSmLsUmLjUrbrbjUkfkfjUJVKdKdKeKeKdKzJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBTBTBTBPrbrYrYrYrYrYBTBWtltlBXBTrYrYrYrYrYrbrbjUqyqyqVsVnBsYsZCQtatbtoCetpCQsBkfkftqtrkftsqxjUknqBqCkxjUtttutvtutvkWMXtwkWtxqytykWtzMXkWtAtBvXtCtDjUknqBqCkxjUrbrbjUtEtFtGtHtItJtKjUrbrbjUjUjUjUJVKEKdKeKeKdKFJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBTBTBTBPrbrYrYrYrYrYBTtltltltlBTrYrYrYrYrYrbrbjUqzqzqVtLnBnBnBkfCQtMtNtMCQkfhYpnkfkfkfkflAhYjUrNqBqCkxjUtOtvrptvrpvrMXtUkWtQqztQkWwKMXkWtSvXrsvXtTjUknqBqCsajUrbrbjUjUjUjUjUjUjUjUjUrbrbrbrbrbrbJVKdKdKdKdKdKdJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBTBTBTBPrbrYrYrYrYrYBTtltltltlBTrYrYrYrYrYrbrbjUqyqyjUtYtZuaubucufuguhujukulrSumunuoupuqurrSjUknqBqCkxjUusrptvrptvtPMXtUkWutqyutkWwKMXkWrsrsvXrsuujUknqBqCkxjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbJVKdKdKeKeKdKdJVrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBTBTBTBPrbrYrYrYrYrYBTCbtltlCmBTrYrYrYrYrYrbrbjUjUjUjUjUjUoClrlsjUjUjUjUjUjUqxqxqxqxqxtRqxqxjUknqBqCkxjUuvtvrptvrpkWMXtwkWuwqyuxkWtzMXkWtSvXrsvXtTjUknqBqCkxjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbJVJWJVJVJVJVJWJVrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbBPBTBTBTBPrbrYrYrYrYrYBTBTtltlBTBTrYrYrYrYrYrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbjUjUjUjUjUjUjUjUjUjUwuqBqCkxwytvrptvrptvwDMXtUkWsKqzsLkWwKMXwErsrsvXrsrswGknqBqCwIjUrbrbrbrbjUnIjUjUjUjUjUjUjUjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaanJqoCqCqCqCqCqqozDzDzDzDzDzCzCDBDBzCzCzDzDzDzDzDqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqojUuIqBqCkxjUuKuNrpuOuPkWMXrPkWuQqyuRkWrTMXuSrsvXrsvXuujUknqBqCuTjUrbrbrbrbjUxixjxlxCxCyeoLyzjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqoqoqoqoqoqoqozDzDzDzDzDzCzCDBDBzCzCzDzDzDzDzDqoqoqoqoqoqoqojUjUjUjUjUjUjUjUjUjUjUjUjUjUjUjUjUqojUuUqBqCkxwytvrptvrptvwDMXtUjUjUjUjUjUwKMXwErsrsvXrsrswGuVqBqCuWjUrbrbrbrbjUyRmLnBzxzAnBmLzBjUjUjUjUjUjUjUjUjUjUjUjUjUjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozDzDzDzDzDzDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCjUjUjUjUjUjUjUzDzDzKzKzKzKzKjUzWzYzZAaAbCfAcjUjUjUrNqBqCkxjUuXtvrptvrpkWMXMXAhAiAiAiAjMXMXkWtSvXrsvXtTjUknqBqCsajUjUjUjUjUjUkfmLAdAeAfAgmLAkjUAlAmAnAoApAoAoAoApAqArAsjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozDzDzDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDzDzDAtAtAtAtAtjUqCwaCfCfCfvOqBoNoOoPknqBqCkxjUuYrptvrptvtPMXMXMXMXMXMXMXMXMXkWrsrsvXrsuujUknqBqCkxAOnWACACkZADkfmLnBAEAFnBmLkfAHkfmLnBnBnBnBnBnBnBnBmLkfjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDAtAtAtAtAtAIqCqCkfkfkfqBqBploOplknqBqCkxjUuZtvrptvrptPMXMXMXMXMXMXMXMXMXkWtSvXrsvXtTjUknqBqCkxAOoJnXnXmkADkfmLnBAJAKnBmLkfAHkfmLnBnBnBnBnBnBnBnBmLkfjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCALzCzCzCAtAtAtAtAtjUqCAMANANANAPqBoNoOoPrNqBqCkxjUvavbvcvdvhkWMXMXMXMXMXMXMXMXMXkWtAtBBqtCvojUknqBqCsajUjUjUjUjUjUkfmLAdAQARAgmLkfjUASATAUAoAoApAXAoAoAYAZBbjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzKzKzKzKzKjUBdBjBkANBlBmwajUjUjUknqBqCkxjUjUjUjUjUjUjUjUjUjUvpvqvpjUjUjUjUjUjUjUjUjUjUknqBqCkxjUrbrbrbrbjUkfmLnBBnBpnBmLzBjUjUjUjUjUjUjUjUjUjUjUjUjUjUrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDjUjUjUjUjUjUjUjUjUjUjUjUjUqojUknqBqCkxjUBHBIvzvABrvBvCvqvDvEMXvEvFvqvGvBBrvAvzvyvHjUknqBqCkxjUrbrbrbrbjUBtpBkfkfkfkfpBBujUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBvBwBwBwBwBwBwBwBwBwBwBwBwBwBwBwBwBwBwBwBwBxzCzCzCzCzCzCzDjUqoqoqoqoqoqoqoqoqoqoqoqoqojUrNqBqCkxjUBOkfkfkfkfkfvIvJuAMXvKMXvLvMvNkfkfkfkfkfqCjUknqBqCsajUrbrbrbrbjUjUjUjUjUjUjUjUjUjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBzBABABABABABABABABABABABABABABABABABABBBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaaaarbrbjUknqBvOvPuzqBkfkfkfkfvQvRvSwKBZMXCatUvTvUvQkfkfkfkfqCvVvWwaqCkxjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBzBABABABABABABABABABABABABABABABABBBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaaaarbrbjUoJwewfwguzqBkfkfkfwhwiwjwkuAMXvKMXvLwqwrwiwhkfkfkfqCvVwswfwtmkjUrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaaaarbrbjUjUjUuzjUjUCdwvCfCgwvCfwwvqvDvEMXvEvFvqwxCfwvCfCgwvCfjUjUuzjUjUjUrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaaaarbrbjUwzkfkflAjUjUjUChjUCjCljUwAjUjUwBjUjUwAjUjUjUChjUCjCljUpnkfkfwzjUrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDBEzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaaaarbrbjUjUjUuzjUjUjUjUjUjUjUjUjUjUCnCoCoCosTjUjUjUjUjUjUjUjUjUjUuzjUjUjUrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUiHMXMXoRCrMXsPsOsOsOsPsOCstVtVtVwCsOsPsOsOsOsPMXtUoRMXMXiJjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUjUjUjUjUwKvfvfMXMXfRvfvfvfCtCoCuvfvfvfvgMXvfvfMXtUjUjUjUjUjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUCvCwqHjUCxCyCzCyCyCACyCBCyvZMXCAMXMXMXCCCyCyvXMXtUjUwFCDwHjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUCEwLrqjUCxCyCzCyCFCGCyCyCBCCvKvYMXMXCyvZCHCyvXMXtUjUwRwLCIjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUCJrpCKjUCxCyCzCyCBCGCBCyCBvZMXvYMXCyCyvZMXMXCLCytUjUwTrprOjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUjUwUjUjUCxCyCzCyCBCGCBCyCBvZwZvYMXCyCyCCCyCBCzMXtUjUqxwUqxjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUxarpCcxcwKMXvXMXCyCACyMXCyvZMXvYMXCyMXvZMXMXCzMXtUxcCcrpxdjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUxerpxfjUwKMXCzCyCFCAMXMXCyvZvKvYMXCyCyCCCHMXvXMXtUjUxfrpxgjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDBEzDzDBEzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUxhrpxfjUwKMXCzCyCyvYMXCBCyvZMXvYCyCyCyCCCyMXCzMXtUjUxfrpCMjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDBEzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUCNrpxfjUwKzlzlzlMXxZzlCPCPyBMXxZzlCPCPyBMXzlzlzltUjUxfCRxkjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaaaaaaaarbrbrbrbjUCSrpxfjUwKoSxmxnxoxpMXCyCyxqxsxtMXMXMXxpxAxBxmoStUjUxfCRCUjUrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaarbrbrbrbjUjUjUjUjUjUjUjUjUjUjUjUjUjUCWxDjWjUjUjUjVxDjWjUjUjUjUjUjUjUjUjUjUjUjUjUjUjUrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaarbrbrbrbjUuBuBuBuBuBuBCXuBuBCYuBCZuBuBuBuBuBuBuBuBuBuBDauBuBuBuBuBuBuBDbDcDdDeDeDfDgwSrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDBEzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaarbrbrbrbuBuBuBuBDkDkDkuBuBuBCYuBuBuBuBuBuBDkDkDkDkDkuBuBuBuBDkDkuBuBuBDluBuBDmDeCXDnwSrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaarbrbrbwSDouBDkuBuBuBDkDkCYuBuBuBDkDkDkDkuBDkuBDkuBDkDkDkuBDkuBDkDkuBuBuBDcDfDpDpDqDrrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDBEzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaaaaaarbrbrbwSuBuBuBuBuBuBuBuBuBuBuBDkuBuBDkuBuBuBuBuBuBuBuBuBuBDkuBuBuBDkuBuBuBDnDbDbDcDcwSrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbrcrcrcrYYkrYrYrYDkuBDsxFxQxRDkuBxExSxSxTDkDkuBxUxSxSxVuBDkxWxXxYycuBuBrYrYrYrYrYrYrcrcrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbrcDtrYrYrYrYrYYlDkDkDuyfygyhuBuByiyjylyhuBuBuBymynyoypuBDkyrysytyuuBDkrYrYrYrYYprYrYrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDBEzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbrcrYrYrYrYrYrYrYuBDkDvyvywyxDkuByyDwyAyhuBuBuByiyLyNyhuBDkymyOywyPuBDkrYrYrYrYYkrYYvrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbrbrbrbrbrcrYYwrYrYrYrYrYuBDkDxDyySyTuBuByUyVyWyYuBuBuByQyZzayTuBDkzbzczdzeuBDkrYrYrYrYYxYxYxrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbtctctctctctcrYrYrYYlDzrYuBDkuBuBuBuBDkuBuBuBuBDkDkDkuBuBuBuBuBuBuBDkuBuBDkDkDkrYrYYprYYxYxYxrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDBEzDzDzDzDzDzDBDBDBGzCzCzCzCzCzCzDjUqoqoqorbtcDFDFDGDGtcrYrYrYrYrYrYuBuBDkDkDkDkDkDkDkDkuBDkuBuBuBuBDkDkDkDkDkDkuBuBDkDkDkrYrYrYrYYxYxYxrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbtcDFDFtcDHtcrYrYrYYyrYrYuBuBxExSzfzgDkDkzhDIzizguBDkuBxEzjxSzgDJuBxEzkzmznuBuBrYrYrYrYrYYprYrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDBEzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbtcDFDFtcDKtcrYrYYyrYYprYuBuBzsztzuzvDkDkzwDTzyzzuBuBuBymDUDVDWuBuBymDXDYzEuBDkrYrYYvrYrYrYtcEgtcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDBEzDzDzDzDzDzDzDzDBDBDBGzCzCzCzCzCzCzDjUqoqoqorbtcDFDFtcDKtcrYYyYyrYrYrYuBuByizFyAyhuBuBzGzHzIyhuBDkDkymyfEqyhuBuBzJErywyhuBDkrYrYrYrYrYrYtcrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBDzDzDzDzDzDzDzDzDzDzDzDzDBEzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbtcEsEstcDKtctcrYrYrYrYrYuBuByUzLzMzRuBuByQyZzSyTuBDkuByQyZzTyTuBuByUzLyZzUuBDkrYrYrYrYrYrYtcrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbtcEsEstcDKDKEtrYrYrYrYrYuBuBuBuBuBuBuBuBuBuBuBuBuBDkuBuBuBDkDkDkuBuBuBDkDkDkuBrYrYrYrYrYrYtcEurcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbtctctctctctctctdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtdtctctcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqorbrbrbrbrbtctjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjZNtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBGzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbtktltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltkrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBDBDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDzDBDBDBCzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbtktltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltltkrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBFBDBJBABABABABABABABABABABABABABABABABKBDBCzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbtctjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtjtcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCByBJBABABABABABABABABABABABABABABABABABABKBGzCzCzCzCzCzCzDjUqoqoqoaaaarbrbrbtctctctmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtmtctctcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozCzCzCzCBLBMBMBMBMBMBMBMBMBMBMBMBMBMBMBMBMBMBMBMBMBNzCzCzCzCzCzDzDjUqoqoqoaaaarbrbrbrcrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqozDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDzDjUqoqoqoaaaarbrbrbrcEAEAEBrYrYrYrYYErYrYYwrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYYFrYrYrYrYrYrYrYrYrYrYrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqojUzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDzDjUqoqoqoaaaarbrbrbrcEEEFEEEArYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYrYYyrYrYrYrYrYrYrYrYrcrYrcrcrcrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqojUzDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDzDzDjUqoqoqoaaaarbrbrbrcEEEGEHEArYrYrYrYrYrYrYrYrYrYrYEAEIEIEJrYEIEAEAEAEArYrYrYrYrYYprYrYrYrYrYrYrcrYYFrcrcrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqojUzDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDzDzDjUqoqoqoaaaarbrbrbrcEEEGEEELrYrYrYrYrYrYrYrYrYrYrYEAEMENrYrYrYEOrYrYrYEArYYyrYrYrYrYrYrYrYrYrcrYEPEQEQEPrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqojUzDzDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzDzDzDzDjUqoqoqoaaaarbrbrbrcEREEEGEArYrYrYrYrYrYrYrYYlrYrYEIrYESYyrYrYrYrYrYrYETrYrYrYrYrYrYrcrcrcrcrcrYEUEVEQEPrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqojUzDzDzDzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCzCjUjUjUjUjUjUqoqoqoaaaarbrbrbrcEEEEEEEEEArYrYrYrYrYrYrYrYrYrYEIrYrYrYrYrYYFrYEZEZFdrYrYrYrYrYrYrYrYrYFercFfEPEPEUEPrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoaaaarbrbrbrcFgFkYFFlEArYrYrYrYrYrYrYrYrYrYEAFmFnENFnENEAEAFoFoEArYrYrYrYrYrYrYrcFpFfYwrcEPEPEQFqrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoqoaaaarbrbrbrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcEAEArcrcrcEArcEAEArcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrcrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbrbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHhHhHhHhHhHhHhHhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHhHhHhHhHhHhHhHhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHhHhHhHhHhHhHhHhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHjOjOjOjOjOjOjOjOjOhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHoUjOjOjOjOjOjOjOjOhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHjOjOjOjOjOjOjOjOjOhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHjOjOjOjOjOjOjOhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHjOjOjOjOjOjOjOhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHjOjOjOjOjOjOjOhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-hHhHhHhHhHhHhHhHhHhHhHhHhHaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+"}
+(2,1,1) = {"
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+oU
+jO
+hH
+hH
+hH
+hH
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+hH
+hH
+hH
+hH
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(5,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(7,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(8,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(9,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(10,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+jO
+jO
+jO
+jO
+jO
+jO
+hH
+"}
+(11,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+"}
+(13,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+hH
+"}
+(14,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(15,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(16,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(17,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(18,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(19,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(20,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(21,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+KM
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(22,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(23,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(31,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(32,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(33,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(34,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(35,1,1) = {"
+aa
+aa
+aa
+KH
+KH
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(36,1,1) = {"
+aa
+aa
+aa
+KI
+KN
+KQ
+KQ
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(37,1,1) = {"
+aa
+aa
+aa
+KJ
+KN
+KR
+KQ
+KQ
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+nJ
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(38,1,1) = {"
+aa
+aa
+aa
+KK
+KN
+KS
+KH
+KO
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tc
+tc
+tk
+tc
+tc
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(39,1,1) = {"
+aa
+aa
+aa
+KH
+KH
+KS
+La
+Lb
+Ld
+Lj
+Ln
+Lq
+KH
+Lv
+Lv
+Lx
+Lv
+Lv
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+NR
+tj
+tl
+tj
+NR
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+BP
+BP
+BP
+BP
+BP
+BP
+BP
+BP
+Cq
+qo
+zD
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+jU
+jU
+jU
+jU
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(40,1,1) = {"
+aa
+aa
+aa
+aa
+KH
+KU
+Lb
+KV
+Le
+Lk
+Lo
+Lo
+KH
+KV
+KV
+KV
+KV
+KV
+KH
+KH
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+BP
+BT
+BP
+BT
+BT
+BT
+BT
+BT
+Cq
+qo
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+zD
+zD
+zD
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(41,1,1) = {"
+aa
+aa
+aa
+fx
+KO
+KV
+KV
+KV
+Lf
+Ll
+Lo
+Lo
+KH
+Lv
+Lv
+KV
+Lv
+Lv
+KH
+LE
+LH
+LN
+Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+BP
+BT
+BU
+BT
+BT
+BT
+BT
+BT
+Cq
+qo
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+zD
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(42,1,1) = {"
+aa
+aa
+aa
+aa
+KH
+KW
+Lb
+KV
+Lg
+Lm
+Lg
+Lr
+Lt
+KH
+KH
+Ly
+KH
+KH
+KH
+Li
+Lb
+LO
+Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+BP
+BT
+BP
+BT
+BT
+BT
+BT
+BT
+Cq
+qo
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(43,1,1) = {"
+aa
+aa
+aa
+aa
+KP
+KX
+Lb
+KV
+KV
+KV
+KV
+KV
+Lu
+KV
+KV
+KV
+KV
+KV
+LD
+KV
+LI
+LP
+Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+BP
+BP
+BP
+BP
+BP
+BP
+BP
+BP
+Cq
+qo
+zD
+zC
+zC
+zC
+zC
+zC
+Bv
+By
+By
+By
+By
+By
+BF
+BF
+BF
+BF
+BF
+BF
+BF
+By
+BF
+BF
+BF
+BF
+BF
+BF
+BF
+By
+BF
+By
+By
+By
+By
+BF
+By
+By
+By
+BF
+By
+By
+By
+By
+By
+BF
+By
+BL
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(44,1,1) = {"
+aa
+aa
+aa
+aa
+KH
+KY
+Lb
+KV
+Lh
+Lb
+Li
+Li
+Lb
+Li
+Li
+KV
+Lb
+LA
+KH
+LF
+Lb
+LQ
+Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qo
+qo
+zD
+zC
+zC
+zC
+zC
+zC
+Bw
+Bz
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BJ
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(45,1,1) = {"
+aa
+aa
+aa
+jC
+KO
+KV
+KV
+KV
+Lb
+Lb
+Lp
+Lp
+Lb
+Lp
+Lp
+KV
+Lb
+LB
+KH
+LG
+LJ
+LR
+Lw
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+Bz
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BJ
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(46,1,1) = {"
+aa
+aa
+aa
+aa
+KH
+KU
+Lb
+KV
+KV
+KV
+KV
+KV
+KV
+KV
+KV
+KV
+Lb
+LC
+KH
+KH
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(47,1,1) = {"
+aa
+aa
+aa
+KH
+KH
+KS
+Lc
+Lb
+Li
+Li
+Li
+KV
+Li
+Li
+Li
+KV
+Lb
+KU
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(48,1,1) = {"
+aa
+aa
+aa
+KI
+KN
+KS
+KH
+KO
+KH
+KH
+KH
+KO
+KH
+Lw
+KH
+KO
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(49,1,1) = {"
+aa
+aa
+aa
+KJ
+KN
+KZ
+KQ
+KQ
+KH
+aa
+aa
+ve
+aa
+aa
+aa
+xb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(50,1,1) = {"
+aa
+aa
+aa
+KK
+KN
+KQ
+KQ
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+BT
+BT
+BT
+BT
+BT
+BT
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(51,1,1) = {"
+aa
+aa
+aa
+KH
+KH
+KH
+KH
+KH
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+BT
+BW
+tl
+tl
+Cb
+BT
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(52,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+BT
+tl
+tl
+tl
+tl
+tl
+DB
+DB
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(53,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+BT
+tl
+tl
+tl
+tl
+tl
+DB
+DB
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(54,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+tc
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+BT
+BX
+tl
+tl
+Cm
+BT
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(55,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+tl
+tj
+tl
+km
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+rb
+BT
+BT
+BT
+BT
+BT
+BT
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(56,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tc
+tl
+tj
+QC
+tj
+tl
+km
+jU
+jU
+DA
+pg
+pz
+Dh
+jU
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(57,1,1) = {"
+aa
+ae
+ae
+ae
+lI
+lI
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+km
+km
+kW
+lt
+kW
+km
+km
+qy
+jU
+oD
+ph
+kf
+pP
+jU
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(58,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+lI
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kD
+kW
+lu
+kW
+kW
+kW
+qy
+kW
+oE
+kf
+pA
+pQ
+jU
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BE
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(59,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kE
+kW
+lv
+kW
+kE
+kW
+qy
+kW
+oF
+pi
+kf
+pR
+jU
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(60,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+lI
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kF
+kX
+lw
+kX
+mW
+kW
+qy
+kW
+oG
+kf
+kf
+pT
+jU
+rb
+rb
+rb
+rY
+rY
+rY
+rY
+rY
+rY
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(61,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kf
+kf
+lx
+kf
+mX
+kW
+qy
+kW
+oH
+kf
+kf
+Cc
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qo
+qo
+zC
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BA
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+BA
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(62,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+Ax
+Ax
+Ax
+qE
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kG
+kx
+ly
+kx
+mY
+kW
+qy
+kW
+oI
+pj
+kf
+pU
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qo
+qo
+jU
+zC
+zC
+zC
+zC
+zC
+Bw
+BA
+BB
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BK
+BA
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(63,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+MB
+MB
+MB
+To
+To
+To
+To
+To
+MH
+To
+To
+To
+MB
+To
+To
+To
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+qE
+qE
+yC
+zo
+zN
+zo
+Bf
+qE
+Ax
+Ax
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+jU
+kY
+kW
+kY
+jU
+jU
+jU
+jU
+jU
+jU
+kY
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+qo
+qo
+jU
+zC
+zC
+zC
+zC
+zC
+Bw
+BB
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BK
+BM
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(64,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+MB
+MB
+To
+To
+To
+To
+To
+To
+To
+MB
+MB
+To
+To
+To
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+ME
+vj
+ya
+qZ
+qZ
+qZ
+qZ
+qZ
+BS
+qZ
+qZ
+qE
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+jU
+kZ
+lz
+mk
+kf
+kf
+nW
+kY
+oJ
+kf
+kf
+pB
+jU
+qy
+qz
+qy
+qz
+qy
+qz
+qy
+jU
+rb
+qo
+qo
+jU
+zC
+zC
+zC
+zC
+zC
+Bx
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BG
+BC
+BC
+BG
+BC
+BC
+BC
+BC
+BG
+BC
+BC
+BG
+BN
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(65,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+MB
+MB
+To
+To
+To
+To
+To
+To
+MB
+To
+To
+To
+To
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+uD
+wM
+vj
+qE
+qZ
+qZ
+qZ
+qZ
+qZ
+qE
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+kf
+nX
+jU
+oK
+kf
+kf
+kf
+jU
+qy
+qz
+qy
+qz
+qy
+qz
+qy
+jU
+rb
+qo
+qo
+jU
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(66,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+To
+MB
+MB
+To
+To
+To
+To
+To
+MB
+To
+To
+To
+MB
+MB
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+vj
+vj
+vj
+vj
+qE
+yC
+zo
+qZ
+zo
+Bf
+qE
+qZ
+qZ
+qZ
+qE
+DL
+DZ
+Eh
+qE
+qE
+Ax
+qE
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+jU
+kf
+lA
+kf
+kf
+kf
+kZ
+kY
+mk
+kf
+kf
+kf
+jU
+jU
+qV
+qV
+ls
+qV
+qV
+jU
+jU
+rb
+qo
+qo
+jU
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(67,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+To
+To
+MB
+MB
+To
+To
+MB
+MB
+MB
+To
+To
+MB
+MB
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+uC
+vk
+vj
+vj
+xu
+qE
+qE
+Ax
+Ax
+Ax
+qE
+qE
+Ci
+uE
+qZ
+DC
+DM
+DM
+Ei
+EC
+qZ
+qZ
+qE
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+kf
+kf
+kf
+kf
+jU
+ql
+rk
+mK
+qp
+sV
+tL
+tY
+jU
+rb
+qo
+qo
+jU
+zC
+zC
+AL
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(68,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+To
+To
+To
+MB
+MB
+To
+MB
+MB
+MB
+MB
+MB
+MB
+To
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+qE
+qE
+uD
+vj
+vj
+vj
+xv
+qE
+yD
+qZ
+qZ
+qZ
+Bg
+qE
+qZ
+qZ
+qZ
+qE
+DN
+Ea
+Ej
+qE
+qE
+EC
+qE
+qE
+qE
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+oL
+kf
+kf
+pB
+jU
+qm
+nB
+nB
+nB
+nB
+nB
+tZ
+jU
+rb
+qo
+jU
+jU
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(69,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+MB
+MB
+To
+To
+To
+To
+To
+MB
+To
+To
+MB
+To
+To
+To
+To
+To
+To
+ae
+ae
+ae
+lI
+lI
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+rW
+sW
+qE
+qE
+qE
+wb
+qE
+qE
+qE
+yE
+qZ
+qZ
+qZ
+Bh
+qE
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+qZ
+qZ
+FT
+Gr
+qE
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+oC
+uG
+nB
+rz
+su
+sY
+nB
+ua
+oC
+rb
+qo
+jU
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+zD
+zD
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(70,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+FU
+To
+MB
+To
+To
+To
+To
+To
+MB
+MB
+MB
+To
+To
+To
+To
+To
+To
+To
+ae
+ae
+lI
+lI
+lI
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+Ax
+qZ
+qZ
+qZ
+Ax
+qZ
+qZ
+qZ
+wN
+xw
+qE
+qZ
+qZ
+qZ
+qZ
+qZ
+Ax
+qZ
+qZ
+qZ
+qE
+DO
+Eb
+Ek
+qE
+EW
+qZ
+qZ
+Gr
+Gz
+GX
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kc
+kn
+kH
+la
+kn
+ml
+jU
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+ls
+uH
+nB
+rA
+sv
+sZ
+nB
+ub
+lr
+rb
+qo
+jU
+zD
+zD
+zD
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zC
+zD
+zD
+zD
+zD
+zD
+zD
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(71,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+NF
+To
+To
+To
+To
+To
+To
+MB
+Qm
+MB
+To
+To
+To
+To
+To
+To
+AG
+ae
+ae
+ae
+lI
+lI
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+Ax
+ra
+qZ
+qZ
+tX
+qZ
+qZ
+qZ
+qZ
+qZ
+yb
+qZ
+qZ
+zO
+Ay
+qZ
+BS
+qZ
+uE
+qZ
+DD
+uE
+Ec
+uE
+Ax
+EX
+qZ
+qZ
+Gr
+Gz
+GX
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kd
+kf
+kI
+lb
+kf
+mm
+jU
+jU
+jU
+jU
+oL
+kf
+kf
+pB
+qd
+qp
+kf
+CQ
+kf
+CQ
+kf
+uc
+ls
+rb
+qo
+jU
+zK
+At
+At
+At
+zK
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+zD
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(72,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+To
+MB
+MB
+MB
+MB
+To
+MB
+MB
+To
+To
+To
+To
+To
+To
+ae
+ae
+ae
+lI
+lI
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+Ax
+qZ
+qZ
+qZ
+Ax
+qZ
+qZ
+qZ
+wO
+xx
+qE
+qZ
+qZ
+qZ
+qZ
+qZ
+Ax
+qZ
+qZ
+qZ
+qE
+DP
+Ed
+El
+qE
+EW
+qZ
+qZ
+Gr
+Gz
+GX
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+ke
+kf
+kJ
+lc
+kf
+ke
+jU
+nK
+nY
+jU
+oJ
+kf
+kf
+nW
+qe
+Cc
+CQ
+rB
+sw
+ta
+CQ
+uf
+jU
+rb
+qo
+jU
+zK
+At
+At
+At
+zK
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(73,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+MB
+MB
+MB
+MB
+To
+To
+To
+MB
+To
+To
+To
+To
+To
+To
+ae
+ae
+ae
+ae
+lI
+lI
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+rX
+sX
+qE
+qE
+qE
+wc
+qE
+qE
+qE
+yF
+qZ
+qZ
+qZ
+Bh
+qE
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+EY
+qZ
+FT
+Gr
+qE
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+kf
+kf
+mZ
+nL
+nZ
+oy
+oM
+pk
+pk
+oM
+qf
+qq
+rl
+rC
+sx
+tb
+tM
+ug
+jU
+rb
+qo
+jU
+zK
+At
+At
+At
+zK
+jU
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(74,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+MB
+MB
+MB
+To
+To
+To
+To
+To
+MB
+MB
+To
+To
+To
+To
+To
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+qE
+qE
+uE
+vl
+uE
+wP
+xy
+qE
+yG
+zp
+zP
+qZ
+qZ
+qE
+qZ
+qZ
+qZ
+qE
+DQ
+Ee
+Em
+qE
+qE
+Ax
+qE
+qE
+qE
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kg
+kf
+kR
+Ex
+kf
+kg
+jU
+nM
+oa
+jU
+mk
+kf
+kf
+kZ
+qe
+Cc
+rm
+rD
+sy
+to
+tN
+uh
+jU
+rb
+qo
+jU
+zK
+At
+At
+At
+zK
+jU
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(75,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+MB
+MB
+To
+MB
+To
+To
+To
+To
+To
+To
+MB
+MB
+MB
+To
+To
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+uF
+vm
+wd
+uE
+xz
+qE
+qE
+Ax
+Ax
+Ax
+qE
+qE
+Ci
+uE
+qZ
+DE
+DR
+DR
+En
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kd
+kf
+kI
+lb
+kf
+mm
+jU
+jU
+jU
+jU
+oL
+kf
+kf
+pB
+qd
+qr
+rn
+rE
+sz
+Ce
+tM
+uj
+jU
+rb
+qo
+jU
+zK
+At
+At
+At
+zK
+jU
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(76,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+MB
+MB
+To
+To
+MB
+MB
+To
+To
+To
+To
+To
+To
+To
+MB
+MB
+To
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+vn
+uE
+vl
+uE
+Ax
+yH
+yK
+zQ
+Az
+yK
+Ax
+qZ
+qZ
+qZ
+qE
+DS
+Ef
+Eo
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+ke
+kx
+kS
+le
+kx
+mn
+jU
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+jU
+qp
+CQ
+rF
+sA
+tp
+CQ
+uk
+jU
+rb
+qo
+jU
+jU
+jU
+AI
+jU
+jU
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(77,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+MB
+MB
+MB
+To
+To
+To
+To
+To
+To
+To
+To
+MB
+MB
+To
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+uF
+wQ
+wd
+Ax
+yI
+zq
+yI
+AA
+yI
+Ax
+qZ
+uE
+qZ
+qE
+qE
+qE
+qE
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+jU
+kf
+kf
+kf
+jU
+oC
+nO
+kf
+rG
+kf
+CQ
+kf
+ul
+jU
+jU
+qo
+jU
+zW
+qC
+qC
+qC
+Bd
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+tc
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(78,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+MB
+To
+To
+To
+To
+To
+To
+To
+To
+To
+To
+To
+MB
+MB
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+vn
+uE
+Ax
+yJ
+zr
+yK
+zq
+yK
+Ax
+qZ
+qZ
+qE
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+kf
+kf
+kf
+jU
+qx
+tR
+hY
+rH
+sB
+sB
+hY
+rS
+qx
+jU
+qo
+jU
+zY
+wa
+qC
+AM
+Bj
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+tc
+DF
+DF
+DF
+DF
+Es
+Es
+tc
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(79,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+To
+To
+To
+MB
+To
+To
+To
+To
+To
+MB
+To
+To
+To
+To
+To
+To
+MB
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+qE
+qE
+yK
+zq
+yI
+AB
+Bi
+qE
+Ax
+Ax
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+oL
+kf
+pB
+jU
+qx
+qs
+pn
+rI
+kf
+kf
+pn
+um
+qx
+jU
+qo
+jU
+zZ
+Cf
+kf
+AN
+Bk
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+tc
+DF
+DF
+DF
+DF
+Es
+Es
+tc
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(80,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+qE
+qE
+qE
+qE
+qE
+qE
+qE
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+ix
+ix
+ix
+ix
+ix
+ix
+ix
+jU
+jU
+jZ
+jZ
+kh
+ky
+jZ
+jZ
+ky
+jZ
+kh
+ky
+jZ
+jU
+kf
+kf
+kf
+jU
+qx
+qt
+kf
+rI
+kf
+kf
+kf
+un
+qx
+jU
+qo
+jU
+Aa
+Cf
+kf
+AN
+AN
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+tc
+DG
+tc
+tc
+tc
+tc
+tc
+tc
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(81,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+iK
+iE
+iE
+iK
+MX
+jV
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+jV
+kf
+kf
+kf
+jU
+qx
+qu
+kf
+rJ
+sC
+tq
+kf
+uo
+qx
+jU
+qo
+jU
+Ab
+Cf
+kf
+AN
+Bl
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rc
+rc
+rc
+rc
+tc
+DG
+DH
+DK
+DK
+DK
+DK
+tc
+tc
+tk
+tk
+tc
+tc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(82,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+iL
+iE
+iE
+iL
+MX
+jW
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+jW
+kf
+kf
+kf
+jU
+qx
+qv
+kf
+rK
+sD
+tr
+kf
+up
+qx
+jU
+qo
+jU
+Cf
+vO
+qB
+AP
+Bm
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rc
+Dt
+rY
+rY
+tc
+tc
+tc
+tc
+tc
+tc
+DK
+tc
+tj
+tl
+tl
+tj
+tc
+rY
+EA
+EE
+EE
+EE
+ER
+EE
+Fg
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(83,1,1) = {"
+aa
+ae
+ae
+ae
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+lI
+lI
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ix
+ix
+ix
+ix
+jU
+jU
+ka
+ka
+kk
+kz
+ka
+ka
+kz
+ka
+kk
+kz
+ka
+jU
+oN
+pl
+oN
+jU
+qx
+qw
+kf
+rL
+sF
+kf
+kf
+uq
+tR
+jU
+qo
+jU
+Ac
+qB
+qB
+qB
+wa
+jU
+qo
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+wS
+wS
+rc
+rY
+rY
+Yw
+rY
+rY
+rY
+rY
+rY
+tc
+Et
+tc
+tj
+tl
+tl
+tj
+tc
+rY
+EA
+EF
+EG
+EG
+EE
+EE
+Fk
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(84,1,1) = {"
+aa
+ae
+ae
+ae
+lI
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jw
+GP
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+oO
+oO
+oO
+jU
+qx
+qA
+lA
+rM
+sH
+ts
+lA
+ur
+qx
+jU
+qo
+jU
+jU
+oN
+pl
+oN
+jU
+jU
+qo
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+uB
+Do
+uB
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+Yy
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+EB
+EE
+EH
+EE
+EG
+EE
+YF
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(85,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+lI
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jz
+GP
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+oP
+pl
+oP
+jU
+qx
+tR
+hY
+qx
+qx
+qx
+hY
+rS
+qx
+jU
+qo
+qo
+jU
+oO
+oO
+oO
+jU
+qo
+qo
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+uB
+uB
+uB
+uB
+Yk
+rY
+rY
+rY
+rY
+rY
+rY
+Yy
+Yy
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+EA
+EA
+EL
+EA
+EE
+Fl
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(86,1,1) = {"
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+ae
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iM
+iE
+iE
+ji
+jw
+jw
+jR
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+rb
+rb
+rb
+rb
+rb
+jU
+oQ
+lz
+mk
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+oP
+pl
+oP
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+uB
+uB
+Dk
+uB
+rY
+rY
+rY
+rY
+Yl
+rY
+Yy
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+EA
+EA
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(87,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jx
+jw
+GP
+Ep
+Iy
+Iy
+Iy
+Iy
+Iy
+Iy
+Ep
+rb
+rb
+rb
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+jU
+nW
+kn
+rN
+kn
+kn
+rN
+kn
+kn
+wu
+uI
+uU
+rN
+kn
+kn
+rN
+kn
+kn
+rN
+kn
+oJ
+jU
+wz
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+uB
+uB
+uB
+uB
+rY
+rY
+rY
+rY
+Dz
+rY
+rY
+Yp
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(88,1,1) = {"
+mB
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jw
+GP
+Ep
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
+Ep
+Ep
+Ep
+rb
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+qg
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+we
+jU
+kf
+jU
+iH
+jU
+Cv
+CE
+CJ
+jU
+xa
+xe
+xh
+CN
+CS
+jU
+uB
+Dk
+uB
+uB
+rY
+Yl
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(89,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jx
+GP
+Ep
+IA
+IT
+IT
+IT
+IT
+Ju
+JD
+Wx
+Ep
+rb
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+qh
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+vO
+wf
+uz
+kf
+uz
+MX
+jU
+Cw
+wL
+rp
+wU
+rp
+rp
+rp
+rp
+rp
+jU
+uB
+Dk
+uB
+uB
+Dk
+Dk
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+YE
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(90,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jw
+GP
+Ep
+VD
+IU
+IV
+IV
+IU
+Jv
+JD
+Wx
+Ep
+rb
+rb
+rb
+jU
+kf
+lA
+kf
+kf
+jU
+kZ
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+kx
+vP
+wg
+jU
+lA
+jU
+MX
+jU
+qH
+rq
+CK
+jU
+Cc
+xf
+xf
+xf
+xf
+jU
+uB
+Dk
+Dk
+uB
+uB
+Dk
+Dk
+Dk
+Dk
+uB
+uB
+uB
+uB
+uB
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(91,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+nx
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iM
+iE
+iE
+ji
+jz
+jw
+jR
+Ep
+jX
+IV
+Jg
+IV
+IV
+Jv
+JD
+Wx
+Ep
+jU
+jU
+jU
+jU
+oR
+jU
+oR
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+wy
+jU
+wy
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+uz
+uz
+jU
+jU
+jU
+oR
+jU
+jU
+jU
+jU
+jU
+xc
+jU
+jU
+jU
+jU
+jU
+CX
+uB
+Dk
+uB
+Ds
+Du
+Dv
+Dx
+uB
+Dk
+xE
+zs
+yi
+yU
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(92,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jF
+GP
+Ep
+VD
+IU
+IV
+IV
+IU
+Jv
+JD
+Wx
+Ep
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+jU
+qD
+ro
+ro
+sI
+tt
+tO
+us
+uv
+tv
+uK
+tv
+uX
+uY
+uZ
+va
+jU
+BH
+BO
+qB
+qB
+Cd
+jU
+jU
+Cr
+wK
+Cx
+Cx
+Cx
+Cx
+wK
+wK
+wK
+wK
+wK
+jU
+uB
+uB
+CY
+uB
+xF
+yf
+yv
+Dy
+uB
+Dk
+xS
+zt
+zF
+zL
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+Yw
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(93,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+ix
+iE
+iE
+iE
+ji
+jw
+jw
+GP
+Ep
+IC
+IW
+IW
+IW
+IW
+Jw
+JD
+Wx
+Ep
+MX
+MX
+MX
+iJ
+MX
+MX
+MX
+MX
+jU
+qF
+rp
+rp
+jU
+tu
+tv
+rp
+tv
+rp
+uN
+rp
+tv
+rp
+tv
+vb
+jU
+BI
+kf
+kf
+kf
+wv
+jU
+jU
+MX
+vf
+Cy
+Cy
+Cy
+Cy
+MX
+MX
+MX
+zl
+oS
+jU
+uB
+uB
+uB
+uB
+xQ
+yg
+yw
+yS
+uB
+Dk
+zf
+zu
+yA
+zM
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(94,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qx
+ix
+ix
+ix
+iE
+iE
+iE
+ix
+ix
+ix
+Ep
+Ep
+ID
+ID
+ID
+ID
+ID
+ID
+Ep
+Ep
+Ep
+Ep
+nN
+Ep
+Ep
+MX
+MX
+MX
+MX
+jU
+qG
+rp
+rp
+sJ
+tv
+rp
+tv
+rp
+tv
+rp
+tv
+rp
+tv
+rp
+vc
+jU
+vz
+kf
+kf
+kf
+Cf
+Ch
+jU
+sP
+vf
+Cz
+Cz
+Cz
+Cz
+vX
+Cz
+Cz
+zl
+xm
+jU
+CY
+CY
+uB
+uB
+xR
+yh
+yx
+yT
+uB
+Dk
+zg
+zv
+yh
+zR
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+Yl
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(95,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qx
+GM
+iE
+iK
+iE
+iE
+iE
+iK
+iE
+iE
+Il
+Is
+IE
+IX
+Jh
+Jh
+Js
+IE
+Is
+Il
+mo
+na
+GM
+ob
+Ep
+oS
+MX
+MX
+MX
+jU
+qF
+rp
+rp
+sI
+tu
+tv
+rp
+tv
+rp
+uO
+rp
+tv
+rp
+tv
+vd
+jU
+vA
+kf
+kf
+kf
+Cg
+jU
+jU
+sO
+MX
+Cy
+Cy
+Cy
+Cy
+MX
+Cy
+Cy
+zl
+xn
+jU
+uB
+uB
+uB
+Dk
+Dk
+uB
+Dk
+uB
+Dk
+Dk
+Dk
+Dk
+uB
+uB
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(96,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+iy
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+It
+It
+It
+It
+It
+It
+It
+Il
+mp
+ni
+HL
+oc
+EK
+oT
+MX
+MX
+MX
+jU
+qH
+rq
+rO
+jU
+tv
+rp
+tv
+rp
+tv
+uP
+tv
+rp
+tv
+rp
+vh
+jU
+Br
+kf
+kf
+wh
+wv
+Cj
+jU
+sO
+MX
+Cy
+CF
+CB
+CB
+Cy
+CF
+Cy
+MX
+xo
+jU
+CZ
+uB
+Dk
+uB
+uB
+uB
+uB
+uB
+uB
+Dk
+Dk
+Dk
+uB
+uB
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(97,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+iz
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+Iu
+IF
+IF
+IF
+IF
+IF
+IF
+Iu
+Il
+mp
+ni
+HL
+od
+Ev
+MX
+MX
+MX
+MX
+jU
+jU
+jU
+jU
+jU
+kW
+vr
+tP
+kW
+wD
+kW
+wD
+kW
+tP
+tP
+kW
+jU
+vB
+kf
+vQ
+wi
+Cf
+Cl
+jU
+sO
+fR
+CA
+CG
+CG
+CG
+CA
+CA
+vY
+xZ
+xp
+jU
+uB
+uB
+Dk
+uB
+xE
+yi
+yy
+yU
+uB
+Dk
+zh
+zw
+zG
+yQ
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EA
+EA
+EI
+EI
+EA
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(98,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+qx
+iA
+iE
+iE
+iE
+iE
+iE
+Id
+iE
+Id
+Il
+It
+IG
+IG
+IG
+IG
+IG
+IG
+It
+Il
+Id
+GM
+HL
+oe
+Ev
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+iH
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+jU
+vC
+vI
+vR
+wj
+ww
+jU
+jU
+sP
+vf
+Cy
+Cy
+CB
+CB
+Cy
+MX
+MX
+zl
+MX
+CW
+uB
+uB
+Dk
+Dk
+xS
+yj
+Dw
+yV
+uB
+Dk
+DI
+DT
+zH
+yZ
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EI
+EM
+rY
+rY
+Fm
+EA
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(99,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+ht
+hX
+hY
+ht
+hX
+qx
+ht
+hX
+qx
+ht
+hX
+qx
+ht
+hX
+hY
+ht
+hX
+qx
+iB
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+Il
+mp
+ni
+HL
+of
+Ep
+oX
+pm
+pm
+pm
+MX
+MX
+tU
+rP
+tU
+tw
+tU
+tU
+tw
+tU
+rP
+tU
+MX
+MX
+MX
+MX
+jU
+vq
+vJ
+vS
+wk
+vq
+wA
+jU
+sO
+vf
+CB
+Cy
+Cy
+Cy
+MX
+MX
+CB
+CP
+Cy
+xD
+uB
+uB
+Dk
+uB
+xS
+yl
+yA
+yW
+uB
+uB
+zi
+zy
+zI
+zS
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EI
+EN
+ES
+rY
+Fn
+EA
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(100,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rS
+hu
+Cc
+hZ
+wK
+wK
+im
+wK
+wK
+io
+wK
+wK
+ir
+wK
+wK
+iv
+AV
+Cc
+qx
+iC
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+Il
+mp
+ni
+HL
+nk
+Ev
+MX
+pm
+pC
+pm
+MX
+qI
+jU
+kW
+kW
+kW
+kW
+kW
+kW
+kW
+kW
+jU
+Ah
+MX
+MX
+MX
+jU
+vD
+uA
+wK
+uA
+vD
+jU
+Cn
+Cs
+vf
+Cy
+CB
+CB
+CB
+Cy
+Cy
+Cy
+CP
+Cy
+jW
+uB
+uB
+uB
+uB
+xT
+yh
+yh
+yY
+Dk
+Dk
+zg
+zz
+yh
+yT
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EJ
+rY
+Yy
+rY
+EN
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(101,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+hd
+hv
+Cc
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+AW
+Cc
+Cc
+GM
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+IH
+IH
+Ji
+Ji
+IH
+IH
+It
+Il
+Id
+GM
+HL
+og
+Ev
+MX
+pm
+pD
+pm
+MX
+AW
+jU
+rQ
+sK
+tx
+tQ
+ut
+uw
+sK
+uQ
+jU
+Ai
+MX
+MX
+MX
+vp
+vE
+MX
+BZ
+MX
+vE
+jU
+Co
+tV
+Ct
+vZ
+CC
+vZ
+vZ
+vZ
+vZ
+vZ
+yB
+xq
+jU
+uB
+Dk
+Dk
+uB
+Dk
+uB
+uB
+uB
+Dk
+uB
+uB
+uB
+uB
+uB
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+Fn
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(102,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+tR
+Cc
+Cc
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+AW
+Cc
+qx
+GM
+iE
+iE
+iE
+iE
+iE
+HL
+iE
+HN
+Il
+It
+IH
+IH
+kb
+Jq
+IH
+IH
+It
+Il
+mq
+nj
+HL
+oh
+oz
+oY
+pm
+pH
+pm
+MX
+Ba
+jU
+qy
+qy
+qy
+qz
+qy
+qy
+qz
+qy
+jU
+Ai
+MX
+MX
+MX
+vq
+MX
+vK
+MX
+vK
+MX
+wB
+Co
+tV
+Co
+MX
+vK
+MX
+wZ
+MX
+vK
+MX
+MX
+xs
+jU
+uB
+Dk
+uB
+uB
+Dk
+uB
+uB
+uB
+Dk
+uB
+Dk
+uB
+Dk
+Dk
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EI
+rY
+rY
+rY
+EN
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(103,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+hd
+hw
+Cc
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+AW
+Cc
+Cc
+GM
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+IH
+IH
+Ji
+Ji
+IH
+IH
+It
+Il
+mE
+GM
+HL
+oi
+Ev
+MX
+pm
+pI
+pm
+MX
+AW
+jU
+rR
+sL
+ty
+tQ
+ut
+ux
+sL
+uR
+jU
+Ai
+MX
+MX
+MX
+vp
+vE
+MX
+Ca
+MX
+vE
+jU
+Co
+tV
+Cu
+CA
+vY
+vY
+vY
+vY
+vY
+vY
+xZ
+xt
+jU
+uB
+Dk
+Dk
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+Dk
+uB
+uB
+td
+ZN
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EA
+EO
+rY
+YF
+EA
+EA
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(104,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rS
+hQ
+Cc
+il
+tU
+tU
+in
+tU
+tU
+ip
+tU
+tU
+is
+tU
+tU
+iw
+Bc
+Cc
+qx
+iC
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+Il
+mp
+ni
+HL
+nk
+Ev
+MX
+pm
+pJ
+pm
+MX
+qI
+jU
+kW
+kW
+kW
+kW
+kW
+kW
+kW
+kW
+jU
+Aj
+MX
+MX
+MX
+jU
+vF
+vL
+tU
+vL
+vF
+jU
+sT
+wC
+vf
+MX
+MX
+MX
+MX
+MX
+MX
+Cy
+zl
+MX
+jV
+uB
+Dk
+uB
+uB
+xU
+ym
+yi
+yQ
+uB
+uB
+xE
+ym
+ym
+yQ
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EA
+rY
+rY
+rY
+EA
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(105,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+ht
+hX
+hY
+ht
+hX
+qx
+ht
+hX
+qx
+ht
+hX
+qx
+ht
+hX
+hY
+ht
+hX
+qx
+iB
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+IH
+IH
+IH
+IH
+IH
+IH
+It
+Il
+mp
+ni
+HL
+oj
+Ep
+oX
+pm
+pm
+pm
+MX
+MX
+wK
+rT
+wK
+tz
+wK
+wK
+tz
+wK
+rT
+wK
+MX
+MX
+MX
+MX
+jU
+vq
+vM
+vT
+wq
+vq
+wA
+jU
+sO
+vf
+MX
+MX
+Cy
+Cy
+Cy
+Cy
+Cy
+CP
+MX
+xD
+uB
+Dk
+Dk
+uB
+xS
+yn
+yL
+yZ
+uB
+Dk
+zj
+DU
+yf
+yZ
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EA
+rY
+rY
+EZ
+Fo
+EA
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(106,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+hd
+hs
+CQ
+qx
+iA
+iE
+iE
+iE
+iE
+iE
+Id
+iE
+Id
+Il
+It
+II
+II
+II
+II
+II
+II
+It
+Il
+Id
+GM
+HL
+ok
+Ev
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+iJ
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+jU
+vG
+vN
+vU
+wr
+wx
+jU
+jU
+sP
+vf
+MX
+Cy
+Cy
+Cy
+MX
+Cy
+Cy
+CP
+MX
+jW
+uB
+uB
+Dk
+uB
+xS
+yo
+yN
+za
+uB
+Dk
+xS
+DV
+Eq
+zT
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+EA
+rY
+rY
+EZ
+Fo
+EA
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(107,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+CQ
+CQ
+qx
+iz
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+Iu
+IF
+IF
+IF
+IF
+IF
+IF
+Iu
+Il
+mp
+ni
+HL
+ol
+Ev
+MX
+MX
+MX
+MX
+jU
+jU
+jU
+jU
+jU
+kW
+kW
+kW
+kW
+wE
+uS
+wE
+kW
+kW
+kW
+kW
+jU
+vB
+kf
+vQ
+wi
+Cf
+jU
+jU
+sO
+vg
+CC
+vZ
+vZ
+CC
+vZ
+CC
+CC
+yB
+xp
+jU
+Da
+uB
+Dk
+uB
+xV
+yp
+yh
+yT
+uB
+Dk
+zg
+DW
+yh
+yT
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+EA
+ET
+Fd
+EA
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(108,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+iy
+iE
+iE
+iE
+iE
+iE
+HN
+iE
+HN
+Il
+It
+It
+It
+It
+It
+It
+It
+It
+Il
+mp
+ni
+HL
+om
+EK
+oT
+MX
+MX
+MX
+jU
+qQ
+rr
+rU
+jU
+tA
+tS
+rs
+tS
+rs
+rs
+rs
+tS
+rs
+tS
+tA
+jU
+Br
+kf
+kf
+wh
+wv
+jU
+jU
+sO
+MX
+Cy
+CH
+MX
+Cy
+MX
+CH
+Cy
+MX
+xA
+jU
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+Dk
+DJ
+uB
+uB
+uB
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(109,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qx
+GM
+iE
+iL
+iE
+iE
+iE
+iL
+iE
+iE
+Il
+Is
+IJ
+IY
+Jk
+Jk
+Jt
+IJ
+Is
+Il
+mo
+nk
+GM
+ob
+Ep
+oS
+MX
+MX
+MX
+jU
+qR
+vX
+rV
+jU
+tB
+vX
+rs
+vX
+rs
+vX
+rs
+vX
+rs
+vX
+tB
+jU
+vA
+kf
+kf
+kf
+Cf
+Ch
+jU
+sO
+vf
+Cy
+Cy
+MX
+CB
+MX
+MX
+MX
+zl
+xB
+jU
+uB
+uB
+Dk
+Dk
+Dk
+Dk
+Dk
+Dk
+uB
+Dk
+uB
+uB
+uB
+uB
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+Yy
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(110,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+my
+aw
+ma
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+iT
+qx
+iT
+qx
+qx
+qx
+Ep
+Ep
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+Ep
+Ep
+Ep
+Ep
+nN
+Ep
+Ep
+MX
+MX
+MX
+MX
+jU
+qS
+rs
+vX
+sM
+vX
+rs
+vX
+rs
+vX
+rs
+vX
+rs
+vX
+rs
+Bq
+jU
+vz
+kf
+kf
+kf
+Cg
+jU
+jU
+sP
+vf
+vX
+vX
+CL
+Cz
+Cz
+vX
+Cz
+zl
+xm
+jU
+uB
+Dk
+uB
+uB
+xW
+yr
+ym
+zb
+Dk
+Dk
+xE
+ym
+zJ
+yU
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+Yy
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(111,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+aw
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+CQ
+iq
+CQ
+CQ
+iq
+CQ
+CQ
+CQ
+CQ
+nH
+qW
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+Ep
+IL
+IZ
+IZ
+IZ
+IZ
+Jx
+JD
+Wy
+Ep
+MX
+MX
+MX
+iH
+MX
+MX
+MX
+MX
+jU
+qR
+vX
+rV
+jU
+tC
+vX
+rs
+vX
+rs
+vX
+rs
+vX
+rs
+vX
+tC
+jU
+vy
+kf
+kf
+kf
+wv
+Cj
+jU
+MX
+MX
+MX
+MX
+Cy
+MX
+MX
+MX
+MX
+zl
+oS
+jU
+uB
+Dk
+Dk
+uB
+xX
+ys
+yO
+zc
+uB
+uB
+zk
+DX
+Er
+zL
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(112,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+aw
+aw
+nh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+qn
+CQ
+it
+CQ
+iu
+CQ
+CQ
+CQ
+CQ
+iD
+MX
+MX
+qV
+qV
+jh
+qV
+rS
+qV
+qV
+Ep
+VE
+Ja
+Jb
+Jb
+Ja
+Jy
+JD
+Wy
+Ep
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+jU
+qQ
+rr
+rZ
+jU
+tD
+tT
+uu
+tT
+rs
+uu
+rs
+tT
+uu
+tT
+vo
+jU
+vH
+qC
+qC
+qC
+Cf
+Cl
+jU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+tU
+jU
+uB
+uB
+Dk
+uB
+xY
+yt
+yw
+zd
+uB
+uB
+zm
+DY
+yw
+yZ
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+Yp
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(113,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+ki
+ki
+ki
+aw
+my
+ma
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+ki
+nz
+uJ
+nz
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+CQ
+qn
+it
+CQ
+iu
+CQ
+CQ
+CQ
+CQ
+iD
+iI
+MX
+qV
+iV
+Cc
+jj
+jA
+jG
+jS
+Ep
+jY
+Jb
+Jl
+Jb
+Jb
+Jy
+JD
+Wy
+Ep
+jU
+jU
+jU
+jU
+oR
+jU
+oR
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+wG
+jU
+wG
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+vV
+vV
+jU
+jU
+jU
+oR
+jU
+jU
+jU
+jU
+jU
+xc
+jU
+jU
+jU
+jU
+jU
+uB
+uB
+uB
+Dk
+yc
+yu
+yP
+ze
+Dk
+Dk
+zn
+zE
+yh
+zU
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+YF
+rY
+rY
+rY
+rY
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(114,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ku
+ku
+ku
+ku
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+nz
+ll
+nz
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+qn
+CQ
+it
+CQ
+iu
+CQ
+CQ
+CQ
+CQ
+iD
+MX
+MX
+iU
+iW
+Cc
+Cc
+Cc
+Cc
+Cc
+Ep
+VE
+Ja
+Jb
+Jb
+Ja
+Jy
+JD
+Wy
+Ep
+jU
+rb
+rb
+jU
+kf
+pn
+kf
+kf
+jU
+nW
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+uV
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+vW
+ws
+jU
+pn
+jU
+MX
+jU
+wF
+wR
+wT
+qx
+Cc
+xf
+xf
+xf
+xf
+jU
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+uB
+Dk
+Dk
+uB
+uB
+uB
+uB
+Dk
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rc
+rY
+rY
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(115,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+ki
+ki
+ki
+ki
+ki
+nz
+uJ
+nz
+ki
+kt
+ki
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+CQ
+qn
+it
+CQ
+iu
+CQ
+CQ
+CQ
+CQ
+iD
+MX
+MX
+qV
+ja
+Cc
+Cc
+Cc
+Cc
+Cc
+Ep
+IN
+Jc
+Jc
+Jc
+Jc
+Jz
+JD
+Wy
+Ep
+jU
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+qg
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+qB
+wa
+wf
+uz
+kf
+uz
+MX
+jU
+CD
+wL
+rp
+wU
+rp
+rp
+rp
+CR
+CR
+jU
+Db
+Dl
+uB
+uB
+uB
+Dk
+Dk
+Dk
+Dk
+Dk
+uB
+Dk
+Dk
+Dk
+uB
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rc
+rY
+rc
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(116,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+aw
+aw
+my
+aw
+aw
+aw
+ki
+ki
+ku
+ku
+ku
+ku
+ku
+ud
+ku
+ku
+ku
+ku
+ki
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+qn
+CQ
+it
+CQ
+iu
+CQ
+CQ
+CQ
+CQ
+iD
+iI
+MX
+qV
+jg
+Cc
+jv
+jB
+jH
+jT
+Ep
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
+Ep
+Ep
+Ep
+jU
+rb
+rb
+jU
+kf
+kf
+kf
+kf
+qh
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+wt
+jU
+kf
+jU
+iJ
+jU
+wH
+CI
+rO
+qx
+xd
+xg
+CM
+xk
+CU
+jU
+Dc
+uB
+Dc
+uB
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rc
+rY
+Fp
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(117,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+my
+aw
+aw
+ma
+aw
+aw
+kt
+ku
+ng
+qJ
+re
+se
+pZ
+pZ
+uL
+vu
+wl
+ku
+ku
+ki
+aw
+aw
+aw
+my
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+CQ
+qn
+it
+CQ
+iu
+CQ
+CQ
+CQ
+CQ
+iD
+MX
+MX
+qV
+qV
+jh
+qV
+rS
+qV
+qV
+Ep
+IP
+IP
+IP
+IP
+IP
+IP
+Ep
+jU
+jU
+jU
+rb
+rb
+jU
+nW
+lz
+pK
+jU
+jU
+kZ
+kx
+sa
+kx
+kx
+sa
+kx
+kx
+wI
+uT
+uW
+sa
+kx
+kx
+sa
+kx
+kx
+sa
+kx
+mk
+jU
+wz
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+Dd
+uB
+Df
+Dn
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rY
+rc
+Fe
+Ff
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(118,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hl
+kv
+ll
+lm
+ku
+ki
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ku
+pX
+pZ
+pZ
+rf
+rf
+pZ
+rf
+vv
+wm
+si
+ku
+ki
+ma
+ma
+aw
+aw
+aw
+aw
+oW
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+CQ
+CO
+CQ
+CQ
+CO
+CQ
+CQ
+CQ
+CQ
+nH
+sN
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+Ep
+jU
+rb
+rb
+rb
+rb
+jU
+oZ
+xr
+oZ
+jU
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+AO
+AO
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+De
+Dm
+Dp
+Db
+rY
+rY
+rY
+rY
+Yp
+rY
+rY
+Yv
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+rc
+rc
+rc
+Yw
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(119,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+ki
+nz
+pY
+pZ
+rf
+sf
+te
+pZ
+rf
+vw
+wn
+wV
+ku
+ki
+my
+aw
+aw
+aw
+aw
+oW
+pG
+oW
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+qx
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+pa
+pa
+pa
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+nW
+oJ
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+De
+De
+Dp
+Db
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rc
+rc
+rY
+rY
+Ff
+rc
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(120,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+pZ
+pZ
+rf
+sg
+tf
+pZ
+rf
+vv
+wn
+wW
+ku
+kt
+aw
+ma
+my
+ma
+aw
+aw
+oW
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+wJ
+xr
+wJ
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+AC
+nX
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+Df
+CX
+Dq
+Dc
+rY
+Yp
+Yk
+Yx
+Yx
+Yx
+rY
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rY
+rY
+EP
+EU
+EP
+EP
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(121,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ll
+ll
+ll
+ll
+ny
+ll
+ll
+ll
+ll
+pF
+qa
+pZ
+pZ
+rf
+rf
+pZ
+pZ
+vx
+wo
+wX
+ku
+ki
+kt
+kt
+ki
+ki
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ad
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+kf
+kf
+kf
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+rb
+rb
+rb
+jU
+AC
+nX
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+Dg
+Dn
+Dr
+Dc
+rY
+rY
+rY
+Yx
+Yx
+Yx
+Yp
+rY
+rY
+rY
+rY
+td
+tj
+tl
+tl
+tj
+tm
+rY
+rY
+rc
+YF
+EQ
+EV
+EP
+EP
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(122,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ku
+nz
+nz
+nz
+ku
+ku
+ku
+ku
+ku
+ku
+qK
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+pZ
+ku
+ku
+ku
+nz
+ku
+ku
+hh
+hh
+hh
+hh
+hh
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+lL
+mK
+np
+nO
+on
+jU
+kf
+kf
+kf
+jU
+qi
+qT
+rt
+sb
+sQ
+tE
+jU
+rb
+rb
+rb
+rb
+rb
+jU
+kZ
+mk
+jU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+wS
+wS
+rb
+wS
+rc
+rY
+Yv
+Yx
+Yx
+Yx
+rY
+tc
+tc
+tc
+tc
+tc
+tj
+tl
+tl
+tj
+tc
+rY
+rY
+rc
+rc
+EQ
+EQ
+EU
+EQ
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(123,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+mz
+mA
+kt
+ki
+kt
+kt
+ki
+ki
+ku
+qL
+pZ
+sh
+sh
+sh
+sh
+pZ
+pZ
+wY
+xG
+xG
+xG
+gG
+ku
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+jU
+lM
+mL
+nq
+mL
+oo
+jU
+kf
+po
+pb
+qb
+qj
+qj
+ru
+sc
+sR
+tF
+jU
+rb
+rb
+jU
+jU
+jU
+jU
+AD
+AD
+jU
+jU
+jU
+jU
+rb
+rb
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rc
+rY
+rY
+rY
+rY
+rY
+rY
+Eg
+rY
+rY
+Eu
+tc
+tj
+tl
+tl
+tj
+tc
+rY
+rY
+rc
+rc
+EP
+EP
+EP
+Fq
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(124,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+lm
+ku
+ki
+my
+aw
+aw
+my
+aw
+aw
+my
+kt
+ku
+qM
+pZ
+si
+tg
+tg
+uM
+pZ
+wp
+ku
+xG
+xG
+xG
+gG
+ku
+aa
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+jU
+lN
+mM
+nr
+mL
+op
+ls
+oL
+pp
+pB
+jU
+qU
+mL
+nQ
+mL
+mL
+tG
+jU
+rb
+rb
+nI
+xi
+yR
+kf
+kf
+kf
+kf
+kf
+Bt
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+tc
+rc
+rc
+rc
+tc
+tc
+tk
+tk
+tc
+tc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rc
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(125,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+aw
+aw
+my
+aw
+my
+aw
+aw
+mC
+ku
+ku
+rh
+ku
+ku
+ku
+nz
+uJ
+nz
+ku
+xH
+xG
+xG
+gG
+ku
+aa
+Nd
+PO
+PO
+PO
+Sw
+PO
+PO
+PO
+Nd
+QI
+VA
+Op
+Nd
+Rm
+Tn
+UT
+yd
+Xk
+Xk
+XM
+NT
+UV
+CV
+Xk
+NT
+CT
+oV
+CT
+CT
+oV
+CT
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+jU
+lO
+mN
+ns
+nP
+mP
+oA
+pb
+pq
+kf
+jU
+uy
+op
+rv
+sd
+sS
+tH
+jU
+rb
+rb
+jU
+xj
+mL
+mL
+mL
+mL
+mL
+mL
+pB
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(126,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+ki
+aw
+my
+aw
+ma
+aw
+aw
+my
+ki
+ku
+qN
+ri
+ri
+ku
+ku
+nz
+ll
+nz
+ku
+xI
+xG
+xG
+gG
+ku
+aa
+Nd
+HQ
+PY
+PY
+PY
+PY
+PY
+PY
+Nd
+ZW
+ZW
+ZW
+Za
+Xk
+Xk
+Xk
+Tu
+Xk
+Xk
+Tn
+NT
+Xk
+Xk
+Xk
+NT
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kA
+kT
+jU
+lP
+mO
+nt
+nQ
+oq
+jU
+kf
+pp
+kf
+jU
+nB
+qX
+rw
+sq
+mL
+tI
+jU
+rb
+rb
+jU
+xl
+nB
+Ad
+nB
+nB
+Ad
+nB
+kf
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(127,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+kv
+ll
+ll
+ku
+kt
+aw
+aw
+aw
+my
+aw
+aw
+my
+kt
+ku
+qO
+ri
+sj
+ku
+ku
+nz
+ll
+nz
+ku
+xJ
+xG
+xG
+gG
+ku
+aa
+Nd
+Mu
+QH
+Bo
+vs
+Rj
+PI
+Rd
+Nd
+Pa
+ZW
+ZW
+Nd
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+GY
+NT
+UV
+CV
+Xk
+NT
+Xk
+PF
+Xk
+Px
+Xk
+Zt
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+kl
+kB
+kU
+lf
+lQ
+mP
+mP
+nR
+or
+ls
+oL
+pr
+pL
+qc
+qk
+qk
+rx
+sr
+sU
+tJ
+jU
+rb
+rb
+jU
+xC
+zx
+Ae
+AE
+AJ
+AQ
+Bn
+kf
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(128,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ku
+ku
+ku
+ku
+ki
+aw
+my
+ma
+aw
+aw
+ma
+aw
+mC
+nz
+qP
+rj
+ku
+ku
+ku
+nz
+ll
+nz
+ku
+xK
+xG
+yX
+gH
+ku
+aa
+Nd
+PY
+PY
+PY
+PY
+PY
+PY
+PY
+Nd
+SB
+ZW
+Nw
+Nd
+Xk
+Xk
+Xk
+Ph
+Xk
+Tu
+Vu
+Nd
+Gs
+Xk
+Xk
+Re
+Xk
+PF
+Xk
+Px
+Xk
+PF
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+kC
+kV
+jU
+lR
+mQ
+nu
+mS
+os
+kl
+kf
+ps
+kf
+jU
+jU
+qY
+ry
+ss
+mL
+tK
+jU
+rb
+rb
+jU
+xC
+zA
+Af
+AF
+AK
+AR
+Bp
+kf
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(129,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ki
+ki
+ki
+ki
+ki
+aw
+aw
+aw
+ma
+my
+aw
+ma
+ki
+ku
+ku
+ku
+ku
+ku
+ku
+nz
+ll
+nz
+ku
+ku
+ku
+ku
+ku
+ku
+aa
+Nd
+pE
+NJ
+SW
+PY
+Um
+Nn
+PY
+Nd
+Nd
+Nd
+Nd
+Nd
+Xk
+Xk
+XM
+QL
+Xk
+Xk
+XM
+NT
+PX
+CV
+Xk
+NT
+Xk
+PF
+Xk
+Px
+Xk
+Zt
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+jU
+jU
+lr
+lS
+mR
+nv
+nS
+ot
+oB
+pc
+pt
+kf
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+jU
+ye
+nB
+Ag
+nB
+nB
+Ag
+nB
+kf
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(130,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+my
+aw
+aw
+aw
+my
+kt
+hh
+aa
+ku
+sk
+sk
+sk
+nz
+ll
+nz
+sk
+sk
+sk
+ku
+aa
+aa
+aa
+Nd
+Nd
+Nd
+Nd
+XL
+Nd
+Nd
+py
+Nd
+Xk
+Yo
+Xk
+Xn
+Xk
+Xk
+Tn
+Tu
+Xk
+Xk
+Tn
+NT
+Xk
+Xk
+Xk
+NT
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+ls
+lT
+mS
+nw
+nT
+ou
+jU
+oL
+ps
+kf
+iT
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+oL
+mL
+mL
+mL
+mL
+mL
+mL
+pB
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(131,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+my
+aw
+ma
+aw
+hh
+aa
+ku
+sk
+th
+ue
+nz
+uJ
+nz
+ue
+xL
+sk
+ku
+aa
+aa
+aa
+Nd
+PL
+Xk
+Yo
+Xk
+Xk
+Xk
+Xk
+Yh
+Xk
+Nd
+Nd
+Nd
+Gs
+Xk
+GY
+Tu
+Xk
+Xk
+GY
+NT
+Ym
+CV
+Xk
+NT
+Dj
+Qu
+Dj
+Dj
+Qu
+Dj
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+mT
+jU
+jU
+jU
+jU
+kf
+ps
+kf
+iT
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+yz
+zB
+Ak
+kf
+kf
+kf
+zB
+Bu
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(132,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+ma
+aw
+aw
+ma
+aw
+my
+hh
+aa
+ku
+sl
+ti
+sk
+sk
+sk
+sk
+sk
+xM
+yk
+ku
+aa
+aa
+aa
+Nd
+Tq
+Xk
+MG
+rg
+Nd
+Vm
+Fh
+zV
+Nd
+Nd
+Fa
+KT
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+HH
+Nd
+Xk
+Xk
+Xk
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+jU
+lU
+mS
+nA
+nU
+ov
+ls
+kf
+ps
+kf
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+rb
+jU
+jU
+jU
+jU
+AH
+AH
+jU
+jU
+jU
+jU
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(133,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+my
+aw
+aw
+aw
+hh
+aa
+ku
+sm
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+ku
+aa
+aa
+aa
+Nd
+Xk
+Xk
+Rh
+Mm
+Nd
+MT
+Fh
+Yu
+Nd
+Fb
+Sd
+KT
+Xk
+Xk
+Sd
+Sd
+Sd
+Sd
+Sd
+Re
+Xk
+Xk
+Xk
+NT
+vt
+YV
+OU
+Tb
+RS
+VF
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+lV
+mU
+nB
+nB
+ow
+oC
+oL
+ps
+kf
+pn
+kf
+kf
+pn
+kf
+kf
+jU
+rb
+rb
+rb
+rb
+rb
+jU
+Al
+kf
+kf
+AS
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(134,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+BY
+BY
+BY
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+ku
+sn
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+gF
+ku
+aa
+aa
+aa
+Nd
+Xk
+Xk
+Rh
+Mm
+Nd
+Pr
+Fh
+QW
+Nd
+Fc
+Sd
+KT
+Xk
+Xk
+Sd
+Sd
+Sd
+Sd
+Sd
+Nd
+Gs
+Zx
+Xk
+Re
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+lW
+mV
+nC
+nV
+ox
+lr
+kf
+ps
+kf
+lA
+kf
+kf
+lA
+kf
+kf
+jU
+rb
+rb
+rb
+rb
+rb
+jU
+Am
+mL
+mL
+AT
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(135,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+rd
+hh
+hh
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+ku
+sm
+sk
+sk
+sk
+sk
+sk
+sk
+xN
+sk
+ku
+aa
+aa
+aa
+Nd
+Nd
+XL
+Nd
+Nd
+Nd
+JE
+Fh
+YQ
+Nd
+MR
+Sd
+FW
+Xk
+Xk
+Sd
+Sd
+Sd
+Sd
+Sd
+Re
+Xk
+Xk
+Xk
+NT
+XM
+XM
+Xk
+XM
+XM
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+jU
+lr
+ls
+jU
+jU
+jU
+jU
+kf
+ps
+kf
+jU
+jU
+jU
+jU
+st
+jU
+jU
+rb
+rb
+rb
+rb
+rb
+jU
+An
+nB
+nB
+AU
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(136,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+rd
+hh
+Cp
+hh
+aw
+Wh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+ku
+sm
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+ku
+aa
+aa
+aa
+Nd
+yM
+Xk
+Yo
+Xk
+Nd
+SG
+Fh
+Vv
+Nd
+Nd
+Sd
+FX
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+HH
+Nd
+Xk
+Ud
+Ud
+NT
+Po
+Po
+Sd
+Po
+ZU
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+pu
+jU
+jU
+rb
+JV
+JV
+Kk
+JV
+JV
+JV
+JV
+JV
+rb
+rb
+jU
+Ao
+nB
+nB
+Ao
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(137,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+rd
+hh
+hh
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+ku
+so
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+sk
+ku
+aa
+aa
+aa
+Nd
+OG
+Xk
+Xk
+Xk
+Nd
+zX
+Fh
+pS
+Nd
+Nd
+Nd
+Nd
+Gs
+Xk
+XM
+Tu
+Xk
+Xk
+XM
+NT
+Xk
+Ud
+Ud
+NT
+Sd
+Sd
+Sd
+Sd
+MM
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+pd
+pv
+pM
+jU
+rb
+JW
+Kd
+Kd
+Kd
+KE
+Kd
+Kd
+JW
+rb
+rb
+jU
+Ap
+nB
+nB
+Ao
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(138,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+Ck
+Ck
+Ck
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+ku
+sp
+tn
+sk
+sk
+sk
+sk
+sk
+xO
+xP
+ku
+aa
+aa
+aa
+Nd
+TK
+Xk
+Xk
+Xk
+Nd
+QA
+Fh
+Nv
+ED
+Yo
+Yf
+UE
+Xk
+Xk
+Tn
+Xd
+Xk
+Xk
+Tn
+NT
+Xk
+Ud
+Ud
+NT
+Sd
+Sd
+Nq
+Sd
+MM
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+pe
+pw
+pN
+jU
+rb
+JV
+Kd
+Kd
+Kd
+Kd
+Kd
+Kd
+JV
+rb
+rb
+jU
+Ao
+nB
+nB
+Ap
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(139,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+FZ
+sk
+sp
+ui
+ui
+ui
+ui
+ui
+xP
+sk
+ku
+aa
+aa
+aa
+Nd
+YL
+Xk
+Xk
+Xk
+Nd
+Xo
+Fh
+Fh
+py
+Xk
+Yf
+UE
+Xk
+Xk
+GY
+Tu
+Xk
+Xk
+GY
+NT
+Xk
+Ud
+Ud
+NT
+Sd
+Sd
+Sd
+Sd
+MM
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+pf
+px
+pO
+jU
+rb
+JV
+Ke
+Ke
+Ke
+Ke
+Kd
+Ke
+JV
+rb
+rb
+jU
+Ao
+nB
+nB
+AX
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(140,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+ku
+aa
+aa
+aa
+Nd
+Xe
+Xk
+Xk
+Xk
+Nd
+TB
+Fh
+Fh
+BV
+Xk
+Yf
+UE
+Xk
+Xk
+Xk
+Ph
+Xk
+Qk
+Vu
+Nd
+Gs
+Ud
+Ud
+NT
+PA
+PA
+Sd
+PA
+Pl
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+rb
+JV
+Ke
+Ke
+Ke
+Ke
+Kd
+Ke
+JV
+rb
+rb
+jU
+Ao
+nB
+nB
+Ao
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(141,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nd
+Ny
+Xk
+Xk
+Xk
+Nd
+Vz
+Fh
+YJ
+QT
+Xk
+Yf
+UE
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+XM
+NT
+Xk
+Xk
+Xk
+NT
+GY
+GY
+Xk
+GY
+GY
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+JV
+Kd
+Kl
+Kd
+Kd
+Kd
+Kd
+JV
+rb
+rb
+jU
+Ap
+nB
+nB
+Ao
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(142,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nd
+Bs
+Ri
+Xk
+Xk
+XL
+Fh
+Fh
+Fh
+UH
+Xk
+Yf
+UE
+Xk
+Xk
+Xk
+Tu
+Xk
+Xk
+Tn
+NT
+Xk
+Xk
+Xk
+Re
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+JW
+Kf
+Km
+Kz
+KF
+Kd
+Kd
+JW
+rb
+rb
+jU
+Aq
+nB
+nB
+AY
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(143,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nd
+SU
+Xk
+Xx
+Nm
+Nd
+SN
+pV
+Tr
+Nd
+Fj
+Nd
+Nd
+Fi
+Tn
+UT
+Hm
+Xk
+Xk
+GY
+NT
+Xk
+Xk
+Xk
+NT
+vt
+Mx
+OU
+Tb
+Uh
+tW
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+JV
+JV
+JV
+JV
+JV
+JV
+JV
+JV
+rb
+rb
+jU
+Ar
+mL
+mL
+AZ
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(144,1,1) = {"
+hh
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+As
+kf
+kf
+Bb
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(145,1,1) = {"
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+hh
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+jU
+jU
+jU
+jU
+jU
+jU
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(146,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(147,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(148,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+ga
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gv
+hb
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+hb
+ga
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gg
+gv
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(149,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
+gk
+gl
+gl
+gl
+gk
+gj
+gk
+gk
+gk
+gk
+gk
+gj
+gk
+gl
+gl
+gl
+gk
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(150,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+gk
+gl
+gk
+gk
+gk
+gj
+gk
+gk
+hC
+gk
+gk
+gj
+gk
+gk
+gk
+gl
+gk
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(151,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+gk
+gl
+gk
+gk
+gk
+gj
+gk
+hC
+hD
+hC
+gk
+gj
+gk
+gk
+gk
+gl
+gk
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(152,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+gk
+gl
+gk
+gk
+gk
+gj
+gk
+gk
+hC
+gk
+gk
+gj
+gk
+gk
+gk
+gl
+gk
+fZ
+gb
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(153,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
+gk
+gl
+gl
+gl
+gk
+gj
+gk
+gk
+gk
+gk
+gk
+gj
+gk
+gl
+gl
+gl
+gk
+fZ
+gb
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(154,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gc
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gx
+hb
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+hb
+gc
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gx
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(155,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+hb
+hb
+hb
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hb
+hb
+hb
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(156,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(157,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gk
+gk
+gk
+gw
+gj
+gb
+gk
+gk
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gh
+gh
+gw
+gj
+gb
+gh
+gh
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(158,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+fZ
+gk
+fZ
+gl
+fZ
+gk
+fZ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(159,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gk
+gl
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gl
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(160,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(161,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gk
+gk
+gk
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(162,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(163,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gk
+gl
+gk
+gw
+gB
+gb
+gk
+gl
+gk
+gw
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gk
+gl
+hC
+gl
+gk
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gb
+gh
+gl
+gh
+gw
+gB
+gb
+gh
+gl
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(164,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gl
+gl
+gl
+gw
+gB
+gb
+gl
+gl
+gl
+gw
+gk
+gk
+gh
+gl
+gh
+gk
+gk
+gk
+hC
+hE
+hC
+gk
+gk
+gk
+gh
+gl
+gh
+gk
+gk
+gb
+gl
+gl
+gl
+gw
+gB
+gb
+gl
+gl
+gl
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(165,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gk
+gl
+gk
+gw
+gB
+gb
+gk
+gl
+gk
+gw
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gk
+gl
+hC
+gl
+gk
+gk
+gk
+gh
+fZ
+gh
+gk
+gk
+gb
+gh
+gl
+gh
+gw
+gB
+gb
+gh
+gl
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(166,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(167,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gk
+gk
+gk
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+fZ
+gj
+gj
+gj
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(168,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gk
+gk
+gk
+gk
+gk
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+ga
+gg
+gg
+gg
+gv
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(169,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gk
+gl
+gk
+gw
+gj
+gb
+gk
+gl
+gk
+gw
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gb
+gh
+gl
+gh
+gw
+gj
+gb
+gh
+gl
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(170,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+fZ
+gk
+fZ
+gl
+fZ
+gk
+fZ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+gb
+gl
+gl
+gl
+gw
+gj
+gb
+gl
+gl
+gl
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(171,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gb
+gk
+gk
+gk
+gw
+gj
+gb
+gk
+gk
+gk
+gw
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+gk
+gh
+gh
+gh
+gk
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
+gb
+gh
+gh
+gh
+gw
+gj
+gb
+gh
+gh
+gh
+gw
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(172,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gk
+gk
+gk
+gk
+gk
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+gc
+gi
+gi
+gi
+gx
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(173,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+gu
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+gJ
+gJ
+gJ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+fZ
+gk
+gk
+gk
+fZ
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+gP
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(174,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+gh
+gC
+gD
+gK
+gO
+gS
+gW
+fZ
+fZ
+fZ
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(175,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+gh
+gC
+gL
+gk
+gi
+gk
+gX
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(176,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+gh
+gC
+gh
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+gB
+gB
+gB
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(177,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+RM
+RM
+RM
+sE
+sE
+sE
+sE
+sE
+sE
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gh
+gh
+gh
+gC
+fZ
+go
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(178,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+sE
+sE
+RM
+sE
+sE
+sE
+sE
+sE
+sE
+RM
+RL
+aa
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+gU
+gM
+gh
+gU
+gY
+fZ
+go
+gB
+gh
+hj
+gh
+gj
+gk
+gj
+gk
+gj
+gk
+gj
+gh
+hj
+gh
+gB
+go
+gB
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(179,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+aa
+RL
+RM
+sG
+Ga
+RM
+sE
+sE
+sE
+sE
+sE
+sE
+RM
+RL
+aa
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+gL
+gk
+gi
+gk
+gX
+fZ
+go
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(180,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fY
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RL
+aa
+RL
+RM
+yq
+Gt
+Hk
+sE
+sE
+sE
+sE
+sE
+Hy
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+hj
+gh
+fZ
+gl
+hj
+hj
+hj
+gl
+fZ
+gh
+hj
+gh
+fZ
+go
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(181,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+Su
+Su
+Su
+Su
+Su
+RM
+RL
+aa
+RL
+RM
+sE
+GA
+RM
+sE
+sE
+sE
+sE
+sE
+sE
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+gh
+gC
+gh
+gh
+gh
+gh
+gC
+gl
+go
+gl
+gh
+hj
+gh
+gB
+hj
+hj
+hj
+hj
+hj
+gB
+gh
+hj
+gh
+gl
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(182,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+Su
+SE
+SF
+SH
+Su
+RM
+RL
+aa
+RL
+RM
+sE
+GB
+RM
+sE
+sE
+sE
+sE
+sE
+sE
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+gh
+gC
+gU
+gM
+gh
+gU
+gY
+gl
+go
+gl
+gh
+hj
+gh
+gB
+hj
+hj
+gl
+hj
+hj
+gB
+gh
+hj
+gh
+gl
+go
+gB
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Ls
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(183,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+Su
+SF
+Su
+SS
+Su
+RM
+RL
+aa
+RL
+RM
+RM
+RM
+RM
+Sp
+Hl
+SI
+sE
+sE
+sE
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+gh
+gC
+gL
+gk
+gi
+gk
+gX
+gl
+go
+gl
+gh
+hj
+gh
+gB
+hj
+hj
+hj
+hj
+hj
+gB
+gh
+hj
+gh
+gl
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+iR
+je
+jp
+iR
+jp
+jD
+iR
+aa
+aa
+aa
+aa
+iR
+iR
+mi
+jy
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(184,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+Su
+SH
+SF
+SE
+Su
+RM
+RL
+aa
+RL
+RM
+RT
+Sb
+Sb
+Sq
+Sz
+SJ
+Sb
+Sb
+Te
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+hj
+gh
+fZ
+gl
+hj
+hj
+hj
+gl
+fZ
+gh
+hj
+gh
+fZ
+go
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+iY
+jf
+jq
+iR
+jq
+jE
+iY
+aa
+aa
+aa
+aa
+iR
+lJ
+mj
+mH
+nm
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(185,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+Su
+Su
+Su
+Su
+Su
+RM
+RL
+aa
+RL
+RM
+RU
+Sc
+Sj
+Sr
+SA
+SK
+SM
+ST
+Tg
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gh
+gh
+gh
+gC
+fZ
+go
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+iF
+iR
+iR
+jk
+jp
+iR
+jp
+jI
+iR
+iR
+iR
+iR
+iF
+ab
+lK
+mD
+mI
+nn
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(186,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RL
+aa
+RL
+RM
+RV
+Se
+Sf
+Ss
+SC
+Sf
+Sf
+Se
+Th
+RM
+RL
+aa
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gU
+gM
+gh
+gU
+gY
+fZ
+go
+gB
+gh
+hj
+gh
+gj
+gk
+gj
+gk
+gj
+gk
+gj
+gh
+hj
+gh
+gB
+go
+gB
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+iG
+iG
+iZ
+jl
+iN
+jt
+ju
+jJ
+iZ
+iZ
+iZ
+iG
+iG
+iR
+mb
+iP
+mJ
+no
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(187,1,1) = {"
+aa
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+fX
+aa
+aa
+aa
+aa
+aa
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+aa
+RL
+RM
+RW
+Sf
+Sf
+St
+Sf
+Sf
+Sf
+Sf
+GZ
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gL
+gk
+gi
+gk
+gX
+fZ
+go
+gB
+gh
+hj
+gh
+gk
+gj
+gk
+gj
+gk
+gj
+gk
+gh
+hj
+gh
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+iN
+iN
+jb
+jm
+jr
+jr
+jr
+jK
+jM
+jP
+jP
+ju
+ju
+iR
+mc
+mF
+kw
+nD
+mi
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(188,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RM
+RM
+Sg
+Sk
+Ss
+SD
+SL
+SR
+Sf
+Tj
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gL
+gk
+gT
+gC
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+iO
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+kj
+iF
+md
+iP
+kw
+nE
+jy
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(189,1,1) = {"
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RL
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RM
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gh
+gh
+gh
+gC
+hc
+hi
+hm
+hr
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hy
+hI
+gh
+gh
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+gV
+iP
+iS
+jc
+iG
+iS
+iG
+iS
+iG
+iS
+iG
+jQ
+iS
+kw
+lp
+me
+iP
+kw
+me
+lp
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(190,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+RL
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gU
+gM
+gh
+gU
+gY
+hj
+hj
+hn
+gb
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+hJ
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+gV
+iP
+iS
+jc
+jn
+iS
+jn
+iS
+jn
+iS
+jn
+jQ
+iS
+kw
+ab
+mf
+mG
+lo
+nF
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(191,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+gL
+gl
+gl
+gl
+gX
+hj
+hj
+hn
+gb
+gk
+gl
+gk
+fZ
+gl
+gl
+gl
+fZ
+gk
+gl
+gk
+hJ
+fZ
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+iP
+iS
+jc
+jn
+iS
+jn
+iS
+jn
+iS
+jn
+jQ
+iS
+kw
+jy
+ab
+ab
+lp
+ab
+iF
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(192,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+kK
+lg
+lB
+lX
+mr
+aa
+aa
+aa
+kK
+lg
+lB
+lX
+mr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gh
+gL
+gk
+gT
+gC
+hj
+hj
+hn
+gb
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+hJ
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+gV
+iP
+iS
+jc
+jn
+iS
+jn
+iS
+jn
+iS
+jn
+jQ
+iS
+ln
+ab
+mg
+jP
+jP
+mI
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(193,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+ko
+kL
+JF
+lC
+lY
+ms
+nb
+aa
+ko
+kL
+LS
+lC
+lY
+ms
+nb
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gE
+gJ
+gJ
+gJ
+gZ
+he
+hk
+ho
+gc
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+gi
+hK
+gh
+gh
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+gV
+iP
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+iS
+kw
+lq
+iP
+iS
+iS
+kw
+lq
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(194,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+kp
+JA
+li
+JM
+li
+mt
+nc
+aa
+kp
+LK
+li
+LT
+li
+mt
+nc
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gP
+fZ
+fZ
+fZ
+go
+fZ
+hz
+hz
+hz
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hz
+hz
+hL
+fZ
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+iQ
+iX
+jd
+jo
+js
+js
+iX
+jL
+jN
+jL
+jd
+iX
+lo
+ab
+mh
+jd
+iX
+nG
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(195,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+kq
+JB
+li
+lE
+li
+mu
+nd
+aa
+kq
+LL
+li
+lE
+li
+mu
+nd
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hz
+hz
+hz
+hz
+hz
+hj
+gl
+hj
+hz
+hz
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+iF
+ab
+ab
+ab
+ab
+jy
+ab
+ab
+ab
+ab
+iF
+ab
+ab
+ab
+ab
+nl
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(196,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+kr
+JC
+li
+JN
+li
+mv
+ne
+aa
+kr
+LM
+li
+LU
+li
+mv
+ne
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+go
+gB
+hz
+hz
+hz
+hj
+hz
+hz
+hj
+hz
+hz
+hj
+hz
+hz
+hL
+gB
+go
+gB
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(197,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+ks
+kP
+lj
+lG
+lj
+mw
+nf
+aa
+ks
+kP
+lj
+lG
+lj
+mw
+nf
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hz
+hz
+hz
+gl
+hj
+hz
+hz
+hz
+hj
+gl
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(198,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+kQ
+lk
+lH
+lZ
+mx
+aa
+aa
+aa
+kQ
+lk
+lH
+lZ
+mx
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+hz
+hz
+hz
+hz
+gl
+hj
+hz
+hj
+gl
+hz
+hz
+hz
+hL
+fZ
+go
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(199,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+hp
+hz
+fZ
+hz
+hz
+hz
+gl
+hj
+gl
+hz
+hz
+hz
+fZ
+hL
+hp
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(200,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+pW
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+kK
+lg
+lB
+lX
+mr
+aa
+aa
+aa
+kK
+lg
+lB
+lX
+mr
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+go
+hp
+hz
+hz
+fZ
+hz
+hz
+hz
+hz
+hz
+hz
+hz
+fZ
+hz
+hL
+hp
+go
+gB
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(201,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+ko
+kL
+Be
+lC
+lY
+ms
+nb
+aa
+ko
+kL
+lh
+lC
+lY
+ms
+nb
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+hp
+hz
+fZ
+hz
+hz
+hz
+gq
+hB
+gq
+hz
+hz
+hz
+fZ
+hL
+hp
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(202,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+kp
+Au
+li
+BQ
+li
+mt
+nc
+aa
+kp
+kM
+li
+lD
+li
+mt
+nc
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+hz
+hz
+hz
+hz
+gq
+hB
+hz
+hB
+gq
+hz
+hz
+hz
+hL
+fZ
+go
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(203,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+kq
+Av
+li
+lE
+li
+mu
+nd
+aa
+kq
+kN
+li
+lE
+li
+mu
+nd
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hz
+hz
+hz
+gq
+hB
+hz
+hz
+hz
+hB
+gq
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(204,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+kr
+Aw
+li
+BR
+li
+mv
+ne
+aa
+kr
+kO
+li
+lF
+li
+mv
+ne
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+go
+gB
+hz
+hz
+hz
+hB
+hz
+hz
+hB
+hz
+hz
+hB
+hz
+hz
+hL
+gB
+go
+gB
+gI
+gN
+gQ
+gQ
+ha
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(205,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+ks
+kP
+lj
+lG
+lj
+mw
+nf
+aa
+ks
+kP
+lj
+lG
+lj
+mw
+nf
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+hz
+hz
+hz
+hz
+hz
+hB
+gq
+hB
+hz
+hz
+hz
+hz
+hL
+gB
+go
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(206,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+kQ
+lk
+lH
+lZ
+mx
+aa
+aa
+aa
+kQ
+lk
+lH
+lZ
+mx
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+fZ
+hz
+hz
+hz
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hz
+hz
+hL
+fZ
+go
+fZ
+fZ
+fZ
+gR
+fZ
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(207,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gh
+gh
+gd
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+hM
+hP
+hS
+hU
+gO
+gO
+gO
+gO
+ih
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(208,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+ge
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hN
+hB
+hB
+hV
+gh
+ib
+hf
+ie
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(209,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+LV
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LV
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+fZ
+fZ
+ge
+hf
+gq
+hf
+fZ
+gq
+gq
+gq
+fZ
+hf
+gq
+hf
+hN
+hB
+hB
+hV
+ib
+gq
+gq
+gq
+ii
+fZ
+fZ
+gm
+gn
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(210,1,1) = {"
+Di
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Qe
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+ge
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hN
+hB
+hB
+hV
+if
+ic
+gh
+if
+ij
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(211,1,1) = {"
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+Di
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gh
+gh
+hx
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hO
+hR
+hT
+hW
+gh
+gh
+gh
+gh
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(212,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+gh
+ib
+hf
+ie
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(213,1,1) = {"
+ab
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ab
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ab
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ab
+LV
+LW
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+ib
+hf
+gp
+hf
+ii
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(214,1,1) = {"
+ac
+af
+af
+af
+af
+af
+af
+af
+af
+af
+af
+vi
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+vi
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+KL
+LV
+LW
+LY
+LY
+LY
+LZ
+LZ
+LZ
+LZ
+LW
+LV
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+go
+gB
+gh
+hB
+gh
+gs
+hf
+gs
+hf
+gs
+hf
+gs
+gh
+hB
+gh
+gB
+go
+fZ
+if
+ic
+gh
+if
+ij
+fZ
+fZ
+go
+gm
+go
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(215,1,1) = {"
+ac
+af
+aG
+af
+af
+aO
+aR
+aG
+af
+ax
+af
+vi
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+vi
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+KL
+LV
+LX
+LY
+LY
+LY
+LZ
+LZ
+Ma
+Mb
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+gh
+gh
+gh
+gh
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(216,1,1) = {"
+ac
+af
+ax
+af
+af
+af
+af
+af
+af
+ax
+af
+vi
+bk
+bk
+bk
+bk
+ce
+cq
+bk
+bk
+bk
+bk
+vi
+dm
+dG
+dG
+eu
+dG
+dG
+eu
+dG
+dG
+dm
+KL
+LV
+LW
+LY
+LY
+LY
+LZ
+LZ
+LZ
+LZ
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+gh
+hB
+gh
+fZ
+gq
+hB
+hB
+hB
+gq
+fZ
+gh
+hB
+gh
+fZ
+go
+fZ
+gh
+ib
+hf
+ie
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(217,1,1) = {"
+ac
+af
+ax
+aG
+aM
+af
+aS
+af
+af
+aG
+af
+vi
+bk
+bk
+bk
+bk
+bk
+cr
+bk
+bk
+bk
+bk
+vi
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+dG
+dG
+dm
+KL
+LV
+LW
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LZ
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gq
+gh
+hB
+gh
+gB
+hB
+hB
+hB
+hB
+hB
+gB
+gh
+hB
+gh
+gq
+go
+gq
+ib
+hf
+gp
+hf
+ii
+gh
+gh
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(218,1,1) = {"
+ac
+af
+af
+af
+af
+af
+aG
+af
+af
+af
+af
+vi
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+bk
+vi
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+dm
+KL
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+go
+gq
+gh
+hB
+gh
+gB
+hB
+hB
+gq
+hB
+hB
+gB
+gh
+hB
+gh
+gq
+go
+gq
+if
+ic
+gh
+if
+ij
+gh
+gh
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(219,1,1) = {"
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gq
+gh
+hB
+gh
+gB
+hB
+hB
+hB
+hB
+hB
+gB
+gh
+hB
+gh
+gq
+go
+gq
+gh
+gh
+gh
+gh
+gC
+gh
+gh
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(220,1,1) = {"
+ac
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+ah
+vi
+bl
+bn
+bD
+ca
+bD
+bl
+ca
+bD
+bm
+bl
+vi
+dn
+dH
+ed
+ev
+ew
+ev
+ew
+eW
+fj
+dn
+KL
+LV
+LW
+LY
+LY
+LY
+LZ
+LY
+LY
+LY
+LW
+LV
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+go
+fZ
+gh
+hB
+gh
+fZ
+gq
+hB
+hB
+hB
+gq
+fZ
+gh
+hB
+gh
+fZ
+go
+fZ
+gh
+ib
+hf
+ie
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(221,1,1) = {"
+ac
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+ai
+vi
+bm
+bD
+bR
+bl
+bl
+bE
+cD
+cK
+cK
+ca
+vi
+dn
+dI
+ee
+ew
+ev
+ew
+ev
+eX
+fk
+dn
+KL
+LV
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LW
+LV
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+ib
+hf
+gp
+hf
+ii
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(222,1,1) = {"
+ac
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+vi
+bl
+bE
+bS
+cb
+bl
+bl
+bR
+cL
+cM
+bl
+vi
+dn
+dJ
+ed
+ev
+ew
+ev
+ew
+eW
+fl
+dn
+KL
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+LV
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+gI
+gN
+gQ
+gQ
+ha
+gB
+go
+gB
+gh
+hB
+gh
+gs
+hf
+gs
+hf
+gs
+hf
+gs
+gh
+hB
+gh
+gB
+go
+fZ
+if
+ic
+gh
+if
+ij
+fZ
+fZ
+gn
+gm
+gn
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(223,1,1) = {"
+ac
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+vi
+bn
+bF
+bT
+cc
+bl
+bm
+cE
+cM
+cK
+bn
+vi
+dn
+dK
+ee
+ew
+ev
+ew
+ev
+eX
+fm
+dn
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+gB
+gh
+hB
+gh
+hf
+gs
+hf
+gs
+hf
+gs
+hf
+gh
+hB
+gh
+gB
+go
+fZ
+gh
+gh
+gh
+gh
+gC
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(224,1,1) = {"
+ac
+ak
+ay
+aH
+aj
+aH
+aH
+aj
+aH
+ay
+bc
+vi
+bl
+bl
+bD
+ca
+bl
+bD
+bl
+cN
+cW
+bl
+vi
+dn
+dH
+ed
+ev
+ew
+ev
+ew
+eW
+fj
+dn
+KL
+ab
+fB
+fB
+fB
+fB
+fB
+fB
+ab
+aa
+aa
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+go
+fZ
+gh
+gh
+gh
+fZ
+fZ
+gB
+gB
+gB
+fZ
+fZ
+gh
+gh
+gh
+fZ
+go
+fZ
+gh
+ib
+hf
+ie
+gC
+gh
+gh
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(225,1,1) = {"
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+ab
+fC
+fC
+fC
+fC
+fC
+fC
+ab
+ab
+ab
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gC
+ib
+hf
+gp
+hf
+ii
+gh
+gh
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(226,1,1) = {"
+ac
+al
+az
+an
+an
+aP
+aP
+aP
+aP
+aP
+aP
+vi
+bo
+bG
+bH
+bH
+cf
+cs
+bH
+cO
+bH
+cZ
+ac
+do
+dL
+ef
+ex
+eH
+eH
+eH
+eY
+dL
+fq
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fV
+ab
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+fZ
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+fZ
+fZ
+fZ
+ia
+id
+gJ
+ig
+ik
+gh
+gh
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(227,1,1) = {"
+ac
+am
+an
+aI
+an
+aQ
+aT
+aY
+ba
+ba
+bd
+vi
+bp
+bH
+bH
+bH
+bH
+bH
+bH
+cP
+bH
+da
+ac
+dp
+dL
+eg
+ey
+eH
+eH
+eH
+eY
+dL
+fq
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fV
+ab
+aa
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+fZ
+fZ
+gR
+fZ
+fZ
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+fZ
+hf
+hf
+hf
+fZ
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
+fZ
+gO
+gO
+gO
+fZ
+fZ
+fZ
+gm
+gm
+gm
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(228,1,1) = {"
+ac
+an
+aA
+aJ
+aN
+an
+aU
+aZ
+aZ
+aZ
+be
+vi
+bq
+bH
+bU
+cd
+cg
+ct
+bH
+cQ
+cX
+db
+ac
+dq
+dM
+eg
+ez
+eH
+eH
+eH
+eZ
+dL
+fq
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fV
+ab
+aa
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+fZ
+fZ
+gQ
+gB
+gB
+gB
+hf
+hf
+hf
+hf
+hf
+gB
+gB
+gB
+gQ
+fZ
+fZ
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(229,1,1) = {"
+ac
+an
+aA
+aK
+aN
+an
+aV
+aZ
+aZ
+aZ
+be
+vi
+br
+bH
+bV
+cd
+bH
+bH
+bH
+bH
+bH
+dc
+ac
+dr
+dL
+eg
+eA
+eH
+eH
+eH
+eY
+dL
+fq
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fV
+ab
+aa
+fZ
+ge
+gh
+gh
+gh
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+fZ
+fZ
+fZ
+gQ
+fZ
+gB
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
+gB
+fZ
+gQ
+fZ
+fZ
+fZ
+ge
+gh
+gh
+gh
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(230,1,1) = {"
+ac
+ao
+an
+aL
+an
+aQ
+aT
+aZ
+bb
+bb
+bf
+vi
+bs
+bH
+bW
+cd
+ch
+cu
+bH
+bH
+bH
+dd
+ac
+ds
+dL
+eh
+ex
+eH
+eH
+eH
+eY
+dL
+fq
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fV
+ab
+aa
+fZ
+ge
+gq
+gq
+gq
+gz
+gs
+ge
+gq
+gq
+gq
+gz
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+fZ
+hf
+fZ
+gq
+fZ
+hf
+fZ
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
+ge
+gq
+gq
+gq
+gz
+gs
+ge
+gq
+gq
+gq
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(231,1,1) = {"
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+ab
+fD
+fD
+fD
+fD
+fD
+fD
+ab
+ab
+ab
+aa
+fZ
+ge
+gh
+gq
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+ge
+gh
+gq
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(232,1,1) = {"
+ac
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+vi
+bt
+bI
+bI
+bI
+ci
+cv
+cF
+cF
+cF
+de
+vi
+dt
+dN
+ei
+ej
+eI
+eP
+ej
+fa
+fn
+fr
+KL
+fy
+fE
+fL
+fN
+fN
+fS
+fE
+fy
+ab
+aa
+aa
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+fZ
+fZ
+gQ
+fZ
+fZ
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(233,1,1) = {"
+ac
+ap
+aB
+ap
+ap
+ap
+ap
+ap
+ap
+aB
+ap
+vi
+bt
+bI
+bX
+bJ
+cj
+cw
+bJ
+cR
+cF
+de
+vi
+du
+dO
+ej
+ej
+eJ
+eJ
+eV
+fb
+fo
+fs
+KL
+fz
+fz
+fz
+fz
+fz
+fz
+fz
+fz
+ab
+aa
+aa
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hf
+hf
+hf
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(234,1,1) = {"
+ac
+ap
+ap
+ap
+ap
+aB
+aB
+ap
+ap
+ap
+ap
+vi
+bu
+bJ
+bX
+bJ
+cj
+cw
+cG
+cR
+bJ
+df
+vi
+du
+dP
+ek
+ej
+ej
+ej
+eV
+fc
+fo
+fs
+KL
+fA
+fF
+fF
+fF
+fF
+fF
+fF
+fA
+ab
+aa
+aa
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(235,1,1) = {"
+ac
+ap
+aB
+ap
+ap
+ap
+ap
+ap
+ap
+aB
+ap
+vi
+bv
+bK
+bX
+bJ
+cj
+cw
+bJ
+cR
+cH
+dg
+vi
+du
+dQ
+ej
+ej
+eK
+eK
+eV
+fd
+fo
+fs
+KL
+fz
+fG
+fG
+fG
+fG
+fG
+fG
+fz
+ab
+aa
+aa
+fZ
+ge
+gh
+gq
+gh
+gz
+gB
+ge
+gh
+gq
+gh
+gz
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
+hf
+gq
+hC
+gq
+hf
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
+ge
+gh
+gq
+gh
+gz
+gB
+ge
+gh
+gq
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(236,1,1) = {"
+ac
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+ap
+vi
+bv
+bK
+bK
+bK
+ck
+cx
+cH
+cH
+cH
+dg
+vi
+dt
+dR
+el
+ej
+eL
+eQ
+ej
+fe
+fn
+ft
+KL
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+ge
+gq
+gq
+gq
+gz
+gB
+ge
+gq
+gq
+gq
+gz
+hf
+hf
+gh
+gq
+gh
+hf
+hf
+hf
+hC
+hF
+hC
+hf
+hf
+hf
+gh
+gq
+gh
+hf
+hf
+ge
+gq
+gq
+gq
+gz
+gB
+ge
+gq
+gq
+gq
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(237,1,1) = {"
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+ge
+gh
+gq
+gh
+gz
+gB
+ge
+gh
+gq
+gh
+gz
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
+hf
+gq
+hC
+gq
+hf
+hf
+hf
+gh
+fZ
+gh
+hf
+hf
+ge
+gh
+gq
+gh
+gz
+gB
+ge
+gh
+gq
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(238,1,1) = {"
+ac
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+vi
+bw
+bw
+bw
+bw
+bw
+bw
+bw
+cS
+cY
+dh
+vi
+dv
+dS
+em
+eB
+eM
+eR
+eM
+eR
+eM
+ep
+KL
+fz
+fH
+fH
+fO
+fO
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(239,1,1) = {"
+ac
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+vi
+bw
+bL
+bY
+bw
+cl
+bw
+bw
+cT
+cY
+dh
+vi
+dw
+dT
+en
+eB
+eN
+eS
+eN
+eS
+eN
+en
+KL
+fz
+fH
+fH
+fP
+fO
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hf
+hf
+hf
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(240,1,1) = {"
+ac
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+vi
+bw
+bw
+bw
+bw
+bw
+bw
+bw
+cU
+cY
+dh
+vi
+dx
+dU
+eo
+eB
+eB
+eB
+eB
+eB
+eB
+eB
+KL
+fz
+fH
+fH
+fO
+fO
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+gd
+gp
+gp
+gp
+gy
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(241,1,1) = {"
+ac
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+vi
+bw
+bM
+bY
+bw
+bw
+cy
+bw
+cS
+cY
+dh
+vi
+dy
+dV
+ep
+eB
+eM
+eR
+eM
+eR
+eM
+ep
+KL
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+ge
+gh
+gq
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
+ge
+hf
+gq
+hf
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(242,1,1) = {"
+ac
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+vi
+bw
+bw
+bw
+bw
+bw
+bw
+bw
+cS
+cY
+dh
+vi
+dz
+dW
+eq
+eB
+eN
+eS
+eN
+eS
+eN
+en
+KL
+fz
+fH
+fH
+fH
+fH
+fH
+fH
+fz
+ab
+aa
+aa
+fZ
+ge
+gq
+gq
+gq
+gz
+gs
+ge
+gq
+gq
+gq
+gz
+gs
+ge
+gq
+gq
+gq
+gz
+fZ
+hf
+fZ
+gq
+fZ
+hf
+fZ
+ge
+gq
+gq
+gq
+gz
+gs
+ge
+gq
+gq
+gq
+gz
+gs
+ge
+gq
+gq
+gq
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(243,1,1) = {"
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+fz
+fI
+fI
+fI
+fI
+fI
+fI
+fz
+ab
+aa
+aa
+fZ
+ge
+gh
+gh
+gh
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+gs
+ge
+gh
+gq
+gh
+gz
+fZ
+hf
+gh
+gh
+gh
+hf
+fZ
+ge
+hf
+gq
+hf
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+gs
+ge
+gh
+gh
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(244,1,1) = {"
+ac
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+vi
+bx
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+bz
+vi
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+KL
+fA
+fF
+fF
+fF
+fF
+fF
+fF
+fA
+ab
+aa
+aa
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+gf
+gr
+gr
+gr
+gA
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(245,1,1) = {"
+ac
+ar
+aC
+ar
+ar
+ar
+ar
+ar
+ar
+aC
+ar
+vi
+by
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+di
+vi
+dA
+dX
+dA
+eC
+eO
+eT
+eO
+eD
+eO
+dA
+KL
+fz
+fz
+fz
+fz
+fz
+fz
+fz
+fz
+ab
+aa
+aa
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+hq
+hq
+hq
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+hq
+hq
+hq
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+fZ
+gs
+gs
+gs
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(246,1,1) = {"
+ac
+ar
+ar
+ar
+aC
+ar
+ar
+aC
+ar
+ar
+ar
+vi
+by
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+di
+vi
+dA
+dY
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+KL
+fy
+fJ
+fM
+fQ
+fQ
+fT
+fJ
+fy
+ab
+aa
+aa
+fZ
+gd
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gy
+hg
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+hg
+gd
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gp
+gy
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(247,1,1) = {"
+ac
+ar
+aC
+ar
+ar
+ar
+ar
+ar
+ar
+aC
+ar
+vi
+by
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+di
+vi
+dA
+dZ
+dA
+eD
+eO
+eU
+eO
+ff
+eO
+dA
+KL
+ab
+fD
+fD
+fD
+fD
+fD
+fD
+ab
+ab
+ab
+aa
+fZ
+ge
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
+hf
+gq
+gq
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+gq
+gq
+hf
+fZ
+ge
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(248,1,1) = {"
+ac
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+ar
+vi
+bz
+bN
+bN
+bN
+cm
+cz
+bN
+bN
+bN
+bx
+vi
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fW
+ab
+aa
+fZ
+ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+hf
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hC
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+hf
+fZ
+ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(249,1,1) = {"
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fW
+ab
+aa
+fZ
+ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+hf
+gq
+hf
+hf
+hf
+hf
+hf
+hC
+hG
+hC
+hf
+hf
+hf
+hf
+hf
+gq
+hf
+fZ
+ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(250,1,1) = {"
+ac
+as
+aD
+aD
+aD
+aD
+aW
+aW
+aW
+aW
+bg
+vi
+bA
+bO
+bO
+bO
+cn
+cA
+cI
+cI
+cI
+dj
+vi
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+dB
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fW
+ab
+aa
+fZ
+ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+hf
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hC
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+hf
+fZ
+ge
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gt
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(251,1,1) = {"
+ac
+at
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+bh
+vi
+bB
+bP
+bZ
+bP
+co
+cB
+bP
+cV
+bP
+dk
+vi
+dC
+ea
+er
+eE
+eE
+eE
+eE
+fg
+fp
+fu
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fW
+ab
+aa
+fZ
+ge
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
+hf
+gq
+gq
+gq
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+hf
+gq
+gq
+gq
+hf
+fZ
+ge
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gh
+gz
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(252,1,1) = {"
+ac
+at
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+bh
+vi
+bB
+bP
+bZ
+bP
+co
+cB
+bP
+cV
+bP
+dk
+vi
+dD
+eb
+es
+eF
+eF
+eF
+eF
+fh
+fp
+fv
+KL
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+fU
+fW
+ab
+aa
+fZ
+gf
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gA
+hg
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+fZ
+hf
+hf
+hf
+hf
+hf
+hg
+gf
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gr
+gA
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(253,1,1) = {"
+ac
+at
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+aE
+bh
+vi
+bB
+bP
+bZ
+bP
+co
+cB
+bP
+cV
+bP
+dk
+vi
+dE
+ec
+et
+eG
+eG
+eG
+eG
+fi
+fp
+fw
+KL
+ab
+fC
+fC
+fC
+fC
+fC
+fC
+ab
+ab
+ab
+aa
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+fZ
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(254,1,1) = {"
+ac
+au
+aF
+aF
+aF
+aF
+aX
+aX
+aX
+aX
+bi
+vi
+bC
+bQ
+bQ
+bQ
+cp
+cC
+cJ
+cJ
+cJ
+dl
+vi
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+KL
+ab
+fK
+fK
+fK
+fK
+fK
+fK
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(255,1,1) = {"
+ab
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+ab
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+bj
+ab
+av
+av
+av
+av
+av
+av
+av
+av
+av
+av
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -30,9 +30,9 @@
 /datum/ert/deathsquad
 	roles = list(/datum/antagonist/ert/deathsquad)
 	leader_role = /datum/antagonist/ert/deathsquad/leader
-	rename_team = "Deathsquad"
+	rename_team = "Enclave Fireteam"
 	code = "Delta"
-	mission = "Leave no witnesses."
+	mission = "Leave no witnesses. Carry out the orders of your superior."
 	polldesc = "an elite Strike Team"
 
 /datum/ert/centcom_official

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -152,13 +152,13 @@
 
 /obj/item/encryptionkey/headset_bos
 	name = "Brotherhood radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Enclave channel, use :q."
+	desc = "An encryption key for a radio headset.  To access the Brotherhood channel, use :q."
 	icon_state = "cypherkey"
 	channels = list("BOS" = 1)
 
 /obj/item/encryptionkey/headset_enclave
 	name = "Enclave radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Brotherhood channel, use :z."
+	desc = "An encryption key for a radio headset.  To access the Enclave channel, use :z."
 	icon_state = "cypherkey"
 	channels = list("Enclave" = 1)
 

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -60,9 +60,9 @@
 	outfit = /datum/outfit/ert/commander/alert
 
 /datum/antagonist/ert/deathsquad
-	name = "Deathsquad Trooper"
+	name = "Enclave Soldier"
 	outfit = /datum/outfit/death_commando
-	role = "Trooper"
+	role = "Enclave Fireteam Unit"
 
 /datum/antagonist/ert/medic/inquisitor
 	outfit = /datum/outfit/ert/medic/inquisitor
@@ -89,9 +89,9 @@
 	owner.isholy = TRUE
 
 /datum/antagonist/ert/deathsquad/leader
-	name = "Deathsquad Officer"
+	name = "Enclave Officer"
 	outfit = /datum/outfit/death_commando
-	role = "Officer"
+	role = "Enclave Fireteam Officer"
 
 /datum/antagonist/ert/create_team(datum/team/ert/new_team)
 	if(istype(new_team))
@@ -131,9 +131,9 @@
 
 	to_chat(owner, "<B><font size=3 color=red>You are the [name].</font></B>")
 
-	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by Security Division."
+	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by the an Enclave Security Detachment."
 	if(leader) //If Squad Leader
-		missiondesc += " Lead your squad to ensure the completion of the mission. Board the shuttle when your team is ready."
+		missiondesc += " Lead your squad to ensure the completion of the mission. Board the Vertibird when your team is ready."
 	else
 		missiondesc += " Follow orders given to you by your squad leader."
 

--- a/code/modules/clothing/glasses/f13.dm
+++ b/code/modules/clothing/glasses/f13.dm
@@ -41,6 +41,10 @@
 	icon_state = "enclavegoggles"
 	item_state = "enclavegoggles"
 
+/obj/item/clothing/glasses/thermal/f13/enclave/dsquad
+	name = "\improper combat goggles"
+	desc = "Heat-sensitive goggles commonly worn by Enclave ground units."
+
 //Fallout 13 science goggles
 
 /obj/item/clothing/glasses/science/f13

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -367,27 +367,26 @@
 	mask = /obj/item/clothing/mask/breath
 
 /datum/outfit/death_commando
-	name = "Death Commando"
+	name = "Enclave Fireteam Unit"
 
-	uniform = /obj/item/clothing/under/color/green
-	suit = /obj/item/clothing/suit/space/hardsuit/deathsquad
+	head = /obj/item/clothing/head/helmet/f13/combat/enclave
+	uniform = /obj/item/clothing/under/f13/combat
+	suit = /obj/item/clothing/suit/armor/f13/combat/enclave
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	glasses = /obj/item/clothing/glasses/hud/toggle/thermal
+	glasses = /obj/item/clothing/glasses/thermal/f13/enclave/dsquad
 	back = /obj/item/storage/backpack/security
-	l_pocket = /obj/item/melee/transforming/energy/sword/saber
-	r_pocket = /obj/item/shield/energy
-	suit_store = /obj/item/tank/internals/emergency_oxygen
-	belt = /obj/item/gun/ballistic/revolver/mateba
-	r_hand = /obj/item/gun/energy/pulse/loyalpin
+	l_pocket = /obj/item/stock_parts/cell/ammo/mfc
+	r_pocket = /obj/item/stock_parts/cell/ammo/mfc
+	suit_store = /obj/item/gun/energy/laser/plasma/deathsquad
+	belt = /obj/item/gun/energy/laser/plasma/glock/extended/deathsquad
 	id = /obj/item/card/id
-	ears = /obj/item/radio/headset/headset_cent/alt
+	ears = /obj/item/radio/headset/headset_enclave
 
 	backpack_contents = list(/obj/item/storage/box=1,\
-		/obj/item/ammo_box/a357=1,\
+		/obj/item/stock_parts/cell/ammo/ec=2,\
 		/obj/item/storage/firstaid/regular=1,\
-		/obj/item/storage/box/flashbangs=1,\
 		/obj/item/flashlight=1,\
 		/obj/item/grenade/plastic/x4=1)
 
@@ -407,13 +406,16 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()//They get full station access.
 	W.access += get_centcom_access("Death Commando")//Let's add their alloted CentCom access.
-	W.assignment = "Death Commando"
+	W.assignment = "Enclave Fireteam"
 	W.registered_name = H.real_name
 	W.update_label(W.registered_name, W.assignment)
 
 /datum/outfit/death_commando/officer
-	name = "Death Commando Officer"
-	head = /obj/item/clothing/head/helmet/space/beret
+	name = "Enclave Fireteam Officer"
+
+	suit = null
+	uniform = /obj/item/clothing/under/f13/enclave_officer
+	head = /obj/item/clothing/head/soft/f13/enclave
 
 /datum/outfit/chrono_agent
 	name = "Timeline Eradication Agent"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -205,6 +205,12 @@
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 
+/obj/item/gun/energy/laser/plasma/deathsquad
+	name ="modified plasma rifle"
+	desc = "This rifle appears to have a modified charging rail, permitting it to fire much faster."
+	pin = /obj/item/firing_pin/implant/mindshield
+	fire_delay = 1
+
 /obj/item/gun/energy/laser/plasma/scatter
 	name = "multiplas Rifle"
 	item_state = "multiplas"
@@ -256,6 +262,12 @@
 	weapon_weight = WEAPON_LIGHT
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
 	slot_flags = ITEM_SLOT_BELT
+
+/obj/item/gun/energy/laser/plasma/glock/extended/deathsquad
+	name ="modified glock 86a"
+	desc = "This sidearm appears to have a modified charging rail, permitting it to fire much faster."
+	pin = /obj/item/firing_pin/implant/mindshield
+	fire_delay = 1
 
 /obj/item/gun/energy/laser/wattz
 	name = "Wattz 1000 laser pistol"


### PR DESCRIPTION
Changes Deathsquad to be more in line with something thematically appropriate.
- - -
Edits:
 - Enclave Fireteam has replaced DS.
 - Minor edits to CentCom to remove overpowered laser weaponry from being readily accesible.