### PR TITLE
Ghoul Buffs

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -17,6 +17,8 @@ Ask ninjanomnom if they're around
 													// WARNING: This number is highly sensitive to change, graph is first for best results
 #define RAD_BURN_THRESHOLD 250						// Applied radiation must be over this to burn
 
+#define RAD_MOB_HEAL 50								// How much stored radiation in a ghoul for them to start healing
+
 #define RAD_MOB_SAFE 125							// How much stored radiation in a mob with no ill effects
 
 #define RAD_MOB_HAIRLOSS 550						// How much stored radiation to check for hair loss


### PR DESCRIPTION
- - -
Additions:
 - Ghouls may now drink radium to heal. This stacks with what's to follow.
 - Ghouls, when irradiated, now heal over time at a good pace. You may stack this with radium, alongside the fact that the only way to become irradiated is to consume radioactive material.
 - Glowing Ones now properly emit radiation.
