### PR TITLE
super mutants health nerf

### DIFF
--- a/code/modules/fallout/mob/simple_animal/mobs/supermutant.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/supermutant.dm
@@ -18,8 +18,8 @@
 	response_help = "touches"
 	response_disarm = "tries to perform a kung fu move, then suddenly remembers that it's actually"
 	response_harm = "hits"
-	maxHealth = 450
-	health = 450
+	maxHealth = 350
+	health = 350
 	force_threshold = 15
 	faction = list("hostile", "supermutant")
 	melee_damage_lower = 25


### PR DESCRIPTION
Nrf the super mutant health from 450 to 350. I think its better that way since 450 is only 50 hp lower than a deathclaw, making dungeons near impossible to do without faction gears, or advanced loot.

heavy ranged mutant are not touched.