### PR TITLE
General Rebalances

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1744,11 +1744,10 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/legioncamp)
 "afC" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plasteel/f13{
-	icon_state = "dark"
-	},
-/area/f13/legioncamp)
+/obj/effect/decal/waste,
+/turf/open/floor/wood/f13/old,
+/turf/open/floor/plating/f13/inside/mountain,
+/area/f13/underground/mountain)
 "afD" = (
 /turf/closed/wall/r_wall,
 /area/f13/klamat/mine)
@@ -18705,6 +18704,7 @@
 /area/f13/sunny_dale)
 "bav" = (
 /obj/machinery/light,
+/obj/structure/closet/hazard,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -23029,10 +23029,12 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/legioncamp)
 "bmE" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
+/obj/structure/table,
+/obj/item/circular_saw,
+/obj/item/scalpel,
+/obj/item/surgicaldrill,
+/obj/item/razor,
+/turf/open/floor/plasteel/cafeteria,
 /area/f13/ncr_main)
 "bmF" = (
 /obj/structure/closet/crate/footlocker/ncr,
@@ -23041,9 +23043,14 @@
 	},
 /area/f13/ncr_main)
 "bmG" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/wood/f13/old,
-/area/f13/den)
+/obj/structure/spacevine{
+	name = "Mutant Vines"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "ruinswindowbrokenvertical"
+	},
+/area/f13/desert)
 "bmH" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/f13{
@@ -23055,10 +23062,11 @@
 /turf/open/floor/plating,
 /area/f13/brotherhood)
 "bmJ" = (
-/obj/effect/decal/waste,
-/turf/open/floor/wood/f13/old,
-/turf/open/floor/plating/f13/inside/mountain,
-/area/f13/underground/mountain)
+/obj/structure/closet/hazard,
+/turf/open/floor/plasteel/f13{
+	icon_state = "yellowdirtysolid"
+	},
+/area/f13/klamat/mine)
 "bmK" = (
 /obj/item/caution,
 /obj/item/caution,
@@ -23126,21 +23134,21 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/raider_mall)
 "bmV" = (
-/obj/structure/spacevine{
-	name = "Mutant Vines"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/turf/closed/wall/r_wall/f13composite{
-	icon_state = "ruinswindowbrokenvertical"
-	},
-/area/f13/desert)
-"bmW" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/space/basic,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/f13/powerplant)
+"bmW" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/hazard,
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/ncr_main)
 "bmX" = (
 /obj/item/disk/surgery/pacification,
 /turf/open/floor/plasteel/f13{
@@ -23153,6 +23161,12 @@
 /turf/closed/wall/r_wall/f13composite,
 /area/f13/desert)
 "bmZ" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/f13{
+	icon_state = "floorgrime"
+	},
+/area/f13/powerplant)
+"bna" = (
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
@@ -23161,7 +23175,7 @@
 	icon_state = "ruinswindowbroken"
 	},
 /area/f13/desert)
-"bna" = (
+"bnb" = (
 /obj/structure/spacevine{
 	name = "Mutant Vines"
 	},
@@ -24993,13 +25007,6 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/ncr_main)
-"bsy" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel,
-/obj/item/surgicaldrill,
-/turf/open/floor/plasteel/cafeteria,
-/area/f13/ncr_main)
 "bsz" = (
 /obj/structure/table,
 /obj/item/hemostat,
@@ -25189,13 +25196,12 @@
 	},
 /area/f13/ncr_main)
 "bsZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light,
+/obj/structure/closet/hazard,
 /turf/open/floor/plating/f13/outside/road{
-	icon_state = "horizontaltopbordertop0"
+	icon_state = "horizontalbottomborderbottom0"
 	},
-/area/f13/ncr_main)
+/area/f13/sunny_dale)
 "bta" = (
 /obj/structure/rack,
 /turf/open/floor/plating/f13/outside/road{
@@ -26366,12 +26372,6 @@
 /obj/structure/closet,
 /obj/item/clothing/under/sl_suit,
 /obj/item/clothing/shoes/laceup,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/powerplant)
-"bwm" = (
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/f13{
 	icon_state = "floorgrime"
 	},
@@ -29659,12 +29659,6 @@
 /obj/item/dice,
 /turf/open/floor/wood/f13/old,
 /area/f13/den)
-"bFR" = (
-/obj/machinery/light,
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/sunny_dale)
 "bFS" = (
 /obj/item/clothing/suit/armor/f13/brokenpa,
 /obj/item/storage/trash_stack,
@@ -38577,7 +38571,7 @@ scY
 scY
 brP
 scY
-bsy
+bmE
 boq
 bsS
 vQi
@@ -39787,7 +39781,7 @@ bsB
 boq
 bvD
 vQi
-bmE
+vQi
 vQi
 vQi
 buA
@@ -47806,7 +47800,7 @@ aag
 abq
 aag
 bor
-bmE
+vQi
 vQi
 boq
 afp
@@ -49433,7 +49427,7 @@ brW
 boq
 aFW
 boq
-bsZ
+bmW
 bsV
 bRc
 bRc
@@ -62308,7 +62302,7 @@ boT
 boQ
 boQ
 btb
-bwm
+bmZ
 bwF
 bxb
 boQ
@@ -64327,7 +64321,7 @@ byd
 btb
 byF
 byG
-bmW
+bmV
 bqt
 bzY
 boQ
@@ -78640,7 +78634,7 @@ aab
 aab
 aKh
 aKh
-bmJ
+afC
 aab
 aab
 aaf
@@ -79442,7 +79436,7 @@ aaf
 aaf
 aaf
 aab
-bmJ
+afC
 aKh
 aKh
 aab
@@ -79846,7 +79840,7 @@ aaf
 aab
 aab
 aKh
-bmJ
+afC
 aab
 aaf
 aaf
@@ -88973,7 +88967,7 @@ agZ
 bxl
 ahK
 agO
-agR
+bmJ
 afD
 aaf
 aaf
@@ -101737,8 +101731,8 @@ brA
 brA
 aaZ
 abg
-bmZ
 bna
+bnb
 aaz
 aaI
 aag
@@ -107752,7 +107746,7 @@ aaI
 brC
 aeO
 bst
-bmZ
+bna
 bls
 aze
 aaZ
@@ -111752,8 +111746,8 @@ aaU
 aDU
 aCN
 aaU
-bmV
-bmV
+bmG
+bmG
 aaU
 aaI
 bhQ
@@ -115013,7 +115007,7 @@ bET
 bET
 bET
 bET
-bFR
+bsZ
 aHk
 aab
 aab
@@ -118982,8 +118976,8 @@ aag
 aag
 aze
 brA
-bmV
-bmV
+bmG
+bmG
 aaU
 aaU
 aFp
@@ -130499,7 +130493,7 @@ aGG
 aGG
 aLB
 aGG
-bmG
+aGG
 aGq
 afp
 afp
@@ -141589,7 +141583,7 @@ aag
 aag
 aag
 aam
-afC
+aMJ
 aMJ
 aMJ
 aMJ

--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -18401,6 +18401,10 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"aYC" = (
+/obj/structure/closet/hazard,
+/turf/open/floor/plating/tunnel,
+/area/f13/ncr)
 "aYD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -18823,6 +18827,13 @@
 	tag = "icon-housewood3-broken"
 	},
 /area/f13/village)
+"aZD" = (
+/obj/structure/closet/hazard,
+/turf/open/floor/f13{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
+	},
+/area/f13/bunker)
 "aZE" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13/wood,
@@ -24537,10 +24548,6 @@
 	tag = "icon-bluedirtychess2"
 	},
 /area/f13/city)
-"boN" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/wood/f13/old,
-/area/f13/village)
 "boO" = (
 /obj/machinery/jukebox,
 /turf/open/floor/f13/wood,
@@ -24726,13 +24733,6 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bps" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/f13{
-	icon_state = "floorrusty";
-	tag = "icon-floorrusty"
-	},
-/area/f13/city)
 "bpt" = (
 /obj/machinery/door/morgue,
 /turf/open/floor/f13/wood,
@@ -25602,6 +25602,14 @@
 	tag = "icon-bluedirtychess2"
 	},
 /area/f13/city)
+"brN" = (
+/obj/structure/closet/hazard,
+/turf/open/floor/plasteel/barber{
+	icon = 'icons/turf/f13floors2.dmi';
+	icon_state = "bluerustychess2";
+	tag = "icon-bluerustychess2"
+	},
+/area/f13/building)
 "brO" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -25622,6 +25630,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"brR" = (
+/obj/structure/closet/hazard,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "brS" = (
 /turf/closed/indestructible/vaultdoor{
 	desc = "One of the doors to enter and exit the aircraft. This one appears jammed, or perhaps welded shut.";
@@ -42922,7 +42936,7 @@ aBZ
 aTw
 aBZ
 aEl
-bps
+aGv
 aGv
 aGv
 aEl
@@ -49060,7 +49074,7 @@ agk
 bed
 acC
 acC
-bed
+brN
 agk
 adH
 adY
@@ -53516,7 +53530,7 @@ aae
 aae
 aae
 bDY
-ajb
+aYC
 ajb
 ajb
 ajU
@@ -55714,7 +55728,7 @@ aae
 aae
 aae
 aHF
-boN
+aWu
 aWu
 aWu
 aWu
@@ -94795,7 +94809,7 @@ aZj
 aZj
 bbB
 bbL
-aZj
+aZD
 aaD
 aae
 aae
@@ -96977,7 +96991,7 @@ ahM
 ahj
 afz
 afS
-aiz
+brR
 afz
 aat
 aat
@@ -97490,7 +97504,7 @@ agD
 ahN
 afS
 afz
-afS
+aiz
 aiB
 afz
 aat

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -136,6 +136,26 @@
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
 
+//Hazard closet. Much better in every way to Biosuits and Radsuits.
+/obj/structure/closet/hazard
+	name = "hazard suit closet"
+	desc = "It's a storage unit for hazard suits."
+	icon_state = "eng"
+	icon_door = "eng_rad"
+
+/obj/structure/closet/hazard/PopulateContents()
+	..()
+	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/clothing/mask/gas(src)
+	new /obj/item/tank/internals/oxygen(src)
+	new /obj/item/tank/internals/oxygen(src)
+	new /obj/item/geiger_counter(src)
+	new /obj/item/geiger_counter(src)
+	new /obj/item/clothing/suit/bio_suit/f13/hazmat(src)
+	new /obj/item/clothing/head/bio_hood/f13/hazmat(src)
+	new /obj/item/clothing/suit/bio_suit/f13/hazmat(src)
+	new /obj/item/clothing/head/bio_hood/f13/hazmat(src)
+
 /*
  * Bombsuit closet
  */

--- a/code/modules/clothing/suits/f13.dm
+++ b/code/modules/clothing/suits/f13.dm
@@ -138,7 +138,15 @@
 	icon = 'icons/fallout/clothing/suits.dmi'
 	icon_state = "hazmat"
 	item_state = "hazmat_suit"
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/geiger_counter)
+	armor = list("melee" = 15, "bullet" = 15, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 100)
+	strip_delay = 75
+	equip_delay_other = 75
 
+/obj/item/clothing/suit/bio_suit/f13/hazmat/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
+	
 /obj/item/clothing/head/bio_hood/f13/hazmat
 	name = "hazmat hood"
 	desc = "My star, my perfect silence."
@@ -146,9 +154,14 @@
 	icon_state = "hazmat"
 	item_state = "hazmat_helmet"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	armor = list("melee" = 15, "bullet" = 15, "laser" = 5,"energy" = 5, "bomb" = 5, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 100)
+	strip_delay = 75
+	equip_delay_other = 75
 
-
-
+/obj/item/clothing/head/bio_hood/f13/hazmat/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/rad_insulation, RAD_NO_INSULATION, TRUE, FALSE)
+	
 //Fallout 13 toggle apparel directory
 
 /obj/item/clothing/suit/toggle/labcoat/f13

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -341,11 +341,11 @@ Corporal
 	name = "Scout"
 	uniform = /obj/item/clothing/under/f13/ncr/scout
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/scout
-	suit_store = /obj/item/gun/ballistic/shotgun/remington/scoped
+	suit_store = /obj/item/gun/ballistic/automatic/marksman/servicerifle
 	head = /obj/item/clothing/head/beret/ncr_scout
 	shoes = /obj/item/clothing/shoes/f13/military/ncr_scout
 	backpack_contents = list(
-		/obj/item/ammo_box/a762=3,
+		/obj/item/ammo_box/magazine/m556/rifle=2,
 		/obj/item/twohanded/binocs=1)
 /*
 NCR Heavy Trooper

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -29,7 +29,7 @@
 	id = "FEV_solution"
 	description = "An incredibly lethal strain of the Forced Evolutionary Virus. Consume at your own risk."
 	color = "#00FF00"
-	toxpwr = 5
+	toxpwr = 0.5//Does its damage elsewhere.
 	taste_description = "slime"
 	taste_mult = 0.9
 
@@ -45,8 +45,8 @@
 	..()
 
 /datum/reagent/toxin/FEV_solution/on_mob_life(mob/living/carbon/C)
-	C.apply_effect(30,EFFECT_IRRADIATE,0)
-	C.adjustCloneLoss(30,0)
+	C.apply_effect(120,EFFECT_IRRADIATE,0)
+	C.adjustCloneLoss(5,0)
 	return ..()
 
 /datum/reagent/toxin/plasma


### PR DESCRIPTION
- - -
Edits:
 - Hazmat suit now available, replacing both the Radsuit and Biosuit in everything. They're rarer than the aforementioned, however, so use them properly.
 - FEV is now much more deadly in regards to radiation build up, but doesn't immediately put you into cellular crit now. At least, it shouldn't. This is alongside it having near no toxin power, as that wasn't the point of it in the first place. Especially not at FIVE.
 - Scout Specialist of the NCR has lost their scoped rifle. They retain the binoculars.
 - A shaving razor has been added to Sunnydale for the NCR. Start enforcing hair restrictions.
 - Recharger stations made less common. Borgs now have a reason to ration cell charge until late round.