### PR TITLE
slug rebalance/bullet description changes

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -784,7 +784,7 @@
 
 /obj/item/storage/box/slugshot
 	name = "box of slug shotgun shots"
-	desc = "A box full of slug rounds, designed for riot shotguns."
+	desc = "A box full of slug rounds, designed for riot shotguns. These have a limited range compared to buckshot, but no falloff."
 	icon_state = "slugshot_box"
 	illustration = null
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -1,18 +1,18 @@
 // 10mm
 /obj/item/ammo_casing/c10mm
 	name = "10mm FMJ bullet casing"
-	desc = "A 10mm full metal jacket bullet casing."
+	desc = "A 10mm full metal jacket bullet casing, used mostly in high-power semi-auto pistols."
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/c10mm
 
 /obj/item/ammo_casing/c10mm/ap
 	name = "10mm AP bullet casing"
-	desc = "A 10mm armor-piercing bullet casing."
+	desc = "A 10mm armor-piercing bullet casing, for use against armored targets."
 	projectile_type = /obj/item/projectile/bullet/c10mm/ap
 
 /obj/item/ammo_casing/c10mm/hp
 	name = "10mm JHP bullet casing"
-	desc = "A 10mm jacketed hollow point bullet casing."
+	desc = "A 10mm jacketed hollow point bullet casing, for use against unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/c10mm/hp
 
 /*
@@ -25,18 +25,18 @@
 // 9x19mm
 /obj/item/ammo_casing/c9mm
 	name = "9mm FMJ bullet casing"
-	desc = "A 9mm full metal jacket bullet casing."
+	desc = "A 9mm full metal jacket bullet casing, used in low-power semi-auto pistols."
 	caliber = "9mm"
 	projectile_type = /obj/item/projectile/bullet/c9mm
 
 /obj/item/ammo_casing/c9mm/ap
 	name = "9mm AP bullet casing"
-	desc = "A 9mm armor-piercing bullet casing."
+	desc = "A 9mm armor-piercing bullet casing, why are you even crafting this?"
 	projectile_type = /obj/item/projectile/bullet/c9mm/ap
 
 /obj/item/ammo_casing/c9mm/jhp
 	name = "9mm JHP bullet casing"
-	desc = "A 9mm jacketed hollow point bullet casing."
+	desc = "A 9mm jacketed hollow point bullet casing, great work making the worst ammo in the game."
 	projectile_type = /obj/item/projectile/bullet/c9mm/jhp
 
 /*
@@ -49,25 +49,25 @@
 // .22lr
 /obj/item/ammo_casing/c22
 	name = ".22 bullet casing"
-	desc = "A .22 bullet casing."
+	desc = "A .22 bullet casing, for when you want to tickle a lion."
 	caliber = ".22"
 	projectile_type = /obj/item/projectile/bullet/c22
 
 // .45 ACP
 /obj/item/ammo_casing/c45
 	name = ".45 FMJ bullet casing"
-	desc = "A .45 full metal jacket bullet casing."
+	desc = "A .45 full metal jacket bullet casing, used in high powered pistols and submachine guns."
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/c45
 
 /obj/item/ammo_casing/c45/jhp
 	name = ".45 JHP bullet casing"
-	desc = "A .45 jacketed hollow point bullet casing."
+	desc = "A .45 jacketed hollow point bullet casing, for use against unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/c45/jhp
 
 // .50 AE
 /obj/item/ammo_casing/a50AE
 	name = ".50AE bullet casing"
-	desc = "A .50AE bullet casing."
+	desc = "A .50AE bullet casing, used in really fucking high power hand canons."
 	caliber = "50AE"
 	projectile_type = /obj/item/projectile/bullet/a50AE

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -1,41 +1,41 @@
 // .45-70 Gov't
 /obj/item/ammo_casing/c4570
 	name = ".45-70 FMJ bullet casing"
-	desc = "A .45-70 full metal jacket bullet casing."
+	desc = "A .45-70 full metal jacket bullet casing, typically used in high-power revolvers and lever-action rifles."
 	caliber = "4570"
 	projectile_type = /obj/item/projectile/bullet/c4570
 
 /obj/item/ammo_casing/c4570/jhp
 	name = ".45-70 JHP bullet casing"
-	desc = "A .45-70 jacketed hollow point bullet casing."
+	desc = "A .45-70 jacketed hollow point bullet casing, for use with unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/c4570/jhp
 
 // .44 magnum
 /obj/item/ammo_casing/m44
 	name = ".44 magnum FMJ bullet casing"
-	desc = "A .44 magnum full metal jacket bullet casing."
+	desc = "A .44 magnum full metal jacket bullet casing, typically used in high-power revolvers and lever-action rifles."
 	caliber = "44"
 	projectile_type = /obj/item/projectile/bullet/m44
 
 /obj/item/ammo_casing/m44/jhp
 	name = ".44 magnum JHP bullet casing"
-	desc = "A .44 magnum jacketed hollow point bullet casing."
+	desc = "A .44 magnum jacketed hollow point bullet casing, for use with unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/m44/jhp
 
 // .357 magnum, .38 special
 /obj/item/ammo_casing/a357
 	name = ".357 magnum FMJ bullet casing"
-	desc = "A .357 magnum full metal jacket bullet casing."
+	desc = "A .357 magnum full metal jacket bullet casing, typically used in medium-power revolvers and lever-action rifles."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/a357
 
 /obj/item/ammo_casing/a357/jhp
 	name = ".357 magnum JHP bullet casing"
-	desc = "A .357 magnum jacketed hollow point bullet casing."
+	desc = "A .357 magnum jacketed hollow point bullet casing, for use with unarmored targets."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/a357/jhp
 
 /obj/item/ammo_casing/a357/c38
 	name = ".38 Spl. bullet casing"
-	desc = "A .38 special bullet casing."
+	desc = "A .38 special bullet casing, used in select .357 revolvers incase you don't want to over-penetrate your target."
 	projectile_type = /obj/item/projectile/bullet/a38

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -10,48 +10,48 @@
 // 5.56x45mm
 /obj/item/ammo_casing/a556
 	name = "5.56x45 FMJ bullet casing"
-	desc = "A 5.56x45mm full metal jacket bullet casing."
+	desc = "A 5.56x45mm full metal jacket bullet casing, typically used in medium-power rifles."
 	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/a556
 
 /obj/item/ammo_casing/a556/ap
 	name = "5.56x45 AP bullet casing"
-	desc = "A 5.56x45mm armor piercing bullet casing."
+	desc = "A 5.56x45mm armor piercing bullet casing, for use with armored targets."
 	projectile_type = /obj/item/projectile/bullet/a556/ap
 
 /obj/item/ammo_casing/a556/jhp
 	name = "5.56x45 JHP bullet casing"
-	desc = "A 5.56x45mm jacketed hollow point bullet casing."
+	desc = "A 5.56x45mm jacketed hollow point bullet casing, for use with unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/a556/jhp
 
 // 7.62x51, .308 Winchester
 /obj/item/ammo_casing/a762
 	name = "7.62x51 FMJ bullet casing"
-	desc = "A 7.62x51 full metal jacket bullet casing."
+	desc = "A 7.62x51 full metal jacket bullet casing, typically used in high-power, long range rifles."
 	icon_state = "762-casing"
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/ap
 	name = "7.62x51 AP bullet casing"
-	desc = "A 7.62x51 armor piercing bullet casing."
+	desc = "A 7.62x51 armor piercing bullet casing, for use with armored targets."
 	projectile_type = /obj/item/projectile/bullet/a762/ap
 
 /obj/item/ammo_casing/a762/jhp
 	name = "7.62x51 JHP bullet casing"
-	desc = "A 7.62x51 jacketed hollow point bullet casing."
+	desc = "A 7.62x51 jacketed hollow point bullet casing, for use with unarmored targets."
 	projectile_type = /obj/item/projectile/bullet/a762/jhp
 
 // 2mm EC
 /obj/item/ammo_casing/c2mm
 	name = "2mm gauss projectile casing"
-	desc = "A 2mm gauss projectile casing."
+	desc = "A 2mm gauss projectile casing, used solely in gauss rifles."
 	caliber = "2mm"
 	projectile_type = /obj/item/projectile/bullet/c2mm
 
 
 /obj/item/ammo_casing/F13/m308
-	desc = "A .308 bullet casing."
+	desc = "A .308 bullet casing, the goto high-power rifle caliber."
 	caliber = "308mm"
 	icon_state = "762-casing"
 	projectile_type = /obj/item/projectile/bullet/F13/c308mmBullet

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -2,7 +2,7 @@
 
 /obj/item/ammo_casing/shotgun
 	name = "12 gauge slug"
-	desc = "A 12 gauge lead slug."
+	desc = "A 12 gauge lead slug, meant to blow holes through armor and people at a limited range."
 	icon_state = "blshell"
 	caliber = "shotgun"
 	projectile_type = /obj/item/projectile/bullet/shotgun_slug
@@ -10,7 +10,7 @@
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "12 gauge beanbag slug"
-	desc = "A weak beanbag slug for riot control."
+	desc = "A beanbag slug for riot control used to incapacitate single, large targets."
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/shotgun_beanbag
 
@@ -57,7 +57,7 @@
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "12 gauge buckshot shell"
-	desc = "A 12 gauge buckshot shell."
+	desc = "A 12 gauge buckshot shell, best to point-blank for full effect."
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 7
@@ -65,7 +65,7 @@
 
 /obj/item/ammo_casing/shotgun/magnumshot
 	name = "12 gauge magnum buckshot shell"
-	desc = "A 12 gauge magnum buckshot shell."
+	desc = "A 12 gauge magnum buckshot shell, holding a more powerful load than typical buckshot."
 	icon_state = "magshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/magnum_buckshot
 	pellets = 7

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -2,7 +2,7 @@
 
 /obj/item/ammo_casing/p50
 	name = ".50 BMG bullet casing"
-	desc = "A .50 bullet casing."
+	desc = "A .50 bullet casing, for use in high-caliber sniper rifles."
 	caliber = ".50"
 	projectile_type = /obj/item/projectile/bullet/p50
 	icon_state = ".50"
@@ -21,21 +21,21 @@
 
 /obj/item/ammo_casing/a50MG
 	name = ".50MG bullet casing"
-	desc = "A .50MG bullet casing."
+	desc = "A .50MG bullet casing, used in mounted machine guns."
 	caliber = "a50MG"
 	icon_state = "50mg2"
 	projectile_type = /obj/item/projectile/bullet/a50MG
 
 /obj/item/ammo_casing/a50MG/incendiary
 	name = ".50 MG incendiary bullet casing"
-	desc = "A .50 MG incendiary bullet casing."
+	desc = "A .50 MG incendiary bullet casing, burn baby burn!"
 	icon_state = "50in2"
 	caliber = "a50MG"
 	projectile_type = /obj/item/projectile/bullet/a50MG/incendiary
 
 /obj/item/ammo_casing/a50MG/AP
 	name = ".50 MG AP bullet casing"
-	desc = "A .50 MG armor-piercing bullet casing."
+	desc = "A .50 MG armor-piercing bullet casing, for use against the brotherhood."
 	caliber = "a50MG"
 	icon_state = "50ap2"
 	projectile_type = /obj/item/projectile/bullet/a50MG/AP

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,13 +1,14 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 35
+	damage = 40
 	armour_penetration = 25
+	range = 7 //max range cuz slugs should do more damage than buckshot outside of PB, but not instantly buttfuck everything and just be objectively better at range, especially not better than literally any rifle.
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	damage = 0
 	stamina = 60
-	knockdown = 5//we'll try this a bit. Basically nothing, but it's just to knock you on your ass.
+	knockdown = 5 //we'll try this a bit. Basically nothing, but it's just to knock you on your ass.
 
 /obj/item/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -8,6 +8,7 @@
 	name = "beanbag slug"
 	damage = 0
 	stamina = 60
+	range = 7
 	knockdown = 5 //we'll try this a bit. Basically nothing, but it's just to knock you on your ass.
 
 /obj/item/projectile/bullet/incendiary/shotgun

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 50
-	armour_penetration = 20
+	damage = 35
+	armour_penetration = 25
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 40
-	armour_penetration = 25
+	armour_penetration = 15
 	range = 7 //max range cuz slugs should do more damage than buckshot outside of PB, but not instantly buttfuck everything and just be objectively better at range, especially not better than literally any rifle.
 
 /obj/item/projectile/bullet/shotgun_beanbag


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the slug from 50dam/20ap to 40/15 with 7 max range. Now, slugs are not objectively better than most rifles in the game and are instead just a situational alternative to buckshot. Buckshot is better when PBing unarmored targets, while slugs are better when fighting someone outside of PB range and with armor, but not at a capacity outside of what would be considered CQC. Buckshot has falloff, Slugs have a max range. Also, if the person you're fighting doesn't take advantage of the max range, you're effectively using a hunting rifle with a higher ammo cap and .308, although the riot shotgun is still autistically overpowered so whatever.

also adds small descriptions to most bullet types so you know what they go to or what they are used against.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Slugs are fucking retarded. It turns shotguns into, objectively, the best guns in the game. This hopefully fixes that.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
it compiles
## Changelog (necessary)
:cl:
balance: slugs
add: minor detail to bullets
/:cl:
