### PR TITLE
Cyborg speed nerf

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -52,7 +52,7 @@
 
 	var/alarms = list("Motion"=list(), "Fire"=list(), "Atmosphere"=list(), "Power"=list(), "Camera"=list(), "Burglar"=list())
 
-	var/speed = 1 // VTEC speed boost.
+	var/speed = 0.5 // VTEC speed boost.
 	var/magpulse = FALSE // Magboot-like effect.
 	var/ionpulse = FALSE // Jetpack-like effect.
 	var/ionpulse_on = FALSE // Jetpack-like effect.
@@ -991,7 +991,7 @@
 
 	upgrades.Cut()
 
-	speed = 0
+	speed = 0.5
 	ionpulse = FALSE
 	revert_shell()
 
@@ -1180,7 +1180,7 @@
 	scrambledcodes = TRUE // These are rogue borgs.
 	ionpulse = TRUE
 	braintype = "Robot"
-	speed = 1.5
+	speed = 0.5
 	var/playstyle_string = "<span class='userdanger'>You are a Syndicate assault cyborg!</span><br>\
 							<b>You are armed with powerful offensive tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
 							Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -4,7 +4,7 @@
 	return ..()
 
 /mob/living/silicon/robot/movement_delay()
-	. = ..()
+	. = 1
 	var/static/config_robot_delay
 	if(isnull(config_robot_delay))
 		config_robot_delay = CONFIG_GET(number/robot_delay)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
They now move the same speed as humans. Previously they had absolutely 0 movement delay, now it is the same as humans.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cyborgs were retardedly fast, no thanks!
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
locally
## Changelog (necessary)
:cl:
tweak: cyborg movemnettesaads
/:cl:
