### PR TITLE
FEV Changes

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -335,6 +335,17 @@
 	results = list("fluorosurfactant" = 5)
 	required_reagents = list("fluorine" = 2, "carbon" = 2, "sacid" = 1)
 
+/datum/chemical_reaction/FEV_surfactant_burn
+	name = "FEV_Surfactant_Burn"
+	id = "fev_surfactant_burn"
+	required_reagents = list("FEV_solution" = 1, "smoke_powder" = 1)
+
+/datum/chemical_reaction/FEV_surfactant_burn/on_reaction(datum/reagents/holder, created_volume)
+	var/turf/T = get_turf(holder.my_atom)
+	for(var/turf/turf in range(1,T))
+		new /obj/effect/hotspot(turf)
+	holder.clear_reagents()
+
 /datum/chemical_reaction/foam
 	name = "Foam"
 	id = "foam"
@@ -342,6 +353,12 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
+	if(holder.has_reagent("FEV_solution"))
+		var/turf/T = get_turf(holder.my_atom)
+		for(var/turf/turf in range(1,T))
+			new /obj/effect/hotspot(turf)
+		holder.clear_reagents()
+		return
 	var/location = get_turf(holder.my_atom)
 	for(var/mob/M in viewers(5, location))
 		to_chat(M, "<span class='danger'>The solution spews out foam!</span>")

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -43,6 +43,22 @@
 	required_temp = 474
 	strengthdiv = 2
 
+/datum/chemical_reaction/reagent_explosion/FEV_potassium_explosion
+	name = "FEV_Explosion"
+	id = "fev_potassium_explosion"
+	required_reagents = list("FEV_solution" = 1, "potassium" = 1)
+	strengthdiv = 10
+
+/datum/chemical_reaction/FEV_smoke_burn
+	name = "FEV_Smoke_Burn"
+	id = "fev_smoke_burn"
+	required_reagents = list("FEV_solution" = 1, "smoke_powder" = 1)
+
+/datum/chemical_reaction/FEV_smoke_burn/on_reaction(datum/reagents/holder, created_volume)
+	var/turf/T = get_turf(holder.my_atom)
+	for(var/turf/turf in range(1,T))
+		new /obj/effect/hotspot(turf)
+	holder.clear_reagents()
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	name = "Explosion"
@@ -248,6 +264,12 @@
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 
 /datum/chemical_reaction/smoke_powder/on_reaction(datum/reagents/holder, created_volume)
+	if(holder.has_reagent("FEV_solution"))
+		var/turf/T = get_turf(holder.my_atom)
+		for(var/turf/turf in range(1,T))
+			new /obj/effect/hotspot(turf)
+		holder.clear_reagents()
+		return
 	if(holder.has_reagent("stabilizing_agent"))
 		return
 	holder.remove_reagent("smoke_powder", created_volume*3)
@@ -270,6 +292,12 @@
 	mob_react = FALSE
 
 /datum/chemical_reaction/smoke_powder_smoke/on_reaction(datum/reagents/holder, created_volume)
+	if(holder.has_reagent("FEV_solution"))
+		var/turf/T = get_turf(holder.my_atom)
+		for(var/turf/turf in range(1,T))
+			new /obj/effect/hotspot(turf)
+		holder.clear_reagents()
+		return
 	var/location = get_turf(holder.my_atom)
 	var/smoke_radius = round(sqrt(created_volume / 2), 1)
 	var/datum/effect_system/smoke_spread/chem/S = new

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -80,7 +80,7 @@
 /obj/item/reagent_containers/glass/bottle/FEV_solution
 	name = " FEV bottle"
 	desc = "A small vial of the Forced Evolutionary Virus. You think that consuming this would be a bad idea."
-	list_reagents = list("FEV_solution" = 30)
+	list_reagents = list("FEV_solution" = 1, "virusfood" = 29)
 
 /obj/item/reagent_containers/glass/bottle/plasma
 	name = "liquid ultracite bottle"
@@ -316,8 +316,8 @@
 	volume = 60
 	list_reagents = list("blackpowder" = 60)
 
-/obj/item/reagent_containers/glass/bottle/antivenom 
+/obj/item/reagent_containers/glass/bottle/antivenom
 	name = "Antivenom bottle"
 	desc = "Antivenom is modern medicine's answer to the tribal antidote by combining barral cactus fruit, xander root, and a venom gland from a cazador or radscorpion, which acts as a cure against animal venom."
 	icon_state = "bottle_antivenom"
-	list_reagents = list("antivenom" = 30) 
+	list_reagents = list("antivenom" = 30)


### PR DESCRIPTION
## Description
Reduces FEV in FEV bottles to 1u and removes the possibility of making FEV smoke or foam grenades.

## Motivation and Context
People obviously can't be responsible with FEV.

## How Has This Been Tested?
Each reaction added has been tested in-game, including in grenades, and the FEV bottle was checked to ensure it only contains 1u of FEV and 29u of virus food.

## Changelog (necessary)
:cl:
add: Added explosion reaction between FEV and potassium.
add: Added fire explosion reaction between FEV and smoke powder or fluorosurfactant.
del: Removed old things
tweak: FEV bottles now contain 1u FEV and 29u Virus food.
/:cl:
