### PR TITLE
Various bug fixes

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -18,11 +18,13 @@
 	var/item_recycle_sound = 'sound/items/welder.ogg'
 
 /obj/machinery/recycler/Initialize()
-	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_URANIUM, MAT_BANANIUM, MAT_TITANIUM, MAT_BLUESPACE, MAT_PLASTIC), INFINITY, FALSE, null, null, null, TRUE)
-	AddComponent(/datum/component/butchering, 1, amount_produced,amount_produced/5)
 	. = ..()
 	update_icon()
 	req_one_access = get_all_accesses() + get_all_centcom_access()
+
+/obj/machinery/recycler/ComponentInitialize()
+	AddComponent(/datum/component/material_container, list(MAT_METAL, MAT_GLASS, MAT_PLASMA, MAT_SILVER, MAT_GOLD, MAT_DIAMOND, MAT_URANIUM, MAT_BANANIUM, MAT_TITANIUM, MAT_BLUESPACE, MAT_PLASTIC), INFINITY, FALSE, null, null, null, TRUE)
+	AddComponent(/datum/component/butchering, 1, amount_produced,amount_produced/5)
 
 /obj/machinery/recycler/RefreshParts()
 	var/amt_made = 0

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -16,7 +16,7 @@
 	var/drill_delay = 7
 	var/drill_level = DRILL_BASIC
 
-/obj/item/mecha_parts/mecha_equipment/drill/Initialize()
+/obj/item/mecha_parts/mecha_equipment/drill/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 50, 100)
 

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -229,7 +229,7 @@
 				/obj/item/clothing/head/helmet/f13/raider/yankee
 				)
 	var/loot7 = list(
-				/obj/item/clothing/suit/armor/f13/badlands,
+				/obj/item/clothing/suit/armor/f13/raider/badlands,
 				/obj/item/clothing/head/helmet/f13/fiend
 				)
 	var/loot8 = list(

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -379,7 +379,7 @@
 	sharpness = IS_SHARP
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
 
-/obj/item/nullrod/scythe/Initialize()
+/obj/item/nullrod/scythe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 70, 110) //the harvest gives a high bonus chance
 
@@ -487,7 +487,7 @@
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 
-/obj/item/nullrod/chainsaw/Initialize()
+/obj/item/nullrod/chainsaw/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 30, 100, 0, hitsound)
 
@@ -558,7 +558,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = IS_SHARP
 
-/obj/item/nullrod/armblade/Initialize()
+/obj/item/nullrod/armblade/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 80, 70)
 
@@ -620,6 +620,9 @@
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+
+/obj/item/nullrod/tribal_knife/ComponentInitialize()
+	. = ..()
 	AddComponent(/datum/component/butchering, 50, 100)
 
 /obj/item/nullrod/tribal_knife/Destroy()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -74,7 +74,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	var/bayonet = FALSE	//Can this be attached to a gun?
 
-/obj/item/kitchen/knife/Initialize()
+/obj/item/kitchen/knife/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 80 - force, 100, force - 10) //bonus chance increases depending on force
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -44,7 +44,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP
 
-/obj/item/melee/synthetic_arm_blade/Initialize()
+/obj/item/melee/synthetic_arm_blade/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 80) //very imprecise
 
@@ -67,7 +67,7 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(MAT_METAL = 1000)
 
-/obj/item/melee/sabre/Initialize()
+/obj/item/melee/sabre/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 30, 95, 5) //fast and effective, but as a sword, it might damage the results.
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -253,8 +253,6 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 
 /obj/item/shard/Initialize()
 	. = ..()
-	AddComponent(/datum/component/caltrop, force)
-	AddComponent(/datum/component/butchering, 150, 65)
 	icon_state = pick("large", "medium", "small")
 	switch(icon_state)
 		if("small")
@@ -266,6 +264,11 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 		if("large")
 			pixel_x = rand(-5, 5)
 			pixel_y = rand(-5, 5)
+
+/obj/item/shard/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/caltrop, force)
+	AddComponent(/datum/component/butchering, 150, 65)
 
 /obj/item/shard/afterattack(atom/A as mob|obj, mob/user, proximity)
 	. = ..()

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -234,7 +234,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
 	resistance_flags = FIRE_PROOF
 
-/obj/item/twohanded/fireaxe/Initialize()
+/obj/item/twohanded/fireaxe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
 
@@ -475,7 +475,7 @@
 	var/obj/item/grenade/explosive = null
 	var/war_cry = "AAAAARGH!!!"
 
-/obj/item/twohanded/spear/Initialize()
+/obj/item/twohanded/spear/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 
@@ -621,7 +621,7 @@
 	actions_types = list(/datum/action/item_action/startchainsaw)
 	var/on = FALSE
 
-/obj/item/twohanded/required/chainsaw/Initialize()
+/obj/item/twohanded/required/chainsaw/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 30, 100, 0, 'sound/weapons/chainsawhit.ogg', TRUE)
 
@@ -799,7 +799,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
-/obj/item/twohanded/vibro_weapon/Initialize()
+/obj/item/twohanded/vibro_weapon/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 20, 105)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -104,6 +104,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 25
 	sharpness = IS_BLUNT
 
+/obj/item/claymore/machete/pipe/ComponentInitialize()
+	return
+
 /obj/item/claymore/machete/warclub
 	name = "war club"
 	desc = "A simple carved wooden club with turquoise inlays."
@@ -115,6 +118,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_chance = 10
 	armour_penetration = 5
 	sharpness = IS_BLUNT
+
+/obj/item/claymore/machete/warclub/ComponentInitialize()
+	return
 
 /obj/item/claymore/machete/pipe/tireiron
 	name = "tire iron"
@@ -131,6 +137,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb = list("mashed", "bashed", "piped", "hit", "bludgeoned", "whacked", "bonked")
 	force = 25
 	sharpness = IS_BLUNT
+
+/obj/item/claymore/machete/golf/ComponentInitialize()
+	return
 
 /obj/item/claymore/machete/golf/teniron
 	name = "10 iron"
@@ -156,7 +165,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message("<span class='suicide'>[user] keeps hitting \himself with the [src.name]! It looks like \he's trying to commit suicide.</span>")
 	return (BRUTELOSS|FIRELOSS)
 
-/obj/item/claymore/Initialize()
+/obj/item/claymore/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 40, 105)
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -167,6 +167,8 @@
 		loc.visible_message("<span class='warning'>A grotesque blade forms around [loc.name]\'s arm!</span>", "<span class='warning'>Our arm twists and mutates, transforming it into a deadly blade.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	if(synthetic)
 		can_drop = TRUE
+
+/obj/item/melee/arm_blade/ComponentInitialize()
 	AddComponent(/datum/component/butchering, 60, 80)
 
 /obj/item/melee/arm_blade/afterattack(atom/target, mob/user, proximity)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -43,7 +43,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 
-/obj/item/melee/cultblade/Initialize()
+/obj/item/melee/cultblade/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 40, 100)
 
@@ -112,6 +112,8 @@
 	set_light(4)
 	jaunt = new(src)
 	linked_action = new(src)
+
+/obj/item/twohanded/required/cult_bastard/ComponentInitialize()
 	AddComponent(/datum/component/butchering, 50, 80)
 
 /obj/item/twohanded/required/cult_bastard/examine(mob/user)
@@ -661,7 +663,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/datum/action/innate/cult/spear/spear_act
 
-/obj/item/twohanded/cult_spear/Initialize()
+/obj/item/twohanded/cult_spear/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 90)
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -391,12 +391,12 @@
 	name = "reinforced yankee raider armor"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 
-/obj/item/clothing/suit/armor/f13/badlands
+/obj/item/clothing/suit/armor/f13/raider/badlands
 	name = "badlands raider armor"
 	icon_state = "badlands"
 	item_state = "badlands"
 
-/obj/item/clothing/suit/armor/f13/badlands/reinforced
+/obj/item/clothing/suit/armor/f13/raider/badlands/reinforced
 	name = "reinforced badlands raider armor"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1812,7 +1812,7 @@
 /datum/crafting_recipe/superstimpak
 	name = "Super Stimpak"
 	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
-	reqs = list(/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
+	reqs = list(/datum/reagent/medicine/stimpak = 10,
 				/obj/item/stack/sheet/leather = 1,
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 1)
 	tools = list(TOOL_WORKBENCH)

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1813,6 +1813,7 @@
 	name = "Super Stimpak"
 	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/super
 	reqs = list(/datum/reagent/medicine/stimpak = 10,
+				/obj/item/reagent_containers/hypospray/medipen/stimpak = 1,
 				/obj/item/stack/sheet/leather = 1,
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 1)
 	tools = list(TOOL_WORKBENCH)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -132,7 +132,7 @@
 	var/icon/broken_outline = icon('icons/obj/drinks.dmi', "broken")
 	sharpness = IS_SHARP
 
-/obj/item/broken_bottle/Initialize()
+/obj/item/broken_bottle/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 200, 55)
 

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -101,7 +101,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP
 
-/obj/item/hatchet/Initialize()
+/obj/item/hatchet/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 70, 100)
 
@@ -128,7 +128,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/swiping = FALSE
 
-/obj/item/scythe/Initialize()
+/obj/item/scythe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 90, 105)
 

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -139,7 +139,7 @@ Raider
 		/obj/item/clothing/suit/armor/f13/raider/yankee, \
 		/obj/item/clothing/suit/armor/f13/raider/sadist, \
 		/obj/item/clothing/suit/armor/f13/raider/blastmaster, \
-		/obj/item/clothing/suit/armor/f13/badlands, \
+		/obj/item/clothing/suit/armor/f13/raider/badlands, \
 		/obj/item/clothing/suit/armor/f13/raider/painspike)
 	if(prob(10))
 		mask = pick(
@@ -209,7 +209,7 @@ Raider
 
 /datum/outfit/loadout/raider_badlands
 	name = "Badlands"
-	suit = /obj/item/clothing/suit/armor/f13/badlands
+	suit = /obj/item/clothing/suit/armor/f13/raider/badlands
 	head = /obj/item/clothing/head/helmet/f13/fiend
 
 /datum/outfit/loadout/raider_painspike

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -28,7 +28,7 @@
 	var/detonation_damage = 50
 	var/backstab_bonus = 30
 
-/obj/item/twohanded/required/kinetic_crusher/Initialize()
+/obj/item/twohanded/required/kinetic_crusher/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 110) //technically it's huge and bulky, but this provides an incentive to use it
 

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -113,7 +113,7 @@
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharpness = IS_SHARP
 
-/obj/item/shovel/Initialize()
+/obj/item/shovel/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 150, 40) //it's sharp, so it works, but barely.
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -748,6 +748,8 @@
 	spirits = list()
 	START_PROCESSING(SSobj, src)
 	GLOB.poi_list |= src
+
+/obj/item/melee/ghost_sword/ComponentInitialize()
 	AddComponent(/datum/component/butchering, 150, 90)
 
 /obj/item/melee/ghost_sword/Destroy()

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -175,7 +175,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = IS_SHARP
 
-/obj/item/light_eater/Initialize()
+/obj/item/light_eater/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 80, 70)
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -90,7 +90,7 @@
 						"Command Blue" = "pen-fountain-cb"
 						)
 
-/obj/item/pen/fountain/captain/Initialize()
+/obj/item/pen/fountain/captain/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 200, 115) //the pen is mightier than the sword
 
@@ -179,7 +179,7 @@
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") //these wont show up if the pen is off
 	var/on = FALSE
 
-/obj/item/pen/edagger/Initialize()
+/obj/item/pen/edagger/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 60, 100, 0, 'sound/weapons/blade1.ogg', TRUE)
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -131,7 +131,7 @@
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
 
-/obj/item/gun/energy/plasmacutter/Initialize()
+/obj/item/gun/energy/plasmacutter/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 25, 105, 0, 'sound/weapons/plasma_cutter.ogg')
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -86,7 +86,7 @@
 	sharpness = IS_SHARP
 	max_charges = 4
 
-/obj/item/gun/magic/staff/spellblade/Initialize()
+/obj/item/gun/magic/staff/spellblade/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 15, 125, 0, hitsound)
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -112,7 +112,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP_ACCURATE
 
-/obj/item/scalpel/Initialize()
+/obj/item/scalpel/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 80 * toolspeed, 100, 0)
 
@@ -157,7 +157,7 @@
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	sharpness = IS_SHARP
 
-/obj/item/circular_saw/Initialize()
+/obj/item/circular_saw/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 40 * toolspeed, 100, 5, 'sound/weapons/circsawhit.ogg') //saws are very accurate and fast at butchering
 


### PR DESCRIPTION
## Description
Fixes a few bugs, and cleans up some component related code that I noticed wasn't set up right(you add the component in ComponentInitialize() so that you can have the option to override that method so that the components aren't added, which you can't do if it's in Initialize())

## Motivation and Context
Changed the badlands armor to be of the raider armor type so that it isn't weaker than the other armors and because I thought that was an oversight, labeling it as a balance change on the changelog so that it doesn't look like I'm trying to sneak this in.

## How Has This Been Tested?
Yes I spawned in game and tested them

## Changelog (necessary)
:cl: Sneakyrat
balance: Raider badlands armor now has the same stats as other raider armors(it used to be lower)
fix: Fixed being able to use super stimpaks and empty stimpaks for the super stimpak recipe
fix: Fixed being able to butcher stuff with pipes, golf clubs, and war clubs
code: Moved some component initializations out of Initialize() and into ComponentInitialize() where it belongs
/:cl:
