### PR TITLE
Removes erping dead/catatonic people

### DIFF
--- a/interactions/lewd/lewd_interactions.dm
+++ b/interactions/lewd/lewd_interactions.dm
@@ -125,8 +125,8 @@
 			if(target.client && target.client.prefs)
 				if(target.client.prefs.wasteland_toggles & VERB_CONSENT)
 					return TRUE
-				else
-					return FALSE
+			else
+				return FALSE
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## Description
Currently if the body doesn't have a client in it then it doesn't matter whether the player originally had erp verbs allowed or not, so a lot of people grief by killing someone to bypass the erp verb restriction. This PR will make it so that you can no longer use erp interactions on people without a client. This also means that you cant use erp interactions on humans that wouldn't normally have a client like the raider NPCs or maybe a slime copy of yourself but honestly at that point just use custom emotes if you really want to or you're probably just doing lrp shit if that's too hard. But if people want to still be able to diddle the raider npc's then I'll make it just check if the user is alive or not.

## Motivation and Context
Lots of people complaining about this, I've seen a few people from other servers who said they tried crashpoint but decided it wasn't for them because people were getting killed then erp'ed despite their erp toggle.

## How Has This Been Tested?
Yes I tested it on local. Spawn in, spawn human with no client, try to erp, you cannot.

## Changelog
:cl: Sneakyrat
tweak: You can no longer use erp interactions on people who have ghosted
/:cl:
