### PR TITLE
Revert "Removes erping dead/catatonic people"

### DIFF
--- a/interactions/lewd/lewd_interactions.dm
+++ b/interactions/lewd/lewd_interactions.dm
@@ -125,8 +125,8 @@
 			if(target.client && target.client.prefs)
 				if(target.client.prefs.wasteland_toggles & VERB_CONSENT)
 					return TRUE
-			else
-				return FALSE
+				else
+					return FALSE
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Scuffed. Didn't realize it during test merges or looking over the code. Enables the ERP of people regardless of their preferences.

View #190.