### PR TITLE
Cyborg recharge stations

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -23031,9 +23031,9 @@
 "bmE" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+	icon_state = "floorrusty"
 	},
-/area/f13/ncr_main)
+/area/f13/sunny_dale)
 "bmF" = (
 /obj/structure/closet/crate/footlocker/ncr,
 /turf/open/floor/plasteel/f13{
@@ -29661,6 +29661,7 @@
 /area/f13/den)
 "bFR" = (
 /obj/machinery/light,
+/obj/machinery/recharge_station,
 /turf/open/floor/plating/f13/outside/road{
 	icon_state = "horizontalbottomborderbottom0"
 	},
@@ -39787,7 +39788,7 @@ bsB
 boq
 bvD
 vQi
-bmE
+vQi
 vQi
 vQi
 buA
@@ -47806,7 +47807,7 @@ aag
 abq
 aag
 bor
-bmE
+vQi
 vQi
 boq
 afp
@@ -67857,7 +67858,7 @@ bdm
 aOa
 bdJ
 baZ
-baZ
+bmE
 aOa
 big
 aHv

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16940,7 +16940,7 @@
 /area/f13/ahs)
 "aVg" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul,
+/mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/carpet,
 /area/f13/sunny_dale)
 "aVh" = (
@@ -17695,12 +17695,10 @@
 /area/f13/sunny_dale)
 "aXv" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
+/turf/open/floor/plasteel/dark,
 /area/f13/sunny_dale)
 "aXw" = (
-/mob/living/simple_animal/hostile/ghoul,
+/mob/living/simple_animal/hostile/handy,
 /turf/open/floor/plasteel/dark,
 /area/f13/sunny_dale)
 "aXx" = (
@@ -34409,6 +34407,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -35078,6 +35077,10 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/old,
 /area/f13/legioncamp)
+"ehR" = (
+/mob/living/simple_animal/hostile/ghoul/hot,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/desert)
 "ejZ" = (
 /turf/open/floor/wood/f13{
 	icon_state = "housewastelandnorth"
@@ -102418,7 +102421,7 @@ aZD
 baE
 aeE
 aHk
-baf
+aXv
 baf
 baf
 baf
@@ -133360,7 +133363,7 @@ aWK
 aWK
 aXI
 aYO
-aXv
+sRe
 aHF
 aZn
 aPi
@@ -147969,7 +147972,7 @@ aio
 abM
 aag
 aag
-aag
+ehR
 aag
 aag
 aag

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27070,7 +27070,7 @@
 	},
 /area/f13/prison)
 "bym" = (
-/obj/machinery/autolathe/hacked,
+/obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -34960,13 +34960,6 @@
 /obj/item/clothing/head/fluff/cowboy,
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr_main)
-"cth" = (
-/mob/living/simple_animal/hostile/ghoul/hot{
-	desc = "A feral ghoul that has absorbed massive amounts of cheeto dust and radiates cheesy air... It does not appear to be easy.";
-	name = "cheesy ghoul"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/desert)
 "czp" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/f13/outside/road{
@@ -35725,6 +35718,13 @@
 	icon_state = "floorgrime"
 	},
 /area/f13/mountain_bunker)
+"pmH" = (
+/mob/living/simple_animal/hostile/ghoul/hot{
+	desc = "A feral ghoul that has absorbed massive amounts of cheeto dust and radiates cheesy air... It does not appear to be easy.";
+	name = "cheesy ghoul"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/desert)
 "poX" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -147975,7 +147975,7 @@ aio
 abM
 aag
 aag
-cth
+pmH
 aag
 aag
 aag

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -34960,6 +34960,13 @@
 /obj/item/clothing/head/fluff/cowboy,
 /turf/open/floor/wood/f13/old,
 /area/f13/ncr_main)
+"cth" = (
+/mob/living/simple_animal/hostile/ghoul/hot{
+	desc = "A feral ghoul that has absorbed massive amounts of cheeto dust and radiates cheesy air... It does not appear to be easy.";
+	name = "cheesy ghoul"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/desert)
 "czp" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/f13/outside/road{
@@ -35077,10 +35084,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/wood/f13/old,
 /area/f13/legioncamp)
-"ehR" = (
-/mob/living/simple_animal/hostile/ghoul/hot,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/desert)
 "ejZ" = (
 /turf/open/floor/wood/f13{
 	icon_state = "housewastelandnorth"
@@ -147972,7 +147975,7 @@ aio
 abM
 aag
 aag
-ehR
+cth
 aag
 aag
 aag

--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -14379,11 +14379,16 @@
 /obj/item/reagent_containers/food/snacks/f13/steak,
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/village)
 "aNa" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/bunker)
 "aNb" = (
 /obj/structure/fence/corner{
 	dir = 4;
@@ -24434,10 +24439,14 @@
 	},
 /area/f13/village)
 "boC" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/recharge_station,
-/turf/open/floor/f13{
-	icon_state = "floorrusty";
-	tag = "icon-floorrusty"
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
 	},
 /area/f13/building)
 "boD" = (
@@ -24539,8 +24548,11 @@
 /area/f13/city)
 "boN" = (
 /obj/machinery/recharge_station,
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
+	},
+/area/f13/bunker)
 "boO" = (
 /obj/machinery/jukebox,
 /turf/open/floor/f13/wood,
@@ -24662,12 +24674,6 @@
 /obj/structure/kitchenspike/cross,
 /turf/open/floor/wood/f13/stage_tl,
 /area/f13/wasteland)
-"bph" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "bpi" = (
 /turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
@@ -50576,7 +50582,7 @@ aae
 aae
 aaa
 agk
-aWM
+boC
 acC
 acC
 acC
@@ -55714,7 +55720,7 @@ aae
 aae
 aae
 aHF
-boN
+aWu
 aWu
 aWu
 aWu
@@ -74351,7 +74357,7 @@ aaZ
 aaD
 afa
 aaL
-adB
+aNa
 aaD
 aae
 aae
@@ -75060,7 +75066,7 @@ acv
 acv
 bhV
 bmy
-bph
+afS
 afS
 afS
 agk
@@ -75162,7 +75168,7 @@ agk
 agk
 atJ
 aqa
-boC
+aqa
 agk
 acm
 aft
@@ -80908,10 +80914,10 @@ aat
 aat
 aat
 awE
-aat
-adN
-adN
-adN
+ane
+aaQ
+aaQ
+aaQ
 aPp
 aJl
 aJl
@@ -81165,10 +81171,10 @@ aat
 aat
 aat
 awE
-aat
-adN
+ane
+aaQ
 aMZ
-aNa
+aNU
 aPp
 aGR
 aJl
@@ -81422,10 +81428,10 @@ aat
 aat
 aat
 awE
-aat
-adN
-adN
-adN
+ane
+aaQ
+aaQ
+aaQ
 aPp
 aGR
 aJl
@@ -81679,10 +81685,10 @@ aat
 aat
 aat
 awE
-aat
-aat
-aat
-aat
+ane
+ane
+ane
+ane
 aPB
 aYD
 aYD
@@ -94795,7 +94801,7 @@ aZj
 aZj
 bbB
 bbL
-aZj
+boN
 aaD
 aae
 aae


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes around the cyborg recharge stations on both maps to make more sense, with the exception being that the town has one always.
Removes the cyborg recharge stations from the NCR base on sunnydale and places them elsewhere in places that make some kind of sense. The NCR started with 2 of the previous 4 total on the map. The farm location now has robots in it, so the recharger there makes sense. Also, finally, places a cheeto ghoul in the prison.
also fixed a random retarded area placement on pahrump.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I hate powergamers and like consistency. If its an area where robots are, there is probably a place where robots can recharge.
## Changelog (necessary)
:cl:
tweak: cyborg stations
fix: farm area
add: cheeto ghoul
/:cl:
