### PR TITLE
Balance Changes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -294,7 +294,7 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 #define MAP_MAXZ 6
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 900
+#define DEFIB_TIME_LIMIT 300
 #define DEFIB_TIME_LOSS 60
 
 // Diagonal movement

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -198,3 +198,38 @@
 /datum/quirk/monochromatic/remove()
 	if(quirk_holder)
 		quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
+
+
+/////////
+//Soapstone Gang
+/////////
+/datum/quirk/soapstone
+	name = "Soapstone"
+	desc = "You recently found this yellow rock. Neat. Now, if only you knew what this did..."
+	value = 0
+	var/obj/item/heirloom ///SPAGETH CODE DON'T LEAVE TO REMOVE THE NAME.
+	var/where
+
+/datum/quirk/soapstone/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/heirloom_type  ///DONT CHANGE HERILOOM STUFF FOR SOME REASON DONT WORK IF YOU REMOVE IT AAAAA.
+	switch(quirk_holder.mind.assigned_role)
+		if("Elder", "Centurion", "Sheriff", "NCR Captain", "Overseer")
+			heirloom_type = pick(/obj/item/soapstone)
+		else
+			heirloom_type = pick(
+				/obj/item/soapstone/trait)
+	heirloom = new heirloom_type(get_turf(quirk_holder)) //IF YOU CHANGE THIS FOR SOME REASON WILL NOT WORK.
+	var/list/slots = list(
+		"in your left pocket" = SLOT_L_STORE, //SPAWNS IN THE POCKETS
+		"in your right pocket" = SLOT_R_STORE,
+		"in your backpack" = SLOT_IN_BACKPACK	//SPAWNS IN THE BACKPACK
+
+	)
+	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
+
+/datum/quirk/soapstone/post_add()
+	if(where == "in your backpack")
+		var/mob/living/carbon/human/H = quirk_holder
+		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -1,6 +1,6 @@
 /obj/item/soapstone
 	name = "soapstone"
-	desc = "Leave informative messages for the crew, including the crew of future shifts!\nEven if out of uses, it can still be used to remove messages.\n(Not suitable for engraving on shuttles, off station or on cats. Side effects may include prompt beatings, psychotic clown incursions, and/or orbital bombardment.)"
+	desc = "Leave informative messages for other wasters, including those of the future!\nEven if out of uses, it can still be used to remove messages.\n(Not suitable for engraving on shuttles, off station or on cats. Side effects may include prompt beatings, psychotic clown incursions, and/or orbital bombardment.)"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "soapstone"
 	throw_speed = 3
@@ -58,7 +58,7 @@
 	user.visible_message("<span class='notice'>[user] starts engraving a message into [T]...</span>", "<span class='notice'>You start engraving a message into [T]...</span>", "<span class='italics'>You hear a chipping sound.</span>")
 	if(can_use() && do_after(user, tool_speed, target = T) && can_use()) //This looks messy but it's actually really clever!
 		if(!locate(/obj/structure/chisel_message) in T)
-			user.visible_message("<span class='notice'>[user] leaves a message for future spacemen!</span>", "<span class='notice'>You engrave a message into [T]!</span>", "<span class='italics'>You hear a chipping sound.</span>")
+			user.visible_message("<span class='notice'>[user] leaves a message for future wasters!</span>", "<span class='notice'>You engrave a message into [T]!</span>", "<span class='italics'>You hear a chipping sound.</span>")
 			playsound(loc, 'sound/items/gavel.ogg', 50, 1, -1)
 			var/obj/structure/chisel_message/M = new(T)
 			M.register(user, message)
@@ -98,6 +98,9 @@
 
 /obj/item/soapstone/empty
 	remaining_uses = 0
+
+/obj/item/soapstone/trait
+	remaining_uses = 1
 
 /proc/good_chisel_message_location(turf/T)
 	if(!T)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -44,13 +44,18 @@
 
 
 /obj/item/bodypart/chest/dismember()
-	return FALSE
 	if(!owner)
 		return FALSE
+
 	var/mob/living/carbon/C = owner
+
 	if(!dismemberable)
 		return FALSE
+
 	if(C.has_trait(TRAIT_NODISMEMBER))
+		return FALSE
+
+	if(C.stat == CONSCIOUS)//Don't want someone 'awake' having this happen, for balance reasons.
 		return FALSE
 
 	var/organ_spilled = 0


### PR DESCRIPTION
- - -
 Balance:
 - Disembowelment has been re-enabled. Currently, it only functions on targets that aren't fully conscious, meaning you can't be disembowelled while mid-combat.
 To disembowel, it requires you to have put the target into anything other than standard condition. This includes, but isn't limited to: Soft-Crit, Hard-Crit, Unconsciousness.
 - Lowers the defib timer to five minutes, from fifteen.
- - -
 Additions:
 - You may now get a soapstone through a new neutral trait.
- - -