### PR TITLE
Removes ERPing SSD/dead players for real this time

### DIFF
--- a/interactions/_interaction.dm
+++ b/interactions/_interaction.dm
@@ -48,6 +48,9 @@ var/list/interactions
 	var/needs_physical_contact
 
 /datum/interaction/proc/evaluate_user(mob/living/carbon/human/user, silent = TRUE)
+	if(user.stat == DEAD)
+		return FALSE
+
 	if(user.refactory_period)
 		if(!silent) //bye spam
 			to_chat(user, "<span class='warning'>You're still questioning your actions and how yourself got into this situation. You need to wait [DisplayTimeText(user.refactory_period * 10, TRUE)] until you can make your parents ashamed even more!</span>")

--- a/interactions/lewd/lewd_interactions.dm
+++ b/interactions/lewd/lewd_interactions.dm
@@ -74,8 +74,7 @@
 			if(user.client && user.client.prefs)
 				if(user.client.prefs.wasteland_toggles & VERB_CONSENT)
 					return TRUE
-				else
-					return FALSE
+			return FALSE
 		return TRUE
 	return FALSE
 

--- a/interactions/lewd/lewd_interactions.dm
+++ b/interactions/lewd/lewd_interactions.dm
@@ -121,11 +121,10 @@
 			return FALSE
 
 		if(require_ooc_consent)
-			if(target.client && target.client.prefs)
+			if(target.stat != DEAD && target.client && target.client.prefs)
 				if(target.client.prefs.wasteland_toggles & VERB_CONSENT)
 					return TRUE
-				else
-					return FALSE
+			return FALSE
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## Description
I forgot to test #190 with multiple connections, but I just learned how so I tested this one and it works, while doing so I also discovered another bug and fixed that one as well.

## Changelog (necessary)
:cl: Sneakyrat
tweak: Removes ERPing SSD/dead players for real this time
fix: Fixes being able to use interactions from your dead body
/:cl:
