### PR TITLE
Tribal loadout for Wastelander role

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -252,7 +252,8 @@ Wastelander
 	/datum/outfit/loadout/petro,
 	/datum/outfit/loadout/follower,
 	/datum/outfit/loadout/merchant,
-	/datum/outfit/loadout/gambler)
+	/datum/outfit/loadout/gambler,
+	/datum/outfit/loadout/tribal)
 
 /datum/outfit/job/wasteland/f13wastelander
 	name = "Wastelander"
@@ -330,6 +331,12 @@ Wastelander
 	head = list(/obj/item/clothing/head/fedora,
  	/obj/item/clothing/head/f13/gambler)
 
+/datum/outfit/loadout/tribal
+	name = "Tribal"
+	uniform = /obj/item/clothing/under/f13/tribe
+	suit = /obj/item/clothing/suit/armor/f13/tribal
+	shoes = /obj/item/clothing/shoes/f13/rag
+	gloves = /obj/item/clothing/gloves/f13/handwraps
 
 /*
 Punished Raider


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the new "Tribal" outfit loadout for Wastelanders. 
The Tribal kit includes:
 * Tribal Armor - Suit
 * Tribal Rags - Uniform
 * Handwraps - Gloves
 * Foot Rags - Shoes
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I quite enjoy playing as a tribal and since the tribal job is currently not used, this offers players a way to play as a tribal right off the bat instead of having to craft the armor. Breaks immersion to spawn in with normal waster clothes as a tribal character. Also offers more opportunities for roleplay!

## Changelog (necessary)
:cl:
add: Tribal loadout added for Wastelanders.
/:cl:
