### PR TITLE
Pahrump Changes

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -682,11 +682,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "acf" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
+/turf/closed/wall/f13/store{
+	icon_state = "store6"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/area/f13/ncr)
 "acg" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
@@ -706,11 +705,10 @@
 	},
 /area/f13/wasteland)
 "acj" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
+/turf/closed/wall/f13/store{
+	icon_state = "store10"
 	},
-/area/f13/tunnel)
+/area/f13/ncr)
 "ack" = (
 /obj/machinery/vending/cigarette,
 /turf/open/indestructible/ground/outside/dirt{
@@ -774,9 +772,15 @@
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker)
 "act" = (
-/obj/effect/landmark/start/f13/villager,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "acu" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 6;
@@ -808,12 +812,12 @@
 	},
 /area/f13/building)
 "acz" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
-/area/f13/building)
+/area/f13/ncr)
 "acA" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/box/pillbottles,
@@ -1228,11 +1232,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "adD" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0";
-	tag = "icon-verticalleftborderright0"
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	tag = "icon-shower (EAST)"
 	},
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "adE" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/indestructible/ground/outside/dirt,
@@ -1301,11 +1310,15 @@
 	},
 /area/f13/bunker)
 "adP" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0";
-	tag = "icon-verticalinnermain0"
+/obj/machinery/shower{
+	dir = 8
 	},
-/area/f13/tunnel)
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "adQ" = (
 /obj/structure/chair/bench,
 /obj/effect/landmark/start/f13/raider,
@@ -1327,11 +1340,21 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "adT" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0";
-	tag = "icon-verticalrightborderleft0"
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/structure/closet,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/area/f13/tunnel)
+/area/f13/ncr)
 "adU" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/f13/wood{
@@ -2652,11 +2675,15 @@
 	},
 /area/f13/caves)
 "ahi" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
-	tag = "icon-verticalrightborderright0"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
-/area/f13/tunnel)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
+/area/f13/ncr)
 "ahj" = (
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
@@ -2879,20 +2906,17 @@
 	},
 /area/f13/wasteland)
 "ahQ" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement";
-	tag = "icon-outerpavement (EAST)"
+/obj/structure/closet/secure_closet,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "ahR" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
+/obj/structure/reagent_dispensers/barrel/explosive,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/ncr)
 "ahS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3076,10 +3100,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"ais" = (
-/obj/item/toy/beach_ball/holoball,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "ait" = (
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
@@ -3176,12 +3196,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
-"aiG" = (
-/obj/structure/table/wood/settler,
-/obj/item/clothing/gloves/color/yellow,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
 "aiH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop";
@@ -3329,9 +3343,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ajb" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
 "ajc" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/combat,
@@ -3398,13 +3409,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
-"ajl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
 "ajm" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
@@ -3516,23 +3520,13 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"ajD" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
-"ajE" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (EAST)"
-	},
-/area/f13/wasteland)
 "ajF" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
+/area/f13/ncr)
 "ajG" = (
 /obj/item/ammo_casing/caseless{
 	dir = 10;
@@ -3641,57 +3635,28 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/vault)
-"ajT" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerborder";
-	tag = "icon-outerborder (EAST)"
-	},
-/area/f13/wasteland)
-"ajU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
-"ajV" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
 "ajW" = (
-/obj/structure/rack,
-/obj/item/ammo_casing/caseless/arrow,
-/obj/item/ammo_casing/caseless/arrow,
-/obj/item/ammo_casing/caseless/arrow,
-/obj/item/ammo_casing/caseless/arrow,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
+	},
+/area/f13/ncr)
 "ajX" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/caves)
-"ajY" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plating/tunnel,
+"akb" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2";
+	tag = "icon-horizontaloutermain2"
+	},
 /area/f13/ncr)
-"ajZ" = (
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
-"aka" = (
+"akc" = (
 /obj/item/circuitboard/machine/biogenerator,
 /obj/item/circuitboard/machine/seed_extractor,
 /obj/structure/rack,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/tunnel,
 /area/f13/ncr)
-"akb" = (
-/obj/machinery/light/lampost,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"akc" = (
-/obj/structure/fence/end{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "akd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerouter";
@@ -3800,57 +3765,28 @@
 	},
 /area/f13/building)
 "akt" = (
-/obj/structure/stacklifter,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain1";
+	tag = "icon-verticaloutermain1"
+	},
+/area/f13/ncr)
 "aku" = (
-/obj/structure/weightlifter,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain2";
+	tag = "icon-verticaloutermain2"
+	},
+/area/f13/ncr)
 "akv" = (
 /obj/item/radio/intercom/kebob,
 /turf/closed/wall/f13/wood,
 /area/f13/city)
-"akw" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
-"akx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0";
-	tag = "icon-verticalleftborderleft0"
-	},
-/area/f13/ncr)
-"aky" = (
-/obj/structure/table/reinforced,
-/obj/item/megaphone,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/ncr)
-"akz" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"akA" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "akB" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13,
-/area/f13/ncr)
-"akC" = (
-/turf/open/floor/wood/f13,
-/area/f13/ncr)
-"akD" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "akE" = (
 /obj/structure/table/wood,
@@ -3924,38 +3860,29 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"akO" = (
-/obj/machinery/light,
+"akQ" = (
+/obj/item/toy/beach_ball/holoball,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+	icon_state = "horizontaloutermain2left";
+	tag = "icon-horizontaloutermain2left"
 	},
 /area/f13/ncr)
-"akP" = (
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"akQ" = (
-/obj/structure/table,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
 "akR" = (
-/obj/structure/chalkboard,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2right";
+	tag = "icon-horizontaloutermain2right"
+	},
 /area/f13/ncr)
 "akS" = (
-/obj/effect/landmark/start/f13/ncrveteranranger,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/settler,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "akT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/ncrcolonel,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"akU" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/f13/stage_l,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "akV" = (
 /obj/structure/cable{
@@ -3964,32 +3891,19 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/f13/brotherhood)
-"akW" = (
-/obj/machinery/vending/cigarette,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
-"akX" = (
-/obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
 "akY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "akZ" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
+/obj/structure/rack,
+/obj/item/mining_scanner,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "ala" = (
 /obj/structure/filingcabinet,
@@ -4118,114 +4032,73 @@
 	},
 /area/f13/building)
 "alu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "alv" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "alw" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/structure/rack,
-/obj/item/clothing/suit/apron/chef,
-/obj/item/clothing/head/chefhat,
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
 /area/f13/ncr)
 "alx" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "aly" = (
-/obj/machinery/vending/snack/green,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/ncr)
 "alz" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner"
 	},
 /area/f13/ncr)
 "alA" = (
-/obj/structure/reagent_dispensers/barrel/half,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
-/area/f13/ncr)
-"alB" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 16;
-	tag = "icon-sink (NORTH)"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/ncr)
 "alC" = (
-/obj/machinery/photocopier,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"alD" = (
-/obj/effect/landmark/poster_spawner/ncr,
-/turf/closed/wall/f13/store,
-/area/f13/ncr)
-"alE" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left";
+	tag = "icon-horizontaltopbordertop2left"
+	},
 /area/f13/ncr)
 "alF" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (WEST)"
+	},
 /area/f13/ncr)
 "alG" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal{
+/obj/machinery/light{
 	dir = 8;
-	termtag = "Public"
+	icon_state = "tube"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"alH" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "alI" = (
 /obj/structure/cable{
@@ -4321,61 +4194,61 @@
 	},
 /area/f13/wasteland)
 "alW" = (
-/obj/structure/chair{
-	dir = 1;
-	tag = "icon-chair (NORTH)"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
 /area/f13/ncr)
 "alX" = (
-/obj/structure/chair{
-	dir = 1;
-	tag = "icon-chair (NORTH)"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrightbottom";
+	tag = "icon-verticalrightborderrightbottom"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"alY" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "alZ" = (
-/obj/structure/chair/wood{
+/obj/machinery/light{
 	dir = 4;
-	tag = "icon-wooden_chair_settler (EAST)"
+	light_color = "#c1caff"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (WEST)"
+	},
 /area/f13/ncr)
 "ama" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
 "amb" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/stage_l,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
 /area/f13/ncr)
 "amc" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"amd" = (
-/obj/structure/table,
+/obj/structure/simple_door/room,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
+"amd" = (
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/plating/tunnel,
+/area/f13/ncr)
 "ame" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (EAST)"
+	icon_state = "verticalleftborderleft3";
+	tag = "icon-verticalleftborderleft3"
 	},
 /area/f13/ncr)
 "amf" = (
@@ -4463,29 +4336,22 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ruins)
 "amt" = (
-/turf/open/floor/plasteel/stairs/left,
-/area/f13/wasteland)
-"amu" = (
-/turf/open/floor/plasteel/stairs/right,
-/area/f13/wasteland)
-"amv" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (NORTH)"
+	icon_state = "verticalrightborderrighttop";
+	tag = "icon-verticalrightborderrighttop"
 	},
 /area/f13/ncr)
-"amw" = (
-/obj/item/flag/ncr,
+"amu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
-	icon_state = "outerbordercorner";
-	tag = "icon-outerbordercorner (NORTH)"
+	icon_state = "outermaincornerinner";
+	tag = "icon-outermaincornerinner (NORTH)"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
+"amv" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/plating/tunnel,
+/area/f13/ncr)
 "amx" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2top";
@@ -4591,15 +4457,12 @@
 	tag = "icon-rubblecorner (NORTH)"
 	},
 /area/f13/ruins)
-"amP" = (
-/obj/structure/simple_door/room,
+"amQ" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
 	},
-/area/f13/ncr)
-"amQ" = (
-/turf/open/floor/wood/f13/stage_r,
 /area/f13/ncr)
 "amR" = (
 /turf/closed/indestructible/vaultdoor{
@@ -4608,7 +4471,10 @@
 	},
 /area/f13/caves)
 "amS" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
@@ -4628,16 +4494,15 @@
 	},
 /area/f13/building)
 "amU" = (
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "amV" = (
-/obj/structure/chair{
-	dir = 1;
-	tag = "icon-chair (NORTH)"
+/obj/structure/kitchenspike,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/obj/effect/landmark/start/f13/ncrranger,
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "amW" = (
 /obj/effect/decal/waste{
@@ -4650,29 +4515,35 @@
 	},
 /area/f13/wasteland)
 "amX" = (
-/obj/structure/chair{
-	dir = 1;
-	tag = "icon-chair (NORTH)"
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
-/obj/effect/landmark/start/f13/ncrranger,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
 /area/f13/ncr)
 "amY" = (
-/obj/machinery/light/small,
+/obj/effect/decal/cleanable/salt,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "amZ" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
+	},
 /area/f13/ncr)
 "ana" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/obj/machinery/vending/snack/green,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull";
+	tag = "icon-reddirtyfull"
+	},
 /area/f13/ncr)
 "anb" = (
 /obj/structure/rack,
@@ -4682,20 +4553,16 @@
 /turf/open/floor/plating,
 /area/f13/brotherhood)
 "anc" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown";
-	tag = "icon-sheetbrown"
-	},
-/obj/effect/landmark/start/f13/ncrcaptain,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"and" = (
-/obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
+/obj/machinery/camera{
+	network = list("ss13","ncr");
+	pixel_x = 10;
+	resistance_flags = 64
+	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+	icon_state = "reddirtyfull";
+	tag = "icon-reddirtyfull"
 	},
 /area/f13/ncr)
 "ane" = (
@@ -4739,106 +4606,71 @@
 	},
 /area/f13/wasteland)
 "anm" = (
-/obj/structure/table/wood,
-/obj/machinery/cell_charger,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"ann" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
 /turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
-/area/f13/ncr)
-"ano" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+	icon_state = "reddirtyfull";
+	tag = "icon-reddirtyfull"
 	},
 /area/f13/ncr)
 "anp" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull";
+	tag = "icon-reddirtyfull"
+	},
 /area/f13/ncr)
-"anq" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/ncrrecruit,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
 "anr" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ans" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 4
+"ant" = (
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
-/obj/item/reagent_containers/food/condiment/enzyme,
+/area/f13/ncr)
+"anu" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/ncr)
+"anv" = (
+/obj/structure/holohoop{
+	dir = 4;
+	icon_state = "hoop";
+	tag = "icon-hoop (EAST)"
+	},
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
-"ant" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown";
-	tag = "icon-sheetbrown"
-	},
-/obj/effect/landmark/start/f13/ncrlieutenant,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"anu" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"anv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+"anw" = (
+/obj/structure/holohoop{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"anw" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/drinks/bottle/nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/nukacola,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
-/obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "anx" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "any" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
-/area/f13/ncr)
+/obj/item/toy/beach_ball/holoball,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "anz" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4904,31 +4736,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland)
-"anI" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
-/area/f13/ncr)
-"anJ" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
-/area/f13/ncr)
-"anK" = (
-/obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/ncr)
 "anL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4938,23 +4745,28 @@
 /turf/open/floor/plating,
 /area/f13/city)
 "anM" = (
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
 "anN" = (
-/obj/structure/chair,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
 /area/f13/ncr)
 "anO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "anP" = (
-/obj/structure/closet/crate/footlocker/ncr,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull";
+	tag = "icon-reddirtyfull"
+	},
 /area/f13/ncr)
 "anQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -5056,29 +4868,28 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ruins)
 "aog" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/ncrtrooper,
-/turf/open/floor/f13/wood,
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/f13/supermart,
 /area/f13/ncr)
 "aoh" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top";
+	tag = "icon-verticalleftborderleft2top"
+	},
 /area/f13/ncr)
 "aoi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "aoj" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
+/area/f13/ncr)
 "aok" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -5087,15 +4898,6 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security)
-"aol" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
 "aom" = (
 /obj/effect/turf_decal/bot,
 /obj/item/gun/ballistic/automatic/shotgun/riot,
@@ -5103,18 +4905,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security/armory)
 "aon" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/ncr)
 "aoo" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
 	},
 /area/f13/ncr)
 "aop" = (
@@ -5431,15 +5231,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security/armory)
 "aph" = (
-/obj/structure/closet/crate/footlocker/ncr,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2bottom";
+	tag = "icon-verticalleftborderleft2bottom"
+	},
 /area/f13/ncr)
 "api" = (
-/obj/structure/closet/crate/footlocker/ncr,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
 /area/f13/ncr)
 "apj" = (
@@ -5575,58 +5376,36 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security)
 "apB" = (
+/obj/effect/landmark/start/f13/ncrtrooper,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/blue,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
 /area/f13/ncr)
 "apC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 8
+/obj/effect/landmark/start/f13/ncrtrooper,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
-/area/f13/ncr)
-"apD" = (
-/obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue,
 /area/f13/ncr)
 "apE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
+/obj/machinery/light/small,
+/obj/structure/rack,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "apF" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/closet/crate/freezer,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "apG" = (
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security)
-"apH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/ncr)
-"apI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 9
-	},
-/area/f13/ncr)
 "apJ" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 1;
@@ -5690,27 +5469,25 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating,
 /area/f13/brotherhood)
-"apT" = (
-/obj/effect/landmark/start/f13/ncrmp,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/ncr)
 "apU" = (
 /obj/structure/foamedmetal/iron,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "apV" = (
-/obj/effect/landmark/start/f13/ncrmp,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheethos";
+	tag = "icon-sheethos"
 	},
+/obj/effect/landmark/start/f13/ncrsergeant,
+/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "apW" = (
+/obj/effect/landmark/start/f13/ncrrecruit,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 10
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/ncr)
 "apX" = (
@@ -5767,9 +5544,17 @@
 	},
 /area/f13/building)
 "aqe" = (
-/mob/living/simple_animal/hostile/handy,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
+/area/f13/ncr)
 "aqf" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -5785,40 +5570,28 @@
 	tag = "icon-housewood2"
 	},
 /area/f13/building)
-"aqh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 1
-	},
-/area/f13/ncr)
-"aqi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plasteel/blue/side{
-	dir = 5
-	},
-/area/f13/ncr)
 "aqj" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/reagentgrinder,
 /turf/open/floor/plating,
 /area/f13/brotherhood)
 "aqk" = (
-/obj/structure/fence{
-	dir = 8
+/obj/structure/closet/cabinet,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/mask/ncr_facewrap,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/obj/item/clothing/shoes/f13/military/ncr,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
-	},
-/area/f13/wasteland)
-"aql" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/ncr)
 "aqm" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 4;
@@ -5916,22 +5689,31 @@
 	},
 /area/f13/building)
 "aqx" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "aqy" = (
 /obj/structure/foamedmetal/iron,
 /turf/open/floor/plating,
 /area/f13/caves)
 "aqz" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "outerpavement"
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor6-old";
+	tag = "icon-floor6-old"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
+/area/f13/ncr)
 "aqA" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/cell_charger,
@@ -6043,29 +5825,10 @@
 "aqQ" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/building)
-"aqR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 9
-	},
-/area/f13/ncr)
-"aqS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 5
-	},
-/area/f13/ncr)
 "aqT" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/ncr)
-"aqU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 6
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
 	},
 /area/f13/ncr)
 "aqV" = (
@@ -6073,46 +5836,27 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aqW" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
-"aqX" = (
-/obj/machinery/shower{
-	dir = 8;
-	tag = "icon-shower (WEST)"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/plasteel/blue,
-/area/f13/ncr)
-"aqY" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerbordercorner";
-	tag = "icon-outerbordercorner (WEST)"
-	},
-/area/f13/wasteland)
 "aqZ" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "ara" = (
-/obj/structure/chair/comfy,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
+	},
 /area/f13/ncr)
 "arb" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/effect/landmark/start/f13/ncrsergeant,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
 	},
 /area/f13/ncr)
 "arc" = (
@@ -6249,78 +5993,48 @@
 "arw" = (
 /turf/open/floor/plating,
 /area/f13/caves)
-"arx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/ncr)
-"ary" = (
-/obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue,
-/area/f13/ncr)
 "arz" = (
-/turf/closed/wall/f13/store,
+/obj/structure/simple_door/wood,
+/obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "arA" = (
 /mob/living/simple_animal/hostile/molerat,
 /turf/open/floor/plating,
 /area/f13/caves)
 "arB" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (NORTH)"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "arC" = (
-/obj/structure/chair/comfy,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
+/obj/structure/simple_door/room,
+/turf/open/floor/plasteel,
 /area/f13/ncr)
 "arD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
+/obj/structure/toilet{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "arE" = (
-/obj/structure/decoration/vent/rusty{
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 4
-	},
-/area/f13/ncr)
-"arF" = (
-/obj/structure/decoration/vent/rusty{
-	pixel_x = 15
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 8
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/ncr)
 "arG" = (
 /obj/item/circuitboard/machine/chem_master,
 /turf/open/floor/plating,
 /area/f13/caves)
-"arH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side{
-	dir = 4
-	},
-/area/f13/ncr)
 "arI" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -6427,43 +6141,21 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"arW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/ncrmp,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/ncr)
 "arX" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/plating,
 /area/f13/caves)
 "arY" = (
-/obj/machinery/shower{
-	dir = 4;
-	tag = "icon-shower (EAST)"
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/soap,
-/turf/open/floor/plasteel/blue,
 /area/f13/ncr)
 "arZ" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/f13/caves)
-"asa" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/ncr)
-"asb" = (
-/obj/machinery/shower{
-	pixel_y = 14
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue,
-/area/f13/ncr)
 "asc" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 4;
@@ -6586,13 +6278,25 @@
 	},
 /area/f13/building)
 "ass" = (
-/obj/structure/window/fulltile/house,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "ast" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00";
+	tag = "icon-toilet00 (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "asu" = (
 /obj/machinery/light{
@@ -6602,8 +6306,9 @@
 /turf/open/floor/plating,
 /area/f13/caves)
 "asv" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/legion)
+/obj/structure/stacklifter,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/ncr)
 "asw" = (
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/caves)
@@ -6614,11 +6319,8 @@
 /turf/open/floor/plating,
 /area/f13/caves)
 "asy" = (
-/obj/structure/chair/comfy{
-	dir = 4;
-	tag = "icon-comfychair (EAST)"
-	},
-/turf/open/floor/f13/wood,
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/ncr)
 "asz" = (
 /obj/structure/fence{
@@ -6735,20 +6437,22 @@
 	},
 /area/f13/building)
 "asO" = (
-/obj/machinery/light/small,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright1";
+	tag = "icon-verticalrightborderright1"
+	},
 /area/f13/ncr)
 "asP" = (
-/obj/structure/chair/comfy{
-	dir = 8;
-	tag = "icon-comfychair (WEST)"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "asQ" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "shadowright";
+	tag = "icon-shadowright"
+	},
 /area/f13/ncr)
 "asR" = (
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -6760,34 +6464,43 @@
 	},
 /area/f13/building)
 "asT" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
+/obj/structure/sink{
+	dir = 1;
+	icon_state = "sink";
+	pixel_y = 16;
+	tag = "icon-sink (NORTH)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "asU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/blue/side{
-	dir = 10
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/ncr)
 "asV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/blue/side,
-/area/f13/ncr)
-"asW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/blue/side{
-	dir = 6
+/obj/structure/bed,
+/obj/effect/landmark/start/f13/ncrrecruit,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/ncr)
 "asX" = (
-/obj/machinery/photocopier,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left (WEST)"
+	},
 /area/f13/ncr)
 "asY" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
@@ -6984,13 +6697,17 @@
 	},
 /area/f13/building)
 "atw" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2";
+	tag = "icon-horizontaltopborderbottom2 (WEST)"
+	},
 /area/f13/ncr)
 "atx" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/ncrambassador,
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom3";
+	tag = "icon-horizontaltopborderbottom3"
+	},
 /area/f13/ncr)
 "aty" = (
 /turf/open/indestructible/ground/outside/ruins{
@@ -7170,22 +6887,25 @@
 	},
 /area/f13/building)
 "atT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "atU" = (
-/obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindow";
+	tag = "icon-housewindow"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housebase";
+	tag = "icon-housebase"
 	},
 /area/f13/ncr)
 "atV" = (
@@ -7194,29 +6914,13 @@
 /turf/open/floor/plating,
 /area/f13/caves)
 "atW" = (
-/obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/turf/closed/wall/f13/supermart,
 /area/f13/ncr)
 "atX" = (
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/closet,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/ncr)
 "atY" = (
@@ -7634,10 +7338,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/tunnel)
 "avb" = (
-/obj/machinery/light{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2";
+	tag = "icon-verticalleftborderleft2"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "avc" = (
 /obj/structure/table/wood,
@@ -7826,6 +7530,7 @@
 "avx" = (
 /obj/structure/chair{
 	dir = 8;
+	icon_state = "chair";
 	tag = "icon-chair (WEST)"
 	},
 /turf/open/floor/f13/wood,
@@ -8128,6 +7833,7 @@
 "awg" = (
 /obj/structure/chair{
 	dir = 8;
+	icon_state = "chair";
 	tag = "icon-chair (WEST)"
 	},
 /obj/effect/decal/remains/human,
@@ -8262,38 +7968,25 @@
 	},
 /area/f13/wasteland)
 "awz" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2";
+	tag = "icon-verticalrightborderright2"
 	},
 /area/f13/ncr)
 "awA" = (
 /turf/closed/wall/f13/supermart,
 /area/f13/wasteland)
 "awB" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "awC" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/ncr)
-"awD" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
-	tag = "icon-wasteland33"
-	},
+/obj/structure/table/wood/settler,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "awE" = (
 /obj/structure/fence{
@@ -8304,21 +7997,25 @@
 "awF" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
-	icon_state = "sheethos";
-	tag = "icon-sheethos"
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
-/obj/effect/landmark/start/f13/ncrsergeant,
-/turf/open/floor/f13/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "awG" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet{
-	icon_state = "sheethos";
-	tag = "icon-sheethos"
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
-/obj/effect/landmark/start/f13/ncrsergeant,
-/turf/open/floor/f13/wood,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "awH" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8459,16 +8156,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/vault/security/armory)
 "axa" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheethos";
-	tag = "icon-sheethos"
-	},
-/obj/effect/landmark/start/f13/ncrsergeant,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "axb" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -8613,13 +8302,6 @@
 	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/tunnel)
-"axw" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/folder/blue,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
 "axx" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottomright";
@@ -8761,30 +8443,15 @@
 /obj/machinery/mineral/wasteland_vendor/general,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
-"axR" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = -6
-	},
-/obj/structure/filingcabinet/medical{
-	pixel_x = 10
-	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
 "axS" = (
 /obj/structure/table/glass,
 /obj/item/roller,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood)
-"axT" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
 "axU" = (
+/obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/ncr)
 "axV" = (
 /obj/machinery/camera/autoname,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8795,37 +8462,11 @@
 	},
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/vents)
-"axX" = (
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/closet,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/ncr)
 "axY" = (
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/closet,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (WEST)"
 	},
 /area/f13/ncr)
 "axZ" = (
@@ -8847,11 +8488,12 @@
 	},
 /area/f13/wasteland)
 "ayc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken";
-	tag = "icon-housewood3-broken"
-	},
+/obj/structure/table/wood/settler,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/onion,
+/obj/item/seeds/onion,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "ayd" = (
 /obj/item/ammo_casing/a50MG,
@@ -8928,12 +8570,6 @@
 	tag = "icon-horizontalbottombordertop2"
 	},
 /area/f13/wasteland)
-"ayo" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
 "ayp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -8941,18 +8577,6 @@
 	tag = "icon-outerbordercorner (NORTH)"
 	},
 /area/f13/wasteland)
-"ayq" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"ayr" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
-/area/f13/ncr)
 "ays" = (
 /obj/structure/table/glass,
 /obj/item/soap,
@@ -9181,24 +8805,24 @@
 	},
 /area/f13/wasteland)
 "ayZ" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
-	},
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "aza" = (
-/obj/structure/table,
 /obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/structure/table,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid";
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "azb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "darkdirty"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
 	},
 /area/f13/ncr)
 "azc" = (
@@ -9288,12 +8912,9 @@
 	},
 /area/f13/village)
 "azp" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2right";
+	tag = "icon-horizontalbottomborderbottom2right"
 	},
 /area/f13/ncr)
 "azq" = (
@@ -9316,19 +8937,37 @@
 	},
 /area/f13/wasteland)
 "azt" = (
-/obj/structure/bed/mattress,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/ncrht,
-/turf/open/floor/f13/wood,
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "azu" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/ncrspecialist,
-/turf/open/floor/f13/wood,
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00";
+	tag = "icon-toilet00 (WEST)"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "azv" = (
-/obj/effect/landmark/poster_spawner/ncr,
-/turf/closed/wall/f13/wood,
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (EAST)"
+	},
 /area/f13/ncr)
 "azw" = (
 /obj/structure/wreck/trash/five_tires,
@@ -9651,9 +9290,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/tunnel)
 "aAl" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/light,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
+	},
+/area/f13/ncr)
 "aAm" = (
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert,
@@ -9842,11 +9484,11 @@
 	},
 /area/f13/building)
 "aAJ" = (
-/obj/structure/closet/crate/freezer/saline,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
+/obj/structure/rack,
+/obj/item/seeds/corn,
+/obj/item/seeds/pumpkin,
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "aAK" = (
 /obj/item/ammo_casing/c10mm,
@@ -10268,15 +9910,6 @@
 	tag = "icon-verticaloutermain2top"
 	},
 /area/f13/wasteland)
-"aBQ" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/ncr)
 "aBR" = (
 /obj/structure/toilet{
 	dir = 8;
@@ -10420,13 +10053,14 @@
 	},
 /area/f13/building)
 "aCl" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt";
-	tag = "icon-dirt (SOUTHEAST)"
-	},
-/area/f13/wasteland)
+/obj/structure/rack,
+/obj/item/seeds/corn,
+/obj/item/seeds/chili,
+/obj/item/seeds/onion,
+/obj/item/seeds/watermelon,
+/obj/item/storage/bag/plants,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/ncr)
 "aCm" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
@@ -10602,13 +10236,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aCL" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTHWEST)"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/item/cultivator,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/ncr)
 "aCM" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -10650,11 +10281,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aCT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
+/obj/structure/table/wood/settler,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "aCU" = (
 /obj/structure/tires,
@@ -11169,19 +10799,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aEn" = (
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/closet,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2left";
+	tag = "icon-horizontaltopborderbottom2left (WEST)"
 	},
 /area/f13/ncr)
 "aEo" = (
@@ -11278,9 +10899,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aED" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/ncrht,
-/turf/open/floor/f13/wood,
+/obj/structure/table/wood/settler,
+/obj/item/seeds/carrot,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
 "aEE" = (
 /turf/open/indestructible/ground/outside/ruins,
@@ -11682,11 +11305,12 @@
 	},
 /area/f13/village)
 "aFE" = (
-/obj/effect/decal/remains/human,
+/obj/machinery/microwave/stove,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/area/f13/village)
+/area/f13/ncr)
 "aFF" = (
 /obj/structure/chair{
 	dir = 4;
@@ -12547,17 +12171,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
 "aHY" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/ncrtrooper,
-/obj/machinery/light,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "aHZ" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/floor/plating/tunnel,
 /area/f13/ncr)
 "aIa" = (
 /obj/effect/turf_decal{
@@ -12566,23 +12188,23 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "aIb" = (
-/obj/structure/bed/mattress,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/ncrspecialist,
-/turf/open/floor/f13/wood,
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull";
+	tag = "icon-reddirtyfull"
+	},
 /area/f13/ncr)
 "aIc" = (
-/obj/structure/rack,
-/obj/item/shovel/spade,
-/obj/item/shovel,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/noticeboard,
+/turf/closed/wall/f13/store,
+/area/f13/ncr)
 "aId" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sunset,
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
 /area/f13/ncr)
 "aIe" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -12680,12 +12302,9 @@
 	},
 /area/f13/wasteland)
 "aIs" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/structure/simple_door/room,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aIt" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/brahmin,
@@ -12710,9 +12329,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aIw" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/effect/landmark/start/f13/ncrtrooper,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "aIx" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/floor/f13/wood{
@@ -12808,25 +12430,20 @@
 	},
 /area/f13/building)
 "aII" = (
-/obj/machinery/workbench,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "aIJ" = (
 /obj/item/flashlight/lamp,
 /obj/structure/table/wood,
 /obj/item/clothing/head/festive,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aIK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/ncr)
 "aIL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12834,16 +12451,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/vents)
 "aIM" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"aIN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "aIO" = (
@@ -12981,9 +12594,13 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "aJf" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/effect/landmark/start/f13/ncrtrooper,
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "aJg" = (
 /obj/structure/chair,
 /turf/open/floor/f13/wood,
@@ -13082,17 +12699,6 @@
 /obj/machinery/processor,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"aJv" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetblue";
-	tag = "icon-sheetblue"
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
 "aJw" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -13110,10 +12716,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aJy" = (
-/obj/structure/simple_door/wood,
-/obj/structure/decoration/rag,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "aJz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -13166,55 +12774,19 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"aJH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"aJI" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
 "aJJ" = (
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	tag = "icon-skulls"
-	},
-/turf/closed/wall/f13/wood,
-/area/f13/village)
-"aJK" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"aJL" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "aJM" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
-"aJN" = (
+/obj/structure/table/reinforced,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
 /area/f13/ncr)
 "aJO" = (
@@ -13355,13 +12927,18 @@
 /turf/open/floor/plating,
 /area/f13/caves)
 "aKj" = (
-/obj/structure/table/wood/settler,
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/table/reinforced,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
 	},
-/area/f13/village)
+/area/f13/ncr)
 "aKk" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken";
@@ -13409,14 +12986,6 @@
 	tag = "icon-rubblecorner"
 	},
 /area/f13/wasteland)
-"aKq" = (
-/obj/structure/table/wood/settler,
-/obj/item/folder/blue,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
 "aKr" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13{
@@ -13501,7 +13070,13 @@
 	},
 /area/f13/wasteland)
 "aKC" = (
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "aKD" = (
 /mob/living/simple_animal/hostile/trog/tunneler,
@@ -13514,12 +13089,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/radiation)
 "aKF" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/obj/machinery/ammobench/makeshift,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
+/area/f13/ncr)
 "aKG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -13527,20 +13105,19 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aKH" = (
-/obj/machinery/workbench,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/simple_door/metal/fence,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid";
+	tag = "icon-floordirtysolid"
+	},
+/area/f13/ncr)
 "aKI" = (
-/obj/structure/rack,
-/obj/item/stack/crafting/powder,
-/obj/item/stack/crafting/powder,
-/obj/item/stack/crafting/powder,
-/obj/item/stack/crafting/powder,
-/obj/item/stack/crafting/powder,
-/obj/item/stack/crafting/powder,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
+	},
+/area/f13/ncr)
 "aKJ" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -13701,7 +13278,9 @@
 "aLj" = (
 /obj/structure/sink{
 	dir = 4;
+	icon_state = "sink";
 	pixel_x = 10;
+	pixel_y = 0;
 	tag = "icon-sink (EAST)"
 	},
 /obj/structure/mirror{
@@ -13919,15 +13498,20 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aLH" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+/obj/structure/chair{
+	dir = 1
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "aLI" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "aLJ" = (
 /obj/machinery/light/kebab_sign,
 /turf/open/indestructible/ground/outside/desert,
@@ -14035,17 +13619,18 @@
 	},
 /area/f13/tunnel)
 "aMa" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"aMb" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTH)"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
+"aMb" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/beret/ncr,
+/obj/item/clothing/head/beret/ncr,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aMc" = (
 /obj/item/clothing/head/f13/police,
 /obj/item/clothing/under/f13/police,
@@ -14287,12 +13872,12 @@
 	},
 /area/f13/village)
 "aMN" = (
-/mob/living/simple_animal/hostile/ghoul/reaver,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/area/f13/village)
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aMO" = (
 /obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/f13/wood{
@@ -14437,9 +14022,12 @@
 	},
 /area/f13/village)
 "aNi" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aNj" = (
 /obj/structure/chair,
 /obj/effect/spawner/lootdrop/trash,
@@ -14521,11 +14109,14 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "aNt" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/structure/decoration/clock/old{
+	pixel_y = 32
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/ncr)
 "aNu" = (
 /obj/machinery/light/small,
 /obj/structure/table/wood/settler,
@@ -15096,12 +14687,18 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "aOY" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/ammo_box/magazine/m556/rifle/small,
+/obj/item/ammo_box/magazine/m556/rifle/small,
+/obj/item/ammo_box/magazine/m556/rifle/small,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "aOZ" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/full,
@@ -15144,9 +14741,17 @@
 	},
 /area/f13/city)
 "aPe" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr,
+/obj/item/clothing/head/f13/ncr/goggles,
+/obj/item/clothing/head/f13/ncr/goggles,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "aPf" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -15277,11 +14882,9 @@
 	},
 /area/f13/wasteland)
 "aPz" = (
-/obj/structure/closet,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark";
-	tag = "icon-redmark (SOUTHWEST)"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2";
+	tag = "icon-horizontalbottomborderbottom2"
 	},
 /area/f13/ncr)
 "aPA" = (
@@ -15663,9 +15266,12 @@
 	},
 /area/f13/brotherhood)
 "aQz" = (
-/obj/structure/closet/crate/wicker,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/structure/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aQA" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -15978,14 +15584,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"aRu" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	tag = "icon-housewindow"
-	},
-/obj/structure/curtain,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
 "aRv" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/snacks/f13/porknbeans,
@@ -16220,10 +15818,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/building)
 "aSh" = (
 /obj/structure/toilet{
@@ -16399,12 +15994,17 @@
 	},
 /area/f13/wasteland)
 "aSK" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
+/obj/structure/bed,
+/obj/machinery/light{
 	dir = 4;
-	icon_state = "dirtcorner"
+	light_color = "#c1caff"
 	},
-/area/f13/wasteland)
+/obj/item/bedsheet{
+	icon_state = "sheethos";
+	tag = "icon-sheethos"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aSL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16843,16 +16443,9 @@
 /area/f13/village)
 "aTY" = (
 /obj/structure/rack,
-/obj/item/stack/f13Cash/random/ncr/high,
-/obj/item/stack/f13Cash/random/ncr/high,
-/obj/item/stack/f13Cash/random/ncr/high,
-/obj/item/stack/f13Cash/random/ncr/high,
-/obj/item/stack/f13Cash/random/denarius/high,
-/obj/item/stack/f13Cash/random/bottle_cap/high,
-/obj/item/stack/f13Cash/random/bottle_cap/high,
-/obj/item/stack/f13Cash/random/bottle_cap/high,
-/obj/item/stack/f13Cash/random/bottle_cap/high,
-/obj/item/stack/f13Cash/random/aureus/high,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "aTZ" = (
@@ -17329,9 +16922,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "aVu" = (
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/ncrlieutenant,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aVv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -18328,12 +17924,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aYs" = (
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/ncrcolonel,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "aYt" = (
 /obj/structure/sink/well/dwell,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18348,6 +17941,7 @@
 /obj/structure/table,
 /obj/item/ammo_box/c10mm,
 /obj/item/clothing/ears/earmuffs,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark";
@@ -18405,10 +17999,6 @@
 /obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"aYC" = (
-/obj/structure/closet/hazard,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
 "aYD" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
@@ -18701,6 +18291,7 @@
 	id = 4;
 	pixel_y = 32
 	},
+/mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/f13{
 	icon_state = "darkredfull";
 	tag = "icon-darkredfull"
@@ -19185,12 +18776,21 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bax" = (
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/structure/bed,
+/obj/effect/landmark/start/f13/ncrrecruit,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
-/area/f13/wasteland)
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/ncr)
 "bay" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -19679,12 +19279,21 @@
 	},
 /area/f13/radiation)
 "bbL" = (
-/mob/living/simple_animal/hostile/handy/gutsy,
-/turf/open/floor/f13{
-	icon_state = "darkredfull";
-	tag = "icon-darkredfull"
+/obj/structure/bed,
+/obj/effect/landmark/start/f13/ncrrecruit,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
 	},
-/area/f13/bunker)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/ncr)
 "bbM" = (
 /obj/machinery/door/poddoor{
 	id = 42
@@ -19749,10 +19358,19 @@
 	},
 /area/f13/building)
 "bbW" = (
-/obj/structure/chair/bench,
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/a556,
+/obj/item/ammo_box/a556,
+/obj/item/ammo_box/a556,
+/obj/item/ammo_box/magazine/m556/rifle,
+/obj/item/ammo_box/magazine/m556/rifle,
+/obj/item/ammo_box/magazine/m556/rifle,
+/obj/item/ammo_box/magazine/m556/rifle,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "bbX" = (
 /obj/structure/table/wood,
 /obj/item/mining_scanner,
@@ -20013,12 +19631,15 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building)
 "bcH" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outerpavement"
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/marksman/servicerifle,
+/obj/item/gun/ballistic/automatic/marksman/servicerifle,
+/obj/item/gun/ballistic/automatic/marksman/servicerifle,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bcI" = (
 /obj/structure/bed/mattress,
 /turf/open/floor/f13/wood,
@@ -20055,14 +19676,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bcO" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
+/obj/structure/rack,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/village)
+/area/f13/ncr)
 "bcP" = (
 /obj/structure/chair{
 	dir = 4;
@@ -20379,12 +20004,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bdE" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2bottom";
-	tag = "icon-verticalrightborderleft2bottom"
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/obj/item/clothing/suit/armor/f13/ncrarmor,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bdF" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/shoes/f13/military/diesel,
@@ -20581,12 +20211,16 @@
 	},
 /area/f13/building)
 "beh" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0";
-	tag = "icon-horizontaltopborderbottom0"
+/obj/machinery/camera{
+	dir = 5;
+	icon_state = "camera";
+	network = list("ss13","ncr");
+	tag = "icon-camera (NORTHEAST)"
 	},
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bei" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/road{
@@ -20601,13 +20235,6 @@
 	tag = "icon-floorrusty"
 	},
 /area/f13/city)
-"bek" = (
-/obj/machinery/photocopier,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
 "bel" = (
 /obj/structure/chair,
 /obj/effect/decal/remains{
@@ -20663,11 +20290,11 @@
 	},
 /area/f13/building)
 "ber" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
 	},
-/area/f13/building)
+/area/f13/ncr)
 "bes" = (
 /obj/structure/piano,
 /turf/open/floor/f13{
@@ -20805,11 +20432,10 @@
 	},
 /area/f13/building)
 "beL" = (
-/mob/living/simple_animal/hostile/gecko,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland)
+/obj/structure/table/wood/settler,
+/obj/item/pen/fountain,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "beM" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbrokenvertical";
@@ -21209,13 +20835,10 @@
 	},
 /area/f13/wasteland)
 "bfL" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt";
-	tag = "icon-dirt (WEST)"
-	},
-/area/f13/wasteland)
+/obj/item/paper_bin,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bfM" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0";
@@ -21524,7 +21147,8 @@
 /area/f13/brotherhood)
 "bgD" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2";
@@ -21605,7 +21229,8 @@
 	tag = "icon-remains"
 	},
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull";
@@ -21613,17 +21238,9 @@
 	},
 /area/f13/building)
 "bgO" = (
-/obj/structure/window/fulltile/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bgP" = (
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
@@ -21644,8 +21261,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building)
 "bgT" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
+	},
 /area/f13/wasteland)
 "bgU" = (
 /obj/docking_port/stationary{
@@ -21738,6 +21359,7 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /obj/item/clothing/head/beret,
 /obj/item/clothing/ears/earmuffs,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	dir = 10;
 	icon_state = "redmark";
@@ -21877,7 +21499,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bhw" = (
-/turf/closed/wall/f13/wood/house,
+/obj/structure/bed/mattress,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bhx" = (
 /obj/structure/simple_door/metal/store{
@@ -21888,13 +21511,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bhy" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "bhz" = (
 /obj/item/seeds/poppy/broc,
 /turf/open/indestructible/ground/outside/desert,
@@ -21940,6 +21556,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -22001,6 +21618,7 @@
 /obj/item/clothing/suit/armor/vest,
 /obj/structure/closet,
 /obj/item/clothing/head/beret,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -22018,9 +21636,16 @@
 	},
 /area/f13/admeme)
 "bhO" = (
-/obj/effect/mob_spawner/molerat,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/ncr)
 "bhP" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
@@ -22132,6 +21757,7 @@
 "bih" = (
 /obj/structure/chair{
 	dir = 4;
+	icon_state = "chair";
 	tag = "icon-chair (EAST)"
 	},
 /turf/open/floor/f13{
@@ -22244,7 +21870,7 @@
 /area/f13/building)
 "biz" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -22299,6 +21925,7 @@
 "biG" = (
 /obj/structure/chair{
 	dir = 1;
+	icon_state = "chair";
 	tag = "icon-chair (NORTH)"
 	},
 /obj/effect/decal/remains{
@@ -22432,6 +22059,7 @@
 "biY" = (
 /obj/structure/sink{
 	dir = 8;
+	icon_state = "sink";
 	pixel_x = -12;
 	tag = "icon-sink (WEST)"
 	},
@@ -22765,7 +22393,8 @@
 "bjW" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -22857,9 +22486,9 @@
 	},
 /area/f13/building)
 "bkj" = (
-/obj/structure/kitchenspike/cross,
+/obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/legion)
 "bkk" = (
 /obj/structure/chair{
 	dir = 4
@@ -22883,12 +22512,10 @@
 	},
 /area/f13/wasteland)
 "bkn" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
+/turf/open/indestructible/ground/outside/road{
+	dir = 1;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (NORTH)"
 	},
 /area/f13/ncr)
 "bko" = (
@@ -22950,32 +22577,18 @@
 /obj/item/disk/data,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/science/biology)
-"bkv" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "redmark";
-	tag = "icon-redmark"
-	},
-/area/f13/ncr)
 "bkw" = (
 /obj/structure/table/wood,
 /obj/item/radio/off,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"bkx" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
-	},
-/area/f13/ncr)
 "bky" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/chair/stool{
+	dir = 4;
+	icon_state = "bench";
+	tag = "icon-bench (EAST)"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "bkz" = (
 /obj/structure/closet/crate/bin,
@@ -22994,19 +22607,31 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bkC" = (
-/obj/structure/weightlifter,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0";
-	tag = "icon-horizontalbottomborderbottom0"
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/c4570,
+/obj/item/ammo_box/c4570,
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/tube/m44,
+/obj/item/ammo_box/tube/m44,
+/obj/item/ammo_box/tube/m44,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bkD" = (
-/obj/structure/stacklifter,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0";
-	tag = "icon-horizontalbottomborderbottom0"
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/ninemil,
+/obj/item/gun/ballistic/automatic/pistol/ninemil,
+/obj/item/gun/ballistic/automatic/pistol/ninemil,
+/obj/item/gun/ballistic/automatic/pistol/ninemil,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bkE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/settler,
@@ -23083,13 +22708,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "bkR" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerborder";
-	tag = "icon-outerborder (EAST)"
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun,
+/obj/item/gun/ballistic/shotgun,
+/obj/item/gun/ballistic/shotgun,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bkS" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23097,20 +22724,6 @@
 	tag = "icon-horizontalbottomborderbottomright"
 	},
 /area/f13/wasteland)
-"bkT" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"bkU" = (
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
-	},
-/area/f13/ncr)
 "bkV" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -23125,33 +22738,21 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
 "bkX" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheethos";
+	tag = "icon-sheethos"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bkY" = (
 /obj/machinery/door/airlock,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/science/biology)
 "bkZ" = (
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/closet,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark";
-	tag = "icon-redmark (SOUTHWEST)"
-	},
+/obj/effect/landmark/poster_spawner/ncr,
+/turf/closed/wall/f13/store,
 /area/f13/ncr)
 "bla" = (
 /obj/structure/sink{
@@ -23188,13 +22789,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "blf" = (
-/mob/living/simple_animal/hostile/radroach,
+/mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "blg" = (
-/obj/structure/simple_door/interior,
+/obj/structure/chair{
+	dir = 8;
+	icon_state = "chair";
+	tag = "icon-chair (WEST)"
+	},
+/obj/effect/landmark/start/f13/ncrcaptain,
 /turf/open/floor/f13/wood,
-/area/f13/clinic)
+/area/f13/ncr)
 "blh" = (
 /obj/machinery/light{
 	dir = 4
@@ -23243,32 +22849,24 @@
 	},
 /area/f13/building)
 "blm" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark";
-	tag = "icon-redmark (SOUTHWEST)"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom3";
+	tag = "icon-horizontalbottomborderbottom3"
 	},
 /area/f13/ncr)
 "bln" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/cell_charger,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
+/obj/machinery/photocopier,
+/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "blo" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "blp" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/landmark/start/f13/ncrrecruit,
 /turf/open/floor/f13{
-	icon_state = "floorrusty"
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/ncr)
 "blq" = (
@@ -23286,19 +22884,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bls" = (
-/obj/structure/simple_door/metal/dirtystore,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
-	},
+/turf/open/indestructible/ground/outside/road,
 /area/f13/ncr)
 "blt" = (
-/obj/item/flag/ncr,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/turf/closed/wall/f13/store{
+	icon_state = "store3"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "blu" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt{
@@ -23365,10 +22957,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"blD" = (
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/ncr)
 "blE" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/settler,
@@ -23409,9 +22997,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "blK" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/f13/town,
-/obj/item/clothing/suit/armor/f13/town,
+/obj/machinery/autolathe/constructionlathe,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "blL" = (
@@ -23419,13 +23005,13 @@
 /turf/closed/wall/f13/wood,
 /area/f13/city)
 "blM" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/area/f13/ncr)
 "blN" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -23512,29 +23098,29 @@
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
 "blY" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0";
-	tag = "icon-horizontaltopbordertop0"
+	dir = 1;
+	icon_state = "horizontaloutermain1";
+	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
 /area/f13/ncr)
 "blZ" = (
-/obj/structure/table/wood/settler,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/gauze,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"bma" = (
+/obj/structure/bed,
 /obj/effect/landmark/start/f13/ncrrecruit,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
 	},
 /area/f13/ncr)
 "bmb" = (
@@ -23562,18 +23148,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bme" = (
-/obj/structure/sink/puddle,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"bmf" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	tag = "icon-sheetcmo"
-	},
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/c9mm,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
+/obj/item/ammo_box/magazine/m9mm,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
 /area/f13/ncr)
 "bmg" = (
@@ -23629,11 +23212,13 @@
 /turf/closed/wall/f13/store,
 /area/f13/city)
 "bmo" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "bmp" = (
 /obj/structure/sink/well/dwell,
 /turf/open/indestructible/ground/outside/dirt,
@@ -23721,11 +23306,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/science/biology)
 "bmD" = (
-/obj/structure/table/wood/settler,
-/obj/item/defibrillator/loaded,
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/marksman/servicerifle/varmint,
+/obj/item/gun/ballistic/automatic/marksman/servicerifle/varmint,
+/obj/item/gun/ballistic/automatic/marksman/servicerifle/varmint,
 /turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
 /area/f13/ncr)
 "bmE" = (
@@ -23775,7 +23362,7 @@
 /area/f13/building)
 "bmL" = (
 /obj/structure/table,
-/obj/item/radio/off,
+/obj/item/radio,
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
 	tag = "icon-floorrusty"
@@ -23786,6 +23373,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/landmark/start/f13/settler,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bmN" = (
@@ -23949,14 +23537,18 @@
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/vents)
 "bnk" = (
-/obj/structure/toilet,
-/obj/effect/decal/remains/human,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/obj/effect/spawner/lootdrop/f13/armor/tier1,
+/obj/structure/rack,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/area/f13/village)
+/area/f13/ncr)
 "bnl" = (
 /obj/structure/spacevine{
 	name = "odd vines"
@@ -23989,9 +23581,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/vents)
 "bnq" = (
-/obj/machinery/autolathe/constructionlathe,
-/turf/open/floor/f13/wood,
-/area/f13/city)
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
+	},
+/area/f13/ncr)
 "bnr" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -24067,7 +23662,8 @@
 /area/f13/building)
 "bnD" = (
 /obj/structure/simple_door/metal/fence{
-	dir = 8
+	dir = 8;
+	icon_state = "fence"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -24079,6 +23675,7 @@
 	tag = "icon-chair (NORTH)"
 	},
 /obj/machinery/light,
+/obj/effect/landmark/start/f13/settler,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bnF" = (
@@ -24141,6 +23738,7 @@
 /area/f13/vault/vents)
 "bnN" = (
 /obj/machinery/light,
+/obj/effect/landmark/start/f13/settler,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -24304,14 +23902,17 @@
 /turf/open/floor/plating,
 /area/f13/city)
 "boj" = (
-/obj/effect/landmark/start/f13/settler,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/turf/open/floor/f13{
+	icon_state = "yellowdirtyfull";
+	tag = "icon-yellowdirtyfull"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bok" = (
 /obj/structure/spacevine{
 	name = "odd vines"
@@ -24417,13 +24018,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"boz" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
 "boA" = (
 /obj/machinery/door/poddoor/shutters{
 	id = 560;
@@ -24493,7 +24087,6 @@
 	},
 /obj/item/flashlight/pen,
 /obj/item/flashlight/pen,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2";
 	tag = "icon-bluedirtychess2"
@@ -24579,8 +24172,6 @@
 	},
 /obj/item/reagent_containers/syringe/medx,
 /obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2";
 	tag = "icon-bluedirtychess2"
@@ -24664,33 +24255,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/clinic)
 "bpg" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/floor/wood/f13/stage_tl,
-/area/f13/wasteland)
+/obj/item/clothing/suit/armor/f13/ncrarmor/mantle,
+/obj/item/clothing/suit/armor/f13/ncrarmor/mantle,
+/obj/item/clothing/under/f13/ncr/officer,
+/obj/item/clothing/under/f13/ncr/officer,
+/obj/structure/closet/cabinet,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bph" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
-"bpi" = (
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/wasteland)
-"bpj" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/wasteland)
-"bpk" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/floor/wood/f13/stage_tr,
-/area/f13/wasteland)
-"bpl" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
 "bpm" = (
 /obj/machinery/light,
 /turf/open/floor/f13/wood,
@@ -24748,18 +24325,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
-"bpw" = (
-/turf/open/floor/wood/f13/stage_l,
-/area/f13/wasteland)
 "bpx" = (
 /obj/item/screwdriver,
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/city)
-"bpy" = (
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
 "bpz" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -24770,24 +24341,23 @@
 	},
 /turf/open/floor/plating,
 /area/f13/city)
-"bpA" = (
-/turf/open/floor/wood/f13/stage_r,
-/area/f13/wasteland)
 "bpB" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 10;
-	icon_state = "dirt";
-	tag = "icon-dirt (SOUTHWEST)"
+/obj/machinery/camera{
+	dir = 5;
+	icon_state = "camera";
+	network = list("ss13","ncr");
+	tag = "icon-camera (NORTHEAST)"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bpC" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
+/obj/structure/closet/crate/wooden,
+/obj/item/stack/sheet/glass/ten,
+/obj/item/stack/sheet/mineral/wood/five,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/area/f13/wasteland)
+/area/f13/caves)
 "bpD" = (
 /obj/machinery/button/door{
 	id = 560;
@@ -24809,33 +24379,33 @@
 	},
 /area/f13/wasteland)
 "bpF" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+/obj/machinery/camera{
+	dir = 5;
+	icon_state = "camera";
+	network = list("ss13","ncr");
+	tag = "icon-camera (NORTHEAST)"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/decoration/sign{
+	desc = "It's a portrait of a person you don't know anything about.";
+	icon_state = "painting_president";
+	name = "portrait";
+	pixel_y = -30
+	},
+/obj/effect/landmark/start/f13/ncrlieutenant,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/ncr)
 "bpG" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
-	},
-/area/f13/wasteland)
-"bpH" = (
-/obj/structure/guillotine,
+/obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/f13/wood,
-/area/f13/wasteland)
-"bpI" = (
-/obj/structure/bonfire,
-/turf/open/floor/f13/wood,
-/area/f13/wasteland)
+/area/f13/ncr)
 "bpJ" = (
 /obj/structure/closet/crate{
 	icon_state = "medicalcrate";
 	tag = "icon-medicalcrate"
 	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /obj/item/reagent_containers/blood/radaway,
 /obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/f13{
@@ -24924,31 +24494,40 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bpX" = (
-/obj/structure/target_stake,
-/obj/item/target,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/closet/cabinet,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/ncr)
 "bpY" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"bpZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "bqa" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
+/obj/machinery/camera{
+	dir = 1;
+	icon_state = "camera";
+	network = list("ss13","ncr");
+	tag = "icon-camera (NORTH)"
 	},
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bqb" = (
-/turf/open/floor/wood/f13/stage_bl,
-/area/f13/wasteland)
+/obj/structure/closet/cabinet,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/obj/item/storage/belt/military/assault/ncr,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull";
+	tag = "icon-greenrustyfull"
+	},
+/area/f13/ncr)
 "bqc" = (
 /obj/structure/simple_door/house{
 	icon_state = "roomopening";
@@ -24960,8 +24539,8 @@
 	},
 /area/f13/city)
 "bqd" = (
-/turf/open/floor/wood/f13/stage_b,
-/area/f13/wasteland)
+/turf/closed/wall/f13/tunnel,
+/area/f13/legion)
 "bqe" = (
 /obj/structure/closet,
 /obj/item/clothing/glasses/regular,
@@ -24976,21 +24555,14 @@
 	},
 /area/f13/city)
 "bqf" = (
-/turf/open/floor/wood/f13/stage_br,
-/area/f13/wasteland)
-"bqg" = (
-/obj/structure/rack,
-/obj/machinery/light/small,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/legion)
+"bqg" = (
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "bqh" = (
 /obj/structure/table/wood,
@@ -25072,8 +24644,6 @@
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/syringe/medx,
 /obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /obj/effect/spawner/lootdrop/clothing_middle,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
@@ -25084,12 +24654,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bqu" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/cautery,
+/obj/item/razor,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bqv" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -25100,46 +24673,44 @@
 	},
 /area/f13/city)
 "bqw" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
+/obj/structure/table/optable,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bqx" = (
-/obj/structure/table/wood/settler,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
-	},
-/area/f13/wasteland)
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/legion)
 "bqy" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/item/surgicaldrill,
+/obj/item/circular_saw,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bqz" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 9;
-	icon_state = "dirt";
-	tag = "icon-dirt (NORTHWEST)"
+/obj/structure/closet/crate{
+	icon_state = "medicalcrate";
+	tag = "icon-medicalcrate"
 	},
-/area/f13/wasteland)
+/obj/item/reagent_containers/syringe/medx,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bqA" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bqB" = (
-/obj/structure/simple_door/metal/store{
-	icon_state = "brokenstore";
-	tag = "icon-brokenstore"
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
@@ -25151,48 +24722,50 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bqD" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
-/area/f13/wasteland)
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/ncr)
 "bqE" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bqF" = (
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/item/flag/ncr,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
+	},
+/area/f13/ncr)
 "bqG" = (
-/obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/obj/machinery/camera{
+	network = list("ss13","ncr")
 	},
-/area/f13/wasteland)
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (EAST)"
+	},
+/area/f13/ncr)
 "bqH" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
+/turf/open/floor/f13{
+	icon_state = "stagestairs";
+	tag = "icon-stagestairs"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "bqI" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
 	},
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
+	},
+/area/f13/ncr)
 "bqJ" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -25336,45 +24909,43 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "brd" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/closed/wall/f13/store,
+/area/f13/legion)
 "bre" = (
-/obj/item/storage/box/matches,
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/effect/landmark/poster_spawner/prewar,
+/turf/closed/wall/f13/store,
+/area/f13/legion)
 "brf" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/matches,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/safe,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "brg" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/legionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"brh" = (
-/obj/structure/fence,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bri" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/pill/patch/legionmedx,
-/obj/item/reagent_containers/pill/patch/legionmedx,
-/obj/item/reagent_containers/pill/patch/legionmedx,
-/obj/item/reagent_containers/pill/patch/legionmedx,
-/obj/item/reagent_containers/pill/patch/legionmedx,
-/obj/item/reagent_containers/pill/patch/legionmedx,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"brj" = (
-/obj/structure/kitchenspike/cross,
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt";
-	tag = "icon-dirt"
+/obj/item/flag/ncr,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (EAST)"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
+"brh" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/ncrranger,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
+"bri" = (
+/obj/effect/landmark/start/f13/ncrranger,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
+"brj" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/caves)
 "brk" = (
 /obj/structure/simple_door/house{
 	icon_state = "room";
@@ -25393,65 +24964,81 @@
 	},
 /area/f13/city)
 "brm" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
+/obj/structure/table,
+/obj/item/retractor,
+/obj/item/hemostat,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "brn" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/landmark/start/f13/recleg,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bro" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
-	},
-/obj/effect/landmark/start/f13/recleg,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/ncr)
 "brp" = (
-/obj/structure/table/optable,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder";
+	tag = "icon-outerborder"
+	},
+/area/f13/ncr)
 "brq" = (
-/obj/structure/table/wood/settler,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing/blue,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"brr" = (
-/obj/structure/table/wood/settler,
-/obj/item/clothing/gloves/boxing/green,
-/obj/item/clothing/gloves/boxing/yellow,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"brs" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/effect/landmark/start/f13/recleg,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"brt" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
-	},
-/obj/effect/landmark/start/f13/recleg,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bru" = (
-/obj/item/flag/legion,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"brv" = (
 /obj/structure/fence/corner{
+	dir = 1;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/ncr)
+"brr" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (EAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
+"brs" = (
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/landmark/start/f13/ncrveteranranger,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
+"brt" = (
+/obj/structure/table/wood/settler,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/gauze,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
+"bru" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/cell_charger,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
+"brv" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindow";
+	tag = "icon-housewindow"
+	},
+/obj/structure/curtain,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "brw" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -25464,9 +25051,13 @@
 	},
 /area/f13/city)
 "brx" = (
-/obj/structure/simple_door/metal/fence,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (NORTH)"
+	},
+/area/f13/ncr)
 "bry" = (
 /obj/structure/simple_door/house{
 	icon_state = "dirtyglassopening";
@@ -25538,17 +25129,11 @@
 	},
 /area/f13/city)
 "brF" = (
-/obj/structure/rack,
-/obj/item/radio/off,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2left";
+	tag = "icon-horizontalbottomborderbottom2left"
 	},
-/area/f13/legion)
+/area/f13/ncr)
 "brG" = (
 /obj/structure/simple_door/house{
 	icon_state = "interioropening";
@@ -25609,11 +25194,12 @@
 	},
 /area/f13/building)
 "brO" = (
-/obj/structure/fence/corner{
-	dir = 4
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2";
+	tag = "icon-horizontalbottomborderbottom2"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/ncr)
 "brP" = (
 /obj/structure/destructible/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
@@ -25622,12 +25208,6 @@
 	tag = "icon-dirtcorner (EAST)"
 	},
 /area/f13/wasteland)
-"brQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
 "brR" = (
 /obj/structure/closet/hazard,
 /turf/open/floor/f13{
@@ -25653,29 +25233,37 @@
 	},
 /area/f13/wasteland)
 "brW" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"brX" = (
-/obj/effect/landmark/start/f13/librator,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"brY" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"bsb" = (
-/obj/item/storage/trash_stack,
-/turf/open/indestructible/ground/outside/dirt{
+"brX" = (
+/obj/machinery/light/lampost{
 	dir = 1;
-	icon_state = "dirt"
+	pixel_x = -32
 	},
-/area/f13/wasteland)
+/obj/structure/target_stake,
+/obj/item/target,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder";
+	tag = "icon-outerborder (EAST)"
+	},
+/area/f13/ncr)
+"brY" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (EAST)"
+	},
+/obj/effect/landmark/start/f13/ncrranger,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
+"bsb" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "bsc" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/f13/wood,
@@ -25717,16 +25305,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "bsk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/table/wood/settler,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bsl" = (
-/obj/structure/table/wood,
-/obj/item/stack/f13Cash/random/bottle_cap/med,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bsm" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -25777,13 +25369,6 @@
 	tag = "icon-dirt (NORTHWEST)"
 	},
 /area/f13/wasteland)
-"bsr" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
 "bss" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -25792,18 +25377,16 @@
 	},
 /area/f13/wasteland)
 "bst" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
+/turf/closed/wall/f13/store{
+	icon_state = "store5"
 	},
 /area/f13/ncr)
 "bsu" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bsv" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -25813,27 +25396,27 @@
 	},
 /area/f13/admeme)
 "bsw" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bsx" = (
-/obj/item/melee/curator_whip{
-	desc = "It stings like hell to be hit by.";
-	name = "Slave whip"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (WEST)"
 	},
-/obj/item/melee/chainofcommand{
-	name = "Slave whip"
-	},
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bsy" = (
-/obj/structure/fence,
-/obj/machinery/light,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/target_stake,
+/obj/item/target,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/ncr)
 "bsz" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -25843,9 +25426,14 @@
 	},
 /area/f13/admeme)
 "bsA" = (
-/obj/structure/simple_door/brokenglass,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/rack,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bsB" = (
 /obj/structure/simple_door/house{
 	icon_state = "dirtyglassopen";
@@ -25928,13 +25516,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bsM" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor5-old";
-	tag = "icon-floor5-old"
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/ncr)
 "bsN" = (
 /obj/structure/chair/stool,
 /obj/effect/spawner/lootdrop/trash,
@@ -25974,12 +25564,13 @@
 	},
 /area/f13/wasteland)
 "bsT" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right (WEST)"
 	},
-/obj/effect/landmark/start/f13/slavemaster,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bsU" = (
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/desert,
@@ -25993,20 +25584,19 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bsX" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft";
-	tag = "icon-storewindowleft"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/item/claymore/machete,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bsY" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowhorizontal";
-	tag = "icon-storewindowhorizontal (NORTHEAST)"
+/obj/structure/decoration/hatch{
+	dir = 1;
+	icon_state = "hatch"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
+	},
+/area/f13/ncr)
 "bsZ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
@@ -26059,37 +25649,32 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "btj" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowright";
-	tag = "icon-storewindowright"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right";
+	tag = "icon-horizontaltopborderbottom2right"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "btk" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
-	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/mob/living/simple_animal/chicken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "btl" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
-	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "btm" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/uzim9mm/empty,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "btn" = (
-/obj/effect/landmark/start/f13/auxilia,
-/obj/structure/destructible/tribal_torch,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
+	},
+/area/f13/ncr)
 "bto" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -26139,15 +25724,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/f13/wood,
 /area/f13/city)
-"btw" = (
-/obj/structure/closet,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark";
-	tag = "icon-redmark (SOUTHWEST)"
-	},
-/area/f13/ncr)
 "btx" = (
 /obj/structure/table,
 /obj/item/kitchen/knife,
@@ -26190,34 +25766,36 @@
 	},
 /area/f13/wasteland)
 "btF" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/landmark/start/f13/centurion,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0";
+	tag = "icon-horizontaltopborderbottom0"
+	},
+/area/f13/ncr)
 "btG" = (
-/obj/structure/chair/comfy{
-	dir = 4;
-	tag = "icon-comfychair (EAST)"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "btH" = (
-/obj/structure/showcase/machinery/tv{
-	name = "Old television";
-	pixel_x = 2;
-	pixel_y = 3
+/obj/effect/landmark/start/f13/ncrveteranranger,
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/table/wood/settler,
 /turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "btI" = (
-/obj/machinery/photocopier,
 /obj/machinery/light{
-	dir = 1
+	dir = 8;
+	icon_state = "tube"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "btJ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderrighttop";
@@ -26225,9 +25803,12 @@
 	},
 /area/f13/wasteland)
 "btK" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left (WEST)"
+	},
+/area/f13/ncr)
 "btL" = (
 /obj/structure/chair/wood/worn{
 	dir = 1
@@ -26302,38 +25883,37 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "btX" = (
-/obj/structure/table/wood/settler,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop2";
+	tag = "icon-horizontalbottombordertop2"
+	},
+/area/f13/ncr)
 "btY" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/computer/terminal,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner"
+	},
+/area/f13/ncr)
 "btZ" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/turf/closed/wall/f13/store{
+	icon_state = "store9"
 	},
 /area/f13/ncr)
 "bua" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 1
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "verticalinnermainbottom";
+	tag = "icon-verticalinnermainbottom (WEST)"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bub" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (WEST)"
 	},
-/area/f13/wasteland)
+/area/f13/ncr)
 "buc" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26342,20 +25922,23 @@
 	},
 /area/f13/wasteland)
 "bud" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
-	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
 "bue" = (
-/obj/effect/landmark/start/f13/auxilia,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole";
+	tag = "icon-hole"
+	},
+/area/f13/ncr)
 "buf" = (
-/obj/structure/closet,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
+	},
+/area/f13/wasteland)
 "bug" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -26445,47 +26028,43 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "but" = (
-/obj/structure/closet/cabinet,
-/obj/item/twohanded/binocs,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"buu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"buv" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/cash_legion_med,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"buw" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bux" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
 	},
-/obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
+"buv" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2"
+	},
+/area/f13/ncr)
+"buw" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "buy" = (
-/obj/effect/landmark/start/f13/priestess,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2 (WEST)"
+	},
+/area/f13/ncr)
 "buz" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop2";
+	tag = "icon-horizontalbottombordertop2"
+	},
+/area/f13/ncr)
 "buA" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/neck/stethoscope,
@@ -26498,54 +26077,41 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "buB" = (
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/fence/corner{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "buC" = (
-/obj/structure/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/legate,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	dir = 1;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (NORTH)"
+	},
+/area/f13/ncr)
 "buD" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/matches,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"buE" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/shoes/sandal,
-/obj/item/clothing/under/f13/rag,
-/obj/item/clothing/under/f13/rag,
-/obj/item/clothing/under/f13/rag,
-/obj/item/clothing/under/f13/rag,
-/obj/item/clothing/under/f13/rag,
-/obj/item/clothing/shoes/sandal,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter"
+	},
+/area/f13/ncr)
 "buF" = (
-/obj/structure/closet/cabinet,
-/obj/item/assembly/signaler/electropack/shockcollar,
-/obj/item/assembly/signaler/electropack/shockcollar,
-/obj/item/assembly/signaler/electropack/shockcollar,
-/obj/item/assembly/signaler/electropack/shockcollar,
-/obj/item/assembly/signaler/electropack/shockcollar,
-/obj/item/assembly/signaler/electropack/boomcollar,
-/obj/item/assembly/signaler/electropack/boomcollar,
-/obj/item/assembly/signaler/electropack/boomcollar,
-/obj/item/assembly/signaler/electropack/boomcollar,
-/obj/item/assembly/signaler/electropack/shockcollar,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (WEST)"
+	},
+/area/f13/ncr)
 "buG" = (
-/obj/structure/table/wood/settler,
-/obj/item/assembly/signaler/advanced,
-/obj/item/assembly/signaler/advanced,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalbottombordertopleft";
+	tag = "icon-horizontalbottombordertopleft (WEST)"
+	},
+/area/f13/ncr)
 "buH" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
@@ -26613,143 +26179,119 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "buR" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/box/matches,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermainleft";
+	tag = "icon-horizontalinnermainleft"
+	},
+/area/f13/ncr)
+"buS" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
-/area/f13/legion)
-"buS" = (
-/obj/structure/punching_bag,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"buT" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "buU" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
-"buV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/village)
-"buW" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"buX" = (
-/obj/structure/destructible/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt";
-	tag = "icon-dirt (WEST)"
-	},
-/area/f13/wasteland)
-"buY" = (
 /obj/structure/sink{
 	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
+/area/f13/ncr)
+"buV" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (EAST)"
+	},
+/area/f13/ncr)
+"buW" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
+"buY" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road{
+	dir = 1;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (NORTH)"
+	},
+/area/f13/ncr)
 "buZ" = (
-/obj/structure/toilet{
-	dir = 8
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (EAST)"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/soap/deluxe,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
-/area/f13/legion)
+/area/f13/ncr)
 "bva" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/chair/wood,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ncr)
 "bvb" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetcmo";
+	tag = "icon-sheetcmo"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bvc" = (
-/obj/structure/weightlifter,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/ncr)
 "bvd" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/fence/corner{
+	dir = 9
 	},
-/area/f13/legion)
-"bve" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bvf" = (
-/obj/machinery/shower{
+/obj/structure/fence{
 	dir = 8
 	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bvg" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/vexillarius,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ncr)
 "bvh" = (
-/obj/structure/closet/cabinet,
-/obj/item/claymore/machete/gladius,
-/obj/item/claymore/machete/gladius,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvi" = (
-/obj/machinery/light{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (EAST)"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvj" = (
-/obj/structure/chalkboard,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvk" = (
-/obj/structure/table/wood/settler,
-/obj/item/pen,
-/turf/open/floor/f13/wood,
+/area/f13/ncr)
+"bvi" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "bvl" = (
 /turf/closed/indestructible/fakeglass,
 /area/f13/tunnel)
 "bvn" = (
-/obj/structure/chair/wood/fancy{
-	dir = 4
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/wood/f13/stage_tr,
+/area/f13/wasteland)
 "bvo" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
 "bvp" = (
 /obj/effect/decal/remains{
 	icon_state = "remains";
@@ -26766,43 +26308,39 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "bvr" = (
-/obj/structure/chair/wood/fancy{
-	dir = 8
+/obj/machinery/iv_drip,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvs" = (
-/obj/structure/table/wood/settler,
-/obj/item/shovel/spade,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bvt" = (
-/obj/effect/landmark/start/f13/vexillarius,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ncr)
 "bvu" = (
-/obj/structure/simple_door/dirtyglass,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvv" = (
-/obj/structure/table/wood/settler,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
 	},
-/turf/open/floor/f13/wood,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ncr)
+"bvv" = (
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "bvw" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/cash_legion_low,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/bed,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
 "bvx" = (
-/obj/structure/legion_extractor,
+/obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bvy" = (
@@ -26810,22 +26348,22 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bvz" = (
-/obj/structure/reagent_dispensers/compostbin,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/machinery/light/lampost,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/ncr)
 "bvA" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2right";
+	tag = "icon-horizontalbottomborderbottom2right"
 	},
-/area/f13/village)
+/area/f13/ncr)
 "bvB" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/simple_door/room,
+/turf/open/floor/f13,
+/area/f13/ncr)
 "bvC" = (
-/obj/structure/chair{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/f13/wood,
@@ -26849,65 +26387,67 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
 "bvG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvH" = (
-/obj/structure/fence{
+/obj/structure/mirror,
+/turf/closed/wall/f13/store,
+/area/f13/ncr)
+"bvI" = (
+/obj/structure/sink,
+/turf/closed/wall/f13/store,
+/area/f13/ncr)
+"bvM" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
-"bvI" = (
-/obj/structure/closet/cabinet,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvJ" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvK" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvL" = (
-/obj/structure/reagent_dispensers/barrel/half,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvM" = (
-/obj/structure/chair/stool,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerturn";
+	tag = "icon-outerturn (EAST)"
+	},
+/area/f13/ncr)
 "bvN" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/fence/corner{
+	dir = 1;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerturn";
+	tag = "icon-outerturn (NORTH)"
+	},
+/area/f13/ncr)
 "bvO" = (
-/obj/item/storage/bag/plants,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood/settler,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bvP" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold";
+	tag = "icon-twindowold (WEST)"
 	},
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "bvQ" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/structure/decoration/clock/old{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "bvR" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/explorer,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/simple_door/room,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "bvS" = (
 /obj/structure/kitchenspike/cross,
 /turf/open/indestructible/ground/outside/desert,
@@ -26920,51 +26460,74 @@
 	},
 /area/f13/wasteland)
 "bvU" = (
-/obj/structure/bed/mattress,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/explorer,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bvV" = (
-/obj/machinery/ammobench/makeshift,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0";
+	tag = "icon-verticalleftborderright0"
+	},
+/area/f13/ncr)
 "bvW" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/ncr)
+"bvX" = (
+/obj/structure/fence{
 	dir = 8
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
-/area/f13/village)
-"bvX" = (
-/obj/machinery/workbench,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/wasteland)
 "bvY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bvZ" = (
-/obj/structure/table,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bwa" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bwb" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/area/f13/ncr)
+"bwa" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold";
+	tag = "icon-twindowold (WEST)"
+	},
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
+"bwb" = (
+/obj/structure/chair{
+	dir = 8;
+	icon_state = "chair";
+	tag = "icon-chair (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "bwc" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/closet/cabinet,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/under/f13/rag,
+/obj/item/clothing/under/f13/rag,
+/obj/item/clothing/under/f13/rag,
+/obj/item/clothing/under/f13/rag,
+/obj/item/clothing/under/f13/rag,
+/obj/item/clothing/shoes/sandal,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bwd" = (
 /obj/structure/chair/wood{
@@ -26973,29 +26536,35 @@
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bwe" = (
-/obj/structure/bed/mattress,
-/obj/effect/landmark/start/f13/vetlegionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bwf" = (
-/obj/structure/bed/mattress,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/vetlegionary,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bwg" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
 	},
-/area/f13/legion)
-"bwh" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/ncr)
+"bwf" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00";
+	tag = "icon-toilet00 (WEST)"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2";
+	tag = "icon-bluedirtychess2"
+	},
+/area/f13/ncr)
+"bwg" = (
+/obj/structure/fence/corner{
+	dir = 4;
+	icon_state = "end"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
+	},
+/area/f13/ncr)
 "bwi" = (
 /obj/item/clothing/under/f13/female/tribal,
 /turf/open/indestructible/ground/outside/desert,
@@ -27012,218 +26581,177 @@
 	},
 /area/f13/wasteland)
 "bwl" = (
-/obj/structure/table/wood/settler,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
-/obj/item/seeds/tea,
-/obj/item/seeds/tea,
-/obj/item/seeds/cotton,
-/obj/item/seeds/cotton,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/item/flag/ncr,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left";
+	tag = "icon-horizontaltopbordertop2left"
+	},
+/area/f13/wasteland)
 "bwm" = (
-/obj/structure/sink/well/dwell,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerturn";
+	tag = "icon-outerturn"
+	},
+/area/f13/ncr)
 "bwo" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/cash_legion_low,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left";
+	tag = "icon-horizontalinnermain2left (WEST)"
+	},
+/area/f13/ncr)
 "bwp" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
 	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
-	},
-/area/f13/legion)
+/area/f13/ncr)
 "bwq" = (
-/obj/item/storage/belt/military/assault/legion,
-/obj/item/storage/belt/military/assault/legion,
-/obj/item/storage/belt/military/assault/legion,
-/obj/item/storage/belt/military/assault/legion,
-/obj/item/storage/belt/military/assault/legion,
-/obj/structure/rack,
-/obj/item/storage/belt/military/assault/legion,
-/obj/item/storage/belt/military/assault/legion,
-/obj/item/storage/belt/military/assault/legion,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/table/wood/settler,
+/obj/item/toy/cards/deck,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right"
+	},
+/area/f13/ncr)
 "bwr" = (
-/obj/item/storage/backpack/spearquiver,
-/obj/item/storage/backpack/spearquiver,
-/obj/item/storage/backpack/spearquiver,
-/obj/structure/rack,
-/obj/item/throwing_star/spear,
-/obj/item/throwing_star/spear,
-/obj/item/throwing_star/spear,
-/obj/item/throwing_star/spear,
-/obj/item/throwing_star/spear,
-/obj/item/throwing_star/spear,
-/obj/item/storage/backpack/spearquiver,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0";
+	tag = "icon-verticalrightborderleft0"
+	},
+/area/f13/ncr)
 "bws" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/drinks/flask/survival/legion,
-/obj/item/reagent_containers/food/drinks/flask/survival/legion,
-/obj/item/reagent_containers/food/drinks/flask/survival/legion,
-/obj/item/reagent_containers/food/drinks/flask/survival/legion,
-/obj/item/reagent_containers/food/drinks/flask/survival/legion,
-/obj/item/reagent_containers/food/drinks/flask/survival/legion,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
+/area/f13/ncr)
 "bwt" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop2";
+	tag = "icon-horizontalbottombordertop2"
+	},
+/area/f13/ncr)
 "bwu" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/tunnel)
 "bwv" = (
-/obj/structure/rack,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop3";
+	tag = "icon-horizontalbottombordertop3"
+	},
+/area/f13/ncr)
 "bww" = (
-/obj/structure/rack,
-/obj/item/ammo_box/magazine/mm762,
-/obj/item/ammo_box/magazine/mm762,
-/obj/item/ammo_box/magazine/mm762,
-/obj/item/ammo_box/magazine/mm762,
-/obj/item/ammo_box/magazine/mm762,
-/obj/item/ammo_box/magazine/mm762,
-/obj/item/gun/ballistic/automatic/l6_saw/m38,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right"
+	},
+/area/f13/ncr)
 "bwx" = (
-/obj/structure/rack,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/ammo_box/c10mm,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "bwy" = (
-/obj/structure/rack,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a357,
-/obj/item/ammo_box/a357,
-/obj/item/ammo_box/a357,
-/obj/item/ammo_box/a357,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bwz" = (
-/obj/structure/table/wood/settler,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/watermelon,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner";
+	tag = "icon-outerbordercorner (NORTH)"
+	},
+/area/f13/ncr)
 "bwA" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bwB" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2";
+	tag = "icon-verticalinnermain2"
+	},
+/area/f13/wasteland)
 "bwC" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/wasteland)
 "bwD" = (
-/obj/structure/dresser,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "verticalinnermainbottom";
+	tag = "icon-verticalinnermainbottom (WEST)"
+	},
+/area/f13/wasteland)
 "bwE" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/item/soap,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerinner";
+	tag = "icon-innermaincornerinner (WEST)"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bwF" = (
-/obj/structure/table/wood/settler,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/item/seeds/onion,
-/obj/item/seeds/onion,
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/legion)
 "bwG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/decanus,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "verticalinnermaintop";
+	tag = "icon-verticalinnermaintop (WEST)"
+	},
+/area/f13/wasteland)
 "bwH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
-/obj/effect/landmark/start/f13/primedecanus,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/mob_spawner/molerat,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bwI" = (
-/obj/structure/rack,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion,
-/obj/item/shield/legion,
-/obj/item/shield/legion,
-/obj/item/shield/legion,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion/buckler,
-/obj/item/shield/legion,
-/obj/item/shield/legion,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2";
+	tag = "icon-verticalinnermain2"
+	},
+/area/f13/wasteland)
 "bwJ" = (
-/obj/structure/rack,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
+/area/f13/wasteland)
 "bwK" = (
-/obj/structure/rack,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/obj/item/claymore/machete,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
+/area/f13/wasteland)
 "bwL" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/cleanable/oil,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
+/area/f13/wasteland)
 "bwM" = (
 /obj/item/clothing/under/f13/tribal,
 /turf/open/indestructible/ground/outside/desert,
@@ -27236,135 +26764,107 @@
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"bwP" = (
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
-"bwQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
 "bwR" = (
-/obj/structure/rack,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/effect/decal/marking,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
+/area/f13/wasteland)
 "bwS" = (
-/obj/structure/rack,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/item/restraints/legcuffs/bola,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
 "bwT" = (
 /obj/effect/landmark/start/f13/mayor,
 /turf/open/floor/f13/wood,
 /area/f13/city)
 "bwU" = (
-/obj/structure/rack,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/simple_door/room,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
+	},
+/area/f13/ncr)
 "bwV" = (
-/obj/structure/rack,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light/small,
 /turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/building)
 "bwW" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
+/turf/closed/wall/f13/wood/house,
 /area/f13/legion)
 "bwX" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/structure/closet/cabinet,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bwY" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bwZ" = (
-/obj/structure/campfire/stove,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bxa" = (
-/obj/structure/table,
-/obj/machinery/light,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"bxb" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (WEST)"
+	},
+/area/f13/wasteland)
+"bxb" = (
+/obj/structure/closet/cabinet,
+/obj/item/assembly/signaler/electropack/shockcollar,
+/obj/item/assembly/signaler/electropack/shockcollar,
+/obj/item/assembly/signaler/electropack/shockcollar,
+/obj/item/assembly/signaler/electropack/shockcollar,
+/obj/item/assembly/signaler/electropack/shockcollar,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bxc" = (
-/obj/structure/table/wood/settler,
-/obj/item/seeds/carrot,
-/obj/item/seeds/potato,
-/obj/item/seeds/potato,
+/obj/structure/bed/mattress/pregame,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
 "bxd" = (
-/obj/structure/simple_door/metal/store,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bxe" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/structure/fence{
+	dir = 8;
+	icon_state = "straight"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 2;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
 "bxf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
+/obj/structure/fence/corner{
+	dir = 6;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "bxg" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating,
@@ -27387,95 +26887,111 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "bxk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop2";
+	tag = "icon-horizontalbottombordertop2"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bxl" = (
-/obj/structure/table/wood/settler,
-/obj/item/storage/toolbox/mechanical/old,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/fence/corner{
+	dir = 10;
+	icon_state = "corner"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bxm" = (
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (EAST)"
+	},
+/area/f13/wasteland)
 "bxn" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermainbottom";
+	tag = "icon-verticaloutermainbottom"
 	},
-/area/f13/legion)
+/area/f13/wasteland)
 "bxo" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "bxp" = (
-/obj/structure/rack,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/fence/corner,
+/obj/structure/fence/corner{
+	dir = 10;
+	icon_state = "corner"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermainbottom";
+	tag = "icon-verticaloutermainbottom"
+	},
+/area/f13/wasteland)
 "bxq" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outermaincornerouter";
+	tag = "icon-outermaincornerouter (NORTH)"
+	},
+/area/f13/wasteland)
 "bxr" = (
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/shovel,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "plating"
+/obj/structure/fence/corner{
+	dir = 8;
+	icon_state = "corner"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "bxs" = (
-/obj/structure/reagent_dispensers/barrel/three,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
+/area/f13/wasteland)
 "bxt" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/kitchen/knife/butcher,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
-/area/f13/legion)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "bxu" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/area/f13/legion)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
+	},
+/area/f13/wasteland)
 "bxv" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid";
-	tag = "icon-floordirtysolid"
-	},
-/area/f13/legion)
+/turf/closed/wall/f13/ruins,
+/area/f13/village)
 "bxA" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -27552,20 +27068,6 @@
 /obj/item/storage/backpack/satchel/leather,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"bys" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/ammo_box/a556,
-/obj/item/ammo_box/a556,
-/obj/item/ammo_box/a556,
-/obj/item/ammo_box/magazine/m556/rifle,
-/obj/item/ammo_box/magazine/m556/rifle,
-/obj/item/ammo_box/magazine/m556/rifle,
-/obj/item/ammo_box/magazine/m556/rifle,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
 "byC" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -27599,21 +27101,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "byH" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"byL" = (
 /obj/structure/rack,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/area/f13/ncr)
+/area/f13/caves)
 "byM" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "byY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -27628,37 +27129,35 @@
 /turf/open/floor/plating,
 /area/f13/outpost)
 "bza" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/lethalshot,
-/obj/item/ammo_box/magazine/m556/rifle/small,
-/obj/item/ammo_box/magazine/m556/rifle/small,
-/obj/item/ammo_box/magazine/m556/rifle/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/obj/structure/chair/office{
+	dir = 4;
+	icon_state = "chair";
+	tag = "icon-chair (EAST)"
 	},
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bzb" = (
+/obj/structure/table/wood,
+/obj/structure/decoration/rag{
+	icon_state = "flag_ncr";
+	name = "NCR banner";
+	pixel_x = 32;
+	tag = "icon-flag_ncr"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"bzg" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/weldingtool/experimental/brass,
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/area/f13/ncr)
+/area/f13/caves)
 "bzi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "bzn" = (
 /obj/structure/cable{
@@ -27683,28 +27182,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "bzr" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
+/obj/structure/bed/mattress/pregame,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bzv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/ncr)
+/obj/structure/closet,
+/obj/item/reagent_containers/pill/patch/jet,
+/obj/item/reagent_containers/pill/patch/jet,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "bzx" = (
-/obj/machinery/ammobench/makeshift,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "bzG" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -27744,19 +27234,17 @@
 /turf/open/floor/plating,
 /area/f13/outpost)
 "bAp" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9;
+	icon_state = "tracks";
+	tag = "icon-tracks (NORTHWEST)"
 	},
-/area/f13/ncr)
-"bAq" = (
-/obj/structure/holohoop{
-	dir = 4;
-	tag = "icon-hoop (EAST)"
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"bAz" = (
+/obj/structure/chair/stool,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bAC" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
@@ -27887,12 +27375,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood)
-"bAV" = (
-/obj/structure/rack,
-/obj/item/mining_scanner,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating/tunnel,
-/area/f13/ncr)
 "bAY" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
@@ -28414,6 +27896,11 @@
 "bCt" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/tunnel)
+"bCu" = (
+/obj/structure/chair/stool,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bCv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -28539,6 +28026,13 @@
 	tag = "icon-floordirtysolid"
 	},
 /area/f13/brotherhood)
+"bCL" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/caves)
 "bCM" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet,
@@ -28794,10 +28288,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
 "bDO" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/closed/wall/r_wall/rust,
 /area/f13/ncr)
 "bDR" = (
 /obj/structure/table/reinforced,
@@ -28880,15 +28371,16 @@
 	},
 /area/f13/brotherhood)
 "bEc" = (
-/obj/machinery/workbench,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4;
+	icon_state = "tracks";
+	tag = "icon-tracks (EAST)"
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bEd" = (
 /obj/structure/toilet{
 	dir = 4
@@ -29246,9 +28738,9 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/tunnel)
 "bFy" = (
-/obj/machinery/light/small,
-/obj/machinery/jukebox,
-/turf/open/floor/plating/tunnel,
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "ruins3"
+	},
 /area/f13/ncr)
 "bFz" = (
 /obj/structure/sink/kitchen,
@@ -29537,30 +29029,22 @@
 	},
 /area/f13/brotherhood)
 "bGB" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/c9mm,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/ammo_box/magazine/m9mm,
-/obj/item/ammo_box/magazine/m9mm,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4;
+	icon_state = "tracks";
+	tag = "icon-tracks (EAST)"
 	},
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bGF" = (
-/obj/structure/closet/crate{
-	icon_state = "medicalcrate";
-	tag = "icon-medicalcrate"
+/obj/structure/simple_door/house,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4;
+	icon_state = "tracks";
+	tag = "icon-tracks (EAST)"
 	},
-/obj/item/reagent_containers/syringe/medx,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bGK" = (
 /obj/structure/chair{
 	dir = 1
@@ -29830,12 +29314,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
 "bIm" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5;
+	icon_state = "tracks";
+	tag = "icon-tracks (NORTHEAST)"
 	},
-/area/f13/ncr)
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bIn" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/hydrofloor,
@@ -29874,6 +29360,18 @@
 	},
 /turf/open/floor/plasteel/hydrofloor,
 /area/f13/brotherhood)
+"bIy" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
 "bIC" = (
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull";
@@ -33320,20 +32818,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/vault/diner)
 "bUW" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/ammo_box/c4570,
-/obj/item/ammo_box/c4570,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/tube/m44,
-/obj/item/ammo_box/tube/m44,
-/obj/item/ammo_box/tube/m44,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/obj/structure/decoration/clock{
+	pixel_y = 30
 	},
-/area/f13/ncr)
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "bUZ" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -38832,6 +38321,14 @@
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/vault/storage)
+"cnp" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/obj/effect/decal/waste{
+	icon_state = "goo8";
+	tag = "icon-goo8"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "cnt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -39021,10 +38518,8 @@
 	},
 /area/f13/brotherhood)
 "cnS" = (
-/obj/landmark/vertibird{
-	name = "LZ 4 - NCR Outpost"
-	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "cnT" = (
 /obj/effect/mine/explosive,
@@ -39105,7 +38600,7 @@
 "cop" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/f13/store,
-/area/f13/wasteland)
+/area/f13/building)
 "coq" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -39237,99 +38732,78 @@
 	},
 /area/f13/wasteland)
 "cpe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (EAST)"
+	},
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter";
+	tag = "icon-innermaincornerouter (EAST)"
 	},
 /area/f13/ncr)
 "cpg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "cpl" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "cpm" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/simple_door/metal/store,
+/turf/open/floor/f13,
 /area/f13/ncr)
 "cpn" = (
-/obj/structure/chair/bench,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2right";
+	tag = "icon-horizontalinnermain2right (WEST)"
 	},
 /area/f13/ncr)
 "cpo" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
+	},
 /area/f13/ncr)
 "cpp" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0";
+	tag = "icon-verticalrightborderright0"
 	},
-/turf/open/floor/f13/wood,
 /area/f13/ncr)
 "cpq" = (
-/obj/structure/closet,
-/obj/item/storage/bag/plants/portaseeder,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "cps" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "redmark";
-	tag = "icon-redmark"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
 "cpt" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/decoration/clock/old{
+	pixel_y = 32
+	},
+/obj/effect/landmark/start/f13/ncrsergeant,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
 	},
 /area/f13/ncr)
 "cpu" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/f13/ncr,
-/obj/item/clothing/head/f13/ncr,
-/obj/item/clothing/head/f13/ncr,
-/obj/item/clothing/head/f13/ncr,
-/obj/item/clothing/head/f13/ncr,
-/obj/item/clothing/head/f13/ncr,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/mask/ncr_facewrap,
-/obj/item/clothing/accessory/ncr/REC,
-/obj/item/clothing/accessory/ncr/REC,
-/obj/item/clothing/accessory/ncr/REC,
-/obj/item/clothing/accessory/ncr/REC,
-/obj/item/clothing/accessory/ncr/REC,
-/obj/item/clothing/accessory/ncr/REC,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
-"cpv" = (
-/obj/structure/chair/bench,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland)
+/obj/item/stack/f13Cash/random/bottle_cap/med,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "cpx" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39338,216 +38812,171 @@
 	},
 /area/f13/wasteland)
 "cpz" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/cautery,
-/obj/item/razor,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"cpA" = (
-/obj/structure/table/optable,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"cpB" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/surgicaldrill,
-/obj/item/circular_saw,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"cpD" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	tag = "icon-housewindow"
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/f13/wood,
+/area/f13/village)
+"cpA" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"cpB" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"cpD" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
+	},
 /area/f13/ncr)
 "cpF" = (
-/obj/structure/closet,
-/obj/item/storage/bag/plants,
-/obj/item/seeds/wheat,
-/obj/item/seeds/wheat,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair/wood/modern,
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibmid3";
+	tag = "icon-gibmid3"
 	},
+/obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/f13/wood,
-/area/f13/ncr)
+/area/f13/village)
 "cpG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
+/obj/structure/table/wood,
+/obj/item/storage/backpack/satchel/leather,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "cpS" = (
 /obj/structure/rack,
-/obj/item/kitchen/knife/combat/survival,
-/obj/item/kitchen/knife/combat/survival,
-/obj/item/kitchen/knife/combat/survival,
-/obj/item/kitchen/knife/combat/survival,
-/obj/item/kitchen/knife/combat/survival,
-/obj/item/kitchen/knife/combat/survival,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
+/obj/item/storage/pill_bottle/chem_tin/radx,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "cpT" = (
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
+/obj/item/reagent_containers/pill/patch/turbo,
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "cpU" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/hunting,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
+/obj/item/stack/f13Cash/random/bottle_cap/med,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 9;
+	icon_state = "rubble";
+	tag = "icon-rubble (NORTHWEST)"
 	},
-/area/f13/ncr)
-"cpV" = (
-/obj/structure/table/wood,
-/turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "cqb" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
-/area/f13/ncr)
-"cqd" = (
-/turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
-	},
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/f13/store,
 /area/f13/ncr)
 "cqj" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/pistol/ninemil,
-/obj/item/gun/ballistic/automatic/pistol/ninemil,
-/obj/item/gun/ballistic/automatic/pistol/ninemil,
-/obj/item/gun/ballistic/automatic/pistol/ninemil,
-/turf/open/floor/f13{
-	icon_state = "yellowdirtyfull";
-	tag = "icon-yellowdirtyfull"
-	},
-/area/f13/ncr)
-"cqk" = (
-/obj/structure/table,
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
-"cql" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/ncr)
-"cqn" = (
-/obj/structure/simple_door/metal/fence{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavement";
-	tag = "icon-outerpavement (EAST)"
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
 	},
 /area/f13/wasteland)
+"cqk" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubble";
+	tag = "icon-rubble (NORTH)"
+	},
+/area/f13/wasteland)
+"cql" = (
+/turf/closed/wall/r_wall/f13composite{
+	icon_state = "ruins12"
+	},
+/area/f13/ncr)
+"cqn" = (
+/turf/closed/wall/f13/store{
+	icon_state = "store12"
+	},
+/area/f13/ncr)
 "cqt" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood/f13/stage_t,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
+	},
 /area/f13/ncr)
 "cqu" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/f13/ncrrecruit,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"cqv" = (
-/obj/machinery/light{
-	dir = 8
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (NORTH)"
 	},
+/area/f13/wasteland)
+"cqv" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0";
-	tag = "icon-verticalrightborderright0"
+	icon_state = "horizontaltopbordertop2right";
+	tag = "icon-horizontaltopbordertop2right"
 	},
 /area/f13/ncr)
 "cqw" = (
-/turf/closed/wall/f13/wood,
+/obj/structure/table/wood/settler,
+/obj/item/twohanded/binocs,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
 /area/f13/ncr)
 "cqD" = (
-/obj/structure/legion_extractor,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
+/obj/structure/chair/stool,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "cqH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/ncr)
 "crb" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "crv" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0";
+	tag = "icon-verticalinnermain0"
+	},
+/area/f13/wasteland)
+"crA" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 4;
+	icon_state = "tube"
 	},
 /turf/open/indestructible/ground/outside/dirt,
-/area/f13/ncr)
-"crA" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
+/area/f13/village)
 "crB" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/gun/ballistic/automatic/pistol/ninemil,
+/obj/item/ammo_casing/c9mm,
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
 	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "crC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
 	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "crD" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "bluedirtychess2";
-	tag = "icon-bluedirtychess2"
-	},
-/area/f13/ncr)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "crF" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
+	icon_state = "housewindow";
 	tag = "icon-housewindow"
 	},
 /obj/structure/barricade/wooden/planks/pregame,
@@ -39557,8 +38986,8 @@
 	},
 /area/f13/ncr)
 "crG" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/paper_bin,
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
 	tag = "icon-floorrusty"
@@ -39567,7 +38996,6 @@
 "crK" = (
 /obj/structure/table,
 /obj/item/pen,
-/obj/item/paper_bin,
 /turf/open/floor/f13{
 	icon_state = "floorrusty";
 	tag = "icon-floorrusty"
@@ -39575,25 +39003,36 @@
 /area/f13/ncr)
 "crN" = (
 /obj/structure/fence{
-	dir = 8
+	dir = 8;
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
+	dir = 6;
 	icon_state = "outerpavement";
-	tag = "icon-outerpavement (EAST)"
+	tag = "icon-outerpavement (SOUTHEAST)"
 	},
 /area/f13/wasteland)
 "crR" = (
-/obj/structure/table/wood/settler,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gibmid3";
+	pixel_x = -10;
+	pixel_y = -2;
+	tag = "icon-gibmid3"
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso";
+	tag = "icon-gibtorso"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "cse" = (
 /obj/item/flag/ncr,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft2";
-	tag = "icon-verticalleftborderleft2"
+	icon_state = "outerborder";
+	tag = "icon-outerborder"
 	},
 /area/f13/wasteland)
 "csi" = (
@@ -39614,25 +39053,132 @@
 	tag = "icon-horizontalinnermain2"
 	},
 /area/f13/wasteland)
+"cvM" = (
+/turf/open/floor/wood/f13/stage_b,
+/area/f13/wasteland)
 "cwe" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib1-old";
+	tag = "icon-gib1-old"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"cwR" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
 /area/f13/wasteland)
 "cJV" = (
-/obj/structure/bonfire,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/blood/gibs/down{
+	icon_state = "gib3-old";
+	pixel_x = 20;
+	tag = "icon-gib3-old"
+	},
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"cKk" = (
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"cKQ" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"cLJ" = (
+/turf/open/floor/wood/f13/stage_bl,
+/area/f13/wasteland)
+"cMw" = (
+/obj/structure/table/wood/settler,
+/obj/item/claymore/machete/gladius,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "cUo" = (
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
-"djA" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+"cWu" = (
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"cWx" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/stack/f13Cash/random/bottle_cap/med,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"cXL" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
+	},
+/area/f13/wasteland)
+"cXZ" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"cYt" = (
+/obj/structure/reagent_dispensers/barrel/four,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"ddk" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"dgT" = (
+/obj/structure/table/wood/settler,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/lighter,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"djA" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"djD" = (
+/obj/structure/rack,
+/obj/item/shovel,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/caves)
 "dpr" = (
-/obj/structure/bed/dogbed,
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
+	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "dqu" = (
@@ -39644,12 +39190,36 @@
 	tag = "icon-floorrusty"
 	},
 /area/f13/caves)
-"dIH" = (
-/obj/structure/table/wood/settler,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
+"dxy" = (
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"dCz" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/twohanded/binocs,
+/obj/item/storage/box/matches,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"dIH" = (
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft0";
+	tag = "icon-verticalleftborderleft0"
+	},
 /area/f13/wasteland)
+"dKM" = (
+/obj/structure/chair/stool{
+	dir = 6;
+	icon_state = "bench_center";
+	tag = "icon-bench_center (SOUTHEAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "dNB" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/road{
@@ -39665,6 +39235,14 @@
 	tag = "icon-dirt (EAST)"
 	},
 /area/f13/wasteland)
+"dPg" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHWEST)"
+	},
+/area/f13/wasteland)
 "dRi" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -39675,46 +39253,130 @@
 	tag = "icon-verticalrightborderrighttop"
 	},
 /area/f13/wasteland)
-"dXJ" = (
-/obj/structure/legion_extractor,
+"dRL" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"dVv" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"dXJ" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 4;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (EAST)"
+	},
 /area/f13/wasteland)
 "dXP" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"dZg" = (
+/obj/structure/table/wood/settler,
+/obj/item/melee/curator_whip{
+	desc = "It stings like hell to be hit by.";
+	name = "Slave whip"
+	},
+/obj/item/melee/chainofcommand{
+	name = "Slave whip"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"ecb" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"efb" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"efS" = (
+/obj/structure/fence/corner{
+	dir = 9;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"ehJ" = (
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "ekc" = (
 /obj/structure/fence{
-	dir = 8
+	dir = 8;
+	icon_state = "straight"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 7;
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
-"epP" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey";
-	tag = "icon-sheetgrey"
+"elx" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken";
-	tag = "icon-housewood4-broken"
-	},
-/area/f13/village)
-"esz" = (
-/obj/structure/rack,
-/obj/item/stack/medical/gauze/improvised,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"epC" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"epP" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubblecorner";
+	tag = "icon-rubblecorner (WEST)"
+	},
+/area/f13/wasteland)
+"eqX" = (
+/obj/structure/simple_door/fakeglass,
+/obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"esz" = (
+/obj/structure/bed/mattress/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eyl" = (
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"ezE" = (
+/obj/structure/table/wood/settler,
+/obj/item/wirecutters/brass,
+/obj/item/screwdriver,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "eAc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -39724,6 +39386,13 @@
 	},
 /turf/closed/wall/r_wall/f13/vault,
 /area/f13/brotherhood)
+"eEx" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8;
+	icon_state = "fence"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eHs" = (
 /obj/structure/closet/crate/bin{
 	desc = "Smells like shit.";
@@ -39733,31 +39402,56 @@
 /area/f13/ruins)
 "eHM" = (
 /obj/structure/rack,
-/obj/item/clothing/under/f13/female/tribal,
-/obj/item/clothing/under/f13/female/tribal,
-/obj/item/clothing/under/f13/female/tribal,
-/obj/item/clothing/under/f13/tribal,
-/obj/item/clothing/under/f13/tribal,
-/obj/item/clothing/under/f13/tribal,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "eIH" = (
 /obj/machinery/light/small/broken{
 	dir = 8
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"eKF" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (EAST)"
+	},
+/area/f13/wasteland)
 "eKK" = (
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"eTT" = (
-/mob/living/simple_animal/hostile/radroach,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+"eLz" = (
+/obj/structure/fence/corner{
+	dir = 5;
+	icon_state = "corner"
 	},
-/area/f13/village)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"eTT" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	tag = "icon-tree_3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
+	},
+/area/f13/wasteland)
 "eVa" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/indestructible/ground/inside/mountain,
@@ -39772,29 +39466,82 @@
 	tag = "icon-verticalrightborderright3"
 	},
 /area/f13/wasteland)
-"fbV" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+"eWt" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1;
+	icon_state = "comfychair";
+	tag = "icon-comfychair (NORTH)"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
-"feF" = (
+"eZU" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/f13/tribal,
-/obj/item/clothing/suit/armor/f13/tribal,
-/obj/item/clothing/suit/armor/f13/tribal,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/ammo_box/c10mm,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"fbV" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"fcy" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/revolver/caravan_shotgun,
+/obj/item/gun/ballistic/revolver/caravan_shotgun,
+/obj/item/gun/ballistic/revolver/caravan_shotgun,
+/obj/item/gun/ballistic/revolver/caravan_shotgun,
+/obj/item/gun/ballistic/revolver/caravan_shotgun,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"feF" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt";
+	tag = "icon-dirt (WEST)"
+	},
+/area/f13/wasteland)
+"fkW" = (
+/obj/structure/table/wood/settler,
+/obj/item/twohanded/binocs,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"frt" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"ftK" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 2;
+	icon_state = "outerpavementcorner";
+	tag = "icon-outerpavementcorner"
+	},
+/area/f13/wasteland)
 "fuN" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32";
 	tag = "icon-wasteland32"
 	},
 /area/f13/ruins)
+"fvW" = (
+/obj/structure/simple_door/wood,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"fxk" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "fxn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -39802,83 +39549,176 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "fyo" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindow";
+	tag = "icon-housewindow"
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "fCw" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fFq" = (
-/obj/item/candle/tribal_torch,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"fFu" = (
+/obj/structure/table/wood/settler,
 /turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
+	dir = 10;
 	icon_state = "dirt";
-	tag = "icon-dirt (WEST)"
+	tag = "icon-dirt (SOUTHWEST)"
 	},
 /area/f13/wasteland)
 "fHx" = (
-/obj/effect/landmark/start/f13/chief,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
-"fJF" = (
-/obj/structure/table/wood/settler,
-/obj/item/reagent_containers/pill/patch/healpoultice,
-/obj/item/reagent_containers/pill/patch/healpoultice,
-/turf/open/floor/f13/wood,
-/area/f13/legion)
-"fKC" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/random,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
-"fMj" = (
+/obj/item/stack/sheet/animalhide/human,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"fHG" = (
 /obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skin";
-	tag = "icon-skin"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
-"fWz" = (
-/obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner";
-	tag = "icon-dirtcorner"
+	dir = 4;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"fIF" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"fJF" = (
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"fKC" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"fLm" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4;
+	icon_state = "comfychair";
+	tag = "icon-comfychair (EAST)"
+	},
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"fMj" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00";
+	pixel_x = -3;
+	pixel_y = 0;
+	tag = "icon-toilet00 (EAST)"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"fNW" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"fRv" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/shoes/legionleather,
+/obj/item/clothing/shoes/legionleather,
+/obj/item/clothing/shoes/legionleather,
+/obj/item/clothing/shoes/legionleather,
+/obj/item/clothing/shoes/legionleather,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"fUZ" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench_center";
+	tag = "icon-bench_center (WEST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"fWz" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"fYc" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "fZN" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	pixel_y = 3;
+	termtag = "Home"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"gdO" = (
+/obj/structure/closet,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"geV" = (
+/obj/structure/chalkboard,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop2right";
-	tag = "icon-horizontaltopbordertop2right"
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"gfl" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
 	},
-/area/f13/ncr)
-"gdO" = (
-/obj/structure/chair/comfy{
+/area/f13/wasteland)
+"ggv" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"ggy" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"gij" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/filingcabinet,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"gky" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/light/small,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"gld" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4;
+	icon_state = "comfychair";
+	tag = "icon-comfychair (EAST)"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
-"geV" = (
-/obj/structure/table/wood/settler,
-/obj/item/wirecutters,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+"glq" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "glL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39892,13 +39732,30 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"gmY" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
 "gpq" = (
-/obj/structure/chair{
-	dir = 4;
-	tag = "icon-chair (EAST)"
+/obj/structure/fence/corner{
+	dir = 1;
+	icon_state = "corner"
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"gpH" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/carrot,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
 "gxC" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -39911,12 +39768,33 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"gCv" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
+"gyA" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"gyK" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench";
+	tag = "icon-bench (WEST)"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"gCv" = (
+/obj/structure/closet/fridge/cannibal,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"gED" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/legion)
 "gFA" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -39935,12 +39813,68 @@
 	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
-"gWz" = (
-/obj/structure/simple_door/house,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
+"gKP" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"gKR" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"gME" = (
+/obj/structure/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"gPo" = (
+/obj/structure/rack,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/caves)
+"gQe" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"gQS" = (
+/obj/structure/rack,
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/m44,
+/obj/item/ammo_box/m44,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/m44,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/obj/item/ammo_box/a357,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"gWz" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	tag = "icon-skulls"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "gXD" = (
 /turf/open/floor/f13{
@@ -39948,10 +39882,17 @@
 	tag = "icon-floorrusty"
 	},
 /area/f13/caves)
+"gZC" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "heY" = (
-/obj/structure/bed,
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
 "hfB" = (
@@ -39971,6 +39912,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"hjY" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "hlw" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 5;
@@ -39978,25 +39924,91 @@
 	tag = "icon-dirt (NORTHEAST)"
 	},
 /area/f13/wasteland)
+"hmD" = (
+/obj/structure/closet/cabinet,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/gauze,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "hwF" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"hxV" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"hyl" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"hBB" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"hCM" = (
+/obj/structure/chair/wood/worn,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"hHj" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/helmet/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/obj/item/clothing/suit/armor/f13/legion/recruit,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"hJn" = (
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "hKE" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"hNx" = (
+/obj/effect/landmark/start/f13/legate,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"hPw" = (
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"hSX" = (
+/obj/machinery/workbench,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"hYd" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"hYk" = (
+/turf/open/floor/wood/f13/stage_t,
 /area/f13/wasteland)
 "ibj" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ijo" = (
-/obj/structure/rack,
-/obj/item/seeds/xander,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
+/obj/structure/toilet{
+	dir = 1;
+	icon_state = "toilet00";
+	tag = "icon-toilet00 (NORTH)"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "ijq" = (
 /obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
@@ -40004,6 +40016,19 @@
 	tag = "icon-horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"imi" = (
+/obj/effect/mob_spawner/molerat,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"ivc" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/obj/item/clothing/under/f13/legskirt,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "iwx" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore";
@@ -40013,11 +40038,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "ixM" = (
-/obj/structure/chair/wood,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 10;
+	pixel_y = 0;
+	tag = "icon-sink (EAST)"
 	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "iMk" = (
 /obj/machinery/light/lampost,
@@ -40028,28 +40059,47 @@
 	},
 /area/f13/wasteland)
 "iWS" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress1"
-	},
-/mob/living/simple_animal/hostile/ghoul,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/rack,
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"iYe" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "iYy" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33";
 	tag = "icon-wasteland33"
 	},
 /area/f13/ruins)
-"jgK" = (
-/obj/structure/chair/bench,
-/obj/effect/landmark/start/f13/villager,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/village)
-"jkN" = (
-/obj/effect/landmark/start/f13/shaman,
-/mob/living/simple_animal/hostile/ghoul,
+"jbB" = (
+/obj/structure/weightlifter,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"jfn" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"jgC" = (
+/obj/item/flag/legion,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"jgK" = (
+/obj/structure/fence/corner{
+	dir = 4;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"jkN" = (
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "jla" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40079,6 +40129,30 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/city)
+"jqC" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"jrS" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical"
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	tag = "icon-skulls"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"jsS" = (
+/obj/structure/table/wood/settler,
+/obj/item/assembly/signaler/advanced,
+/obj/item/assembly/signaler/advanced,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "jwd" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40086,31 +40160,81 @@
 	tag = "icon-horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"jwt" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	tag = "icon-shower (WEST)"
+	},
+/obj/item/soap/deluxe,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"jyn" = (
+/obj/structure/chair/wood,
+/obj/effect/landmark/start/f13/decanus,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"jyr" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "jAZ" = (
-/obj/structure/fence{
-	dir = 1
+/obj/structure/simple_door/metal/store{
+	icon_state = "brokenstore";
+	tag = "icon-brokenstore"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/decoration/rag,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"jDu" = (
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"jEc" = (
+/obj/item/shovel/spade,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"jGA" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "jJI" = (
-/obj/structure/bed/mattress,
-/obj/item/bedsheet{
-	icon_state = "sheetgrey";
-	tag = "icon-sheetgrey"
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "storewindowright";
+	tag = "icon-storewindowright"
 	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"jMn" = (
+/obj/structure/bed/mattress/pregame,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/stack/f13Cash/random/bottle_cap/med,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
 "jNm" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/brotherhood)
 "jSS" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
 	},
-/area/f13/village)
+/area/f13/wasteland)
 "jWh" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old{
@@ -40127,10 +40251,58 @@
 	tag = "icon-outerborder (WEST)"
 	},
 /area/f13/wasteland)
-"kid" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/outside/dirt,
+"jXp" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"kcv" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"kdj" = (
+/obj/structure/toilet{
+	dir = 4;
+	icon_state = "toilet00";
+	pixel_x = -3;
+	pixel_y = 0;
+	tag = "icon-toilet00 (EAST)"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"khX" = (
+/obj/structure/decoration/clock{
+	pixel_y = 30
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"kid" = (
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (EAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"kmy" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 2;
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland)
+"koI" = (
+/obj/structure/rack,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/caves)
 "kpC" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -40138,18 +40310,45 @@
 	tag = "icon-verticalrightborderleft0"
 	},
 /area/f13/wasteland)
-"krJ" = (
-/obj/structure/simple_door/room,
-/turf/open/floor/f13{
-	icon_state = "floorrusty";
-	tag = "icon-floorrusty"
-	},
-/area/f13/ncr)
-"kwf" = (
+"kra" = (
 /obj/structure/table/wood/settler,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/kitchen/knife,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"krc" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"krJ" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/clothing_middle,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"ktI" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"ktT" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
+/area/f13/wasteland)
+"kwf" = (
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "kAA" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -40160,20 +40359,47 @@
 	tag = "icon-horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland)
+"kFm" = (
+/obj/structure/kitchenspike/cross,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"kMK" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8;
+	icon_state = "fence"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"lbZ" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/obj/item/gun/ballistic/revolver/colt357,
+/obj/item/gun/ballistic/revolver/colt357,
+/obj/item/gun/ballistic/revolver/colt357,
+/obj/item/gun/ballistic/revolver/colt357,
+/obj/item/gun/ballistic/revolver/colt357,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
 "ljE" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "lmA" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/knife,
-/obj/item/hatchet,
-/obj/item/lighter,
-/obj/item/wirecutters,
-/obj/item/screwdriver,
-/obj/item/crowbar,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	tag = "icon-sink (WEST)"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "lwX" = (
 /obj/machinery/computer/shuttle/vault113elevator{
@@ -40185,6 +40411,34 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/tunnel)
+"lBN" = (
+/obj/structure/table/wood/settler,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"lCd" = (
+/obj/structure/rack,
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"lEX" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken";
+	tag = "icon-housewood3-broken"
+	},
+/area/f13/legion)
 "lHq" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old";
@@ -40192,6 +40446,17 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"lJP" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/matches,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"lKr" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "lNT" = (
 /obj/structure/billboard/ritas,
 /turf/open/indestructible/ground/outside/dirt{
@@ -40201,13 +40466,26 @@
 	},
 /area/f13/wasteland)
 "lRH" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/decoration/clock/old{
+	pixel_x = -32
 	},
-/obj/item/seeds/feracactus,
 /turf/open/floor/f13/wood,
-/area/f13/ncr)
+/area/f13/village)
+"lRM" = (
+/obj/structure/piano,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"lXI" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"mbI" = (
+/mob/living/simple_animal/hostile/old_raider/old_tribal,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "mdl" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/dirt{
@@ -40215,15 +40493,116 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"mfG" = (
+/obj/structure/destructible/tribal_torch,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"mhm" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"mjl" = (
+/obj/item/cultivator,
+/obj/item/cultivator,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"mlo" = (
+/obj/structure/rack,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/obj/item/claymore/machete,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
 "moK" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mtr" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"mtC" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
+/area/f13/legion)
+"mwk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"mwM" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"mwO" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
+	},
+/area/f13/legion)
+"mxD" = (
+/obj/structure/kitchenspike/cross,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32";
+	tag = "icon-wasteland32"
+	},
+/area/f13/wasteland)
 "myo" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"mzX" = (
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
+/area/f13/wasteland)
+"mEF" = (
+/obj/structure/chair/stool{
+	dir = 1;
+	icon_state = "bench_center";
+	tag = "icon-bench_center (NORTH)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"mFu" = (
+/obj/structure/fence/corner{
+	dir = 6;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "mLe" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old";
@@ -40231,14 +40610,77 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"mMB" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
+"mVJ" = (
+/obj/structure/rack,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion,
+/obj/item/shield/legion,
+/obj/item/shield/legion,
+/obj/item/shield/legion,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion/buckler,
+/obj/item/shield/legion,
+/obj/item/shield/legion,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"mVY" = (
+/obj/structure/rack,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
 "mWq" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"mWu" = (
+/turf/open/floor/wood/f13/stage_l,
+/area/f13/wasteland)
 "mWX" = (
-/obj/structure/dresser,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"mXv" = (
+/obj/structure/bed/dogbed,
+/obj/structure/decoration/clock/old{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"ndH" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12";
+	tag = "icon-goo12"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "nfU" = (
 /obj/structure/chair/f13chair2,
 /turf/open/floor/f13/wood,
@@ -40254,18 +40696,115 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"npx" = (
-/obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
+"nmE" = (
+/obj/structure/rack,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/area/f13/legion)
+"npx" = (
+/obj/machinery/camera{
+	network = list("ss13","ncr")
 	},
 /turf/open/floor/f13{
-	icon_state = "darkdirtysolid"
+	icon_state = "floorrusty";
+	tag = "icon-floorrusty"
 	},
 /area/f13/ncr)
+"npX" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/watermelon,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/legion)
+"nsL" = (
+/obj/structure/bed/mattress/pregame,
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"ntt" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/legion)
+"ntx" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -3;
+	tag = "icon-toilet00 (EAST)"
+	},
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/city)
+"nyj" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8";
+	tag = "icon-goo8"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"nAB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"nDM" = (
+/obj/structure/simple_door/fakeglass,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"nFT" = (
+/obj/structure/bed,
+/obj/item/bedsheet{
+	icon_state = "sheetbrown";
+	tag = "icon-sheetbrown"
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"nGh" = (
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/legion)
+"nHC" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (EAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"nJA" = (
+/obj/structure/bed/mattress/pregame,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken";
+	tag = "icon-housewood4-broken"
+	},
+/area/f13/legion)
 "nLp" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -40276,31 +40815,138 @@
 	tag = "icon-horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"nTp" = (
-/obj/structure/closet/crate/footlocker/legion,
+"nRU" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"okh" = (
-/obj/effect/landmark/start/f13/shaman,
-/turf/open/indestructible/ground/outside/dirt,
+"nTp" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (WEST)"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"nUL" = (
+/obj/structure/kitchenspike,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"nXn" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
+"okh" = (
+/obj/structure/chair/wood/modern{
+	dir = 4;
+	icon_state = "wooden_chair_old";
+	tag = "icon-wooden_chair_old (EAST)"
+	},
+/obj/effect/decal/remains{
+	icon_state = "remains";
+	tag = "icon-remains"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"omC" = (
+/obj/structure/table/wood/settler,
+/obj/item/twohanded/binocs,
+/obj/item/storage/box/matches,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"ook" = (
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"opz" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"ouN" = (
+/obj/structure/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair_settler";
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ovl" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier2,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ozC" = (
-/obj/structure/fermenting_barrel,
+"oxj" = (
+/obj/structure/chair/wood,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"ozn" = (
+/obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 8;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"ozC" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/satchel/leather,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"ozT" = (
+/obj/machinery/shower{
+	dir = 8;
+	tag = "icon-shower (WEST)"
+	},
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13{
+	icon_state = "whitegreenrustychess"
+	},
+/area/f13/building)
+"oCT" = (
+/obj/structure/simple_door/metal/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"oFn" = (
+/obj/structure/fence,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oJa" = (
 /obj/structure/closet/crate/miningcar,
 /obj/effect/spawner/lootdrop/f13/armor/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"oJK" = (
+/turf/open/floor/wood/f13/stage_br,
+/area/f13/wasteland)
+"oLV" = (
+/obj/structure/chair/wood/modern{
+	dir = 8;
+	icon_state = "wooden_chair_new";
+	tag = "icon-wooden_chair_new (WEST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "oSF" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40315,6 +40961,15 @@
 	tag = "icon-horizontaltopbordertop2right"
 	},
 /area/f13/wasteland)
+"oYM" = (
+/turf/open/floor/wood/f13/stage_tl,
+/area/f13/wasteland)
+"pdZ" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/mob/living/simple_animal/hostile/radroach,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "pgE" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -40325,6 +40980,21 @@
 	tag = "icon-verticalrightborderright1"
 	},
 /area/f13/wasteland)
+"pgI" = (
+/obj/structure/chair{
+	dir = 8;
+	icon_state = "chair";
+	tag = "icon-chair (WEST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"pim" = (
+/obj/structure/kitchenspike/cross,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	tag = "icon-dirt"
+	},
+/area/f13/wasteland)
 "plK" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore";
@@ -40332,14 +41002,32 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"psn" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor6-old";
-	tag = "icon-floor6-old"
+"poH" = (
+/obj/structure/bed/mattress/pregame,
+/obj/effect/landmark/start/f13/campfollower,
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"prX" = (
+/obj/structure/chair/stool{
+	dir = 5;
+	icon_state = "bench_center";
+	tag = "icon-bench_center (NORTHEAST)"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"psn" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	tag = "icon-sink (WEST)"
+	},
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "puP" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old";
@@ -40348,6 +41036,35 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"pwM" = (
+/obj/item/storage/backpack/spearquiver,
+/obj/item/storage/backpack/spearquiver,
+/obj/item/storage/backpack/spearquiver,
+/obj/structure/rack,
+/obj/item/throwing_star/spear,
+/obj/item/throwing_star/spear,
+/obj/item/throwing_star/spear,
+/obj/item/throwing_star/spear,
+/obj/item/throwing_star/spear,
+/obj/item/throwing_star/spear,
+/obj/item/storage/backpack/spearquiver,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"pxa" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
+	},
+/area/f13/wasteland)
+"pxN" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "pzg" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/dirt{
@@ -40356,23 +41073,52 @@
 	},
 /area/f13/wasteland)
 "pAB" = (
-/obj/structure/table/wood/settler,
-/obj/item/kitchen/knife,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/structure/dresser,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "pGL" = (
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"pHG" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
+	},
+/area/f13/legion)
+"pJA" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "pNB" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
-"qaX" = (
-/obj/landmark/vertibird{
-	name = "LZ 6 - Village Exterior"
+"pOW" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pYk" = (
+/obj/structure/kitchenspike,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"pYQ" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"qaX" = (
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "qea" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1";
@@ -40380,27 +41126,46 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qtR" = (
-/obj/structure/table/wood/settler,
-/obj/machinery/light/small{
-	dir = 1
+"qhU" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/cloth/five,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
-/obj/item/reagent_containers/pill/patch/healingpowder,
+/area/f13/caves)
+"qlE" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"qtR" = (
+/obj/structure/toilet{
+	dir = 1;
+	icon_state = "toilet00";
+	tag = "icon-toilet00 (NORTH)"
+	},
 /turf/open/floor/f13/wood,
-/area/f13/legion)
+/area/f13/village)
 "quW" = (
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
-"qDJ" = (
-/obj/structure/barricade/wooden,
-/turf/open/indestructible/ground/outside/dirt,
+"qzw" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
 /area/f13/wasteland)
+"qDJ" = (
+/obj/structure/closet/cabinet,
+/obj/effect/spawner/lootdrop/clothing_low,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "qFO" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor6-old";
@@ -40408,13 +41173,47 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"qNp" = (
-/obj/machinery/light/small{
-	dir = 4
+"qJh" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0";
+	tag = "icon-horizontalbottomborderbottom0"
 	},
-/obj/structure/closet/crate/footlocker/legion,
+/area/f13/wasteland)
+"qLa" = (
+/mob/living/simple_animal/hostile/handy,
 /turf/open/floor/f13/wood,
+/area/f13/building)
+"qNp" = (
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"qPk" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/obj/item/seeds/tea,
+/obj/item/seeds/tea,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/legion)
+"qPG" = (
+/obj/structure/reagent_dispensers/compostbin,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
+/area/f13/legion)
+"qPQ" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowvertical";
+	tag = "icon-housewindowvertical (NORTHEAST)"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "qSr" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40422,13 +41221,65 @@
 	tag = "icon-horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"qSy" = (
+/obj/structure/table/wood/settler,
+/obj/item/bedsheet{
+	icon_state = "sheetgrey";
+	tag = "icon-sheetgrey"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"qTn" = (
+/obj/structure/table/wood/settler,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"rbp" = (
+/obj/structure/reagent_dispensers/barrel/old,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"rcg" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8;
+	icon_state = "fence"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"rgf" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/onion,
+/obj/item/seeds/onion,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/legion)
+"riv" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/landmark/start/f13/centurion,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"rlW" = (
+/mob/living/simple_animal/hostile/handy/gutsy/enclave,
+/turf/open/floor/f13{
+	icon_state = "darkredfull";
+	tag = "icon-darkredfull"
+	},
+/area/f13/bunker)
 "rnb" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/structure/closet/crate/bin,
+/obj/machinery/light,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"rrE" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/caves)
 "rwN" = (
 /obj/structure/closet/crate/bin{
 	desc = "Smells like shit.";
@@ -40436,18 +41287,79 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
-"sgn" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
-"shs" = (
-/obj/machinery/light/small{
-	dir = 1
+"rBU" = (
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/structure/closet/crate/footlocker/legion,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"rEx" = (
+/obj/structure/chair/comfy,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"rGh" = (
+/mob/living/simple_animal/hostile/spawner/radroach,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/building)
+"rSv" = (
+/obj/structure/table/wood/settler,
+/obj/item/paper_bin{
+	pixel_y = 0
+	},
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"rTx" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/caves)
+"rXw" = (
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken";
+	tag = "icon-housewood2-broken"
+	},
+/area/f13/legion)
+"rYJ" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"sbH" = (
+/obj/structure/bed/mattress,
+/obj/effect/landmark/start/f13/recleg,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
+"sfA" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"sgn" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"shd" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHEAST)"
+	},
+/area/f13/legion)
+"shs" = (
+/obj/structure/closet,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "snC" = (
 /obj/structure/fence/corner,
 /turf/open/indestructible/ground/outside/desert,
@@ -40460,16 +41372,18 @@
 	},
 /area/f13/wasteland)
 "sub" = (
-/obj/structure/window/fulltile/house{
-	icon_state = "housewindowbroken";
-	tag = "icon-housewindowbroken (NORTHEAST)"
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"svh" = (
+/obj/structure/bed/mattress,
+/obj/effect/landmark/start/f13/legionary,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "sxe" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1";
@@ -40482,19 +41396,40 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "szl" = (
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/f13/armor/clothes,
-/obj/effect/spawner/lootdrop/f13/armor/random,
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"sHF" = (
+/mob/living/simple_animal/hostile/old_raider/old_biker,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2";
 	tag = "icon-housewood2"
 	},
 /area/f13/village)
+"sKc" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"sKT" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "sOk" = (
-/obj/structure/table/wood/settler,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"sQm" = (
+/obj/structure/campfire/stove,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "sSb" = (
 /mob/living/simple_animal/hostile/cazador,
 /turf/open/indestructible/ground/outside/desert{
@@ -40503,28 +41438,27 @@
 	},
 /area/f13/wasteland)
 "sUB" = (
-/obj/structure/barricade/wooden,
-/obj/structure/decoration/rag{
-	icon_state = "skulls";
-	tag = "icon-skulls"
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
-"sWl" = (
-/obj/machinery/iv_drip,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/floor/f13/wood,
+/area/f13/village)
+"sWl" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"sYQ" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/f13/wood,
+/area/f13/building)
+"tbs" = (
+/turf/closed/wall/f13/ruins,
 /area/f13/legion)
 "tfq" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "tfO" = (
 /obj/machinery/light/lampost{
@@ -40536,12 +41470,85 @@
 	tag = "icon-horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
+"thR" = (
+/mob/living/simple_animal/hostile/gecko,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0";
+	tag = "icon-horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
+"tiC" = (
+/obj/structure/closet/cabinet,
+/obj/item/instrument/guitar,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"tiY" = (
+/obj/structure/table/wood/settler,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"tku" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"tme" = (
+/obj/structure/reagent_dispensers/barrel/explosive,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTHEAST)"
+	},
+/area/f13/wasteland)
+"tmW" = (
+/obj/structure/chair/wood{
+	dir = 1;
+	tag = "icon-wooden_chair_settler (NORTH)"
+	},
+/mob/living/simple_animal/hostile/ghoul/reaver,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"tnF" = (
+/obj/structure/bed/mattress,
+/obj/effect/landmark/start/f13/vexillarius,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"tow" = (
+/obj/structure/rack,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/item/stack/crafting/powder,
+/obj/machinery/light,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"tyg" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13/wood,
+/area/f13/clinic)
+"tCa" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/ammobench/makeshift,
+/turf/open/floor/f13/wood,
+/area/f13/city)
 "tDg" = (
 /obj/machinery/door/airlock/hatch{
 	locked = 1
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/tunnel)
+"tEU" = (
+/obj/structure/guillotine,
+/turf/open/floor/f13/wood,
+/area/f13/wasteland)
 "tFI" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40550,12 +41557,12 @@
 	},
 /area/f13/wasteland)
 "tGl" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
+/obj/structure/table/wood,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Home"
 	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "tJz" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -40574,6 +41581,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random_high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tOJ" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/f13/leatherarmor,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/pill/patch/healingpowder,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
 "tQF" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/old{
@@ -40582,15 +41600,43 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tQJ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"tUZ" = (
+/obj/structure/fence/corner{
+	dir = 9;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"ubX" = (
+/obj/structure/reagent_dispensers/barrel/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"ucI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
 "ueP" = (
-/obj/structure/toilet{
-	dir = 8;
-	tag = "icon-toilet00 (WEST)"
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	tag = "icon-skin"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "whitegreenrustychess"
-	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
 "ugG" = (
 /obj/machinery/light/kebab,
@@ -40599,16 +41645,80 @@
 	tag = "icon-horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
-"usm" = (
-/obj/structure/bed,
-/obj/item/bedsheet{
-	icon_state = "sheetbrown"
+"uin" = (
+/obj/structure/rack,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/obj/item/restraints/legcuffs/bola,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
+"uku" = (
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"unv" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"usm" = (
+/obj/structure/simple_door/interior,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	tag = "icon-skulls"
+	},
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"utI" = (
+/obj/structure/chair/stool,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"uub" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/mask/bandana/legrecruit,
+/obj/item/clothing/mask/bandana/legrecruit,
+/obj/item/clothing/mask/bandana/legrecruit,
+/obj/item/clothing/mask/bandana/legrecruit,
+/obj/item/clothing/mask/bandana/legrecruit,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"uvY" = (
+/obj/structure/chair/wood,
+/obj/effect/landmark/start/f13/settler,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"uwd" = (
+/obj/structure/table/wood/settler,
+/obj/effect/spawner/lootdrop/f13/cash_legion_low,
+/turf/open/floor/plasteel/f13{
+	icon_state = "platingdmg1"
+	},
+/area/f13/legion)
+"uwO" = (
+/obj/structure/bed,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"uAX" = (
+/obj/structure/bed/mattress/pregame,
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "uEx" = (
-/obj/structure/fence,
-/obj/structure/fence,
+/obj/structure/fence/corner{
+	dir = 9;
+	icon_state = "corner"
+	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uGD" = (
@@ -40617,36 +41727,49 @@
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
 "uIa" = (
-/obj/structure/fence{
-	dir = 4;
-	tag = "icon-metal_fence3"
+/obj/structure/fence,
+/obj/structure/fence/corner{
+	dir = 6;
+	icon_state = "corner"
 	},
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33";
-	tag = "icon-wasteland33"
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"uIj" = (
+/obj/structure/closet/fridge/cannibal,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"uJo" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	tag = "icon-skulls"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"uMU" = (
+/obj/structure/simple_door/metal/fence{
+	dir = 8;
+	icon_state = "fence"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"uJo" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	tag = "icon-wooden_chair_settler (EAST)"
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
-/area/f13/village)
 "uOe" = (
-/obj/effect/landmark/start/f13/ncrrecruit,
-/turf/open/floor/f13/wood,
-/area/f13/ncr)
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
 "uQK" = (
 /obj/structure/fence{
 	dir = 4;
+	icon_state = "straight";
 	tag = "icon-metal_fence3"
 	},
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+	icon_state = "dirt";
+	tag = "icon-dirt"
 	},
 /area/f13/wasteland)
 "uRT" = (
@@ -40654,10 +41777,31 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"vaC" = (
-/obj/item/candle/tribal_torch,
+"uTu" = (
+/obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
+	dir = 1;
+	icon_state = "dirt";
+	tag = "icon-dirt (NORTH)"
+	},
+/area/f13/wasteland)
+"uVY" = (
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	tag = "icon-skulls"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"vaC" = (
+/obj/structure/fence/corner{
+	dir = 4;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (WEST)"
 	},
 /area/f13/wasteland)
 "vbb" = (
@@ -40668,13 +41812,21 @@
 	tag = "icon-horizontaloutermain1 (NORTH)"
 	},
 /area/f13/wasteland)
+"vca" = (
+/obj/structure/kitchenspike,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/legion)
 "vcy" = (
-/obj/structure/table/wood/settler,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2";
-	tag = "icon-housewood2"
-	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/effect/spawner/lootdrop/f13/armor/random,
+/turf/open/floor/f13/wood,
 /area/f13/village)
+"vdP" = (
+/obj/structure/kitchenspike,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vjx" = (
 /obj/item/clothing/head/hardhat,
 /obj/effect/decal/remains/human,
@@ -40687,6 +41839,11 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"vpE" = (
+/obj/structure/table/wood/settler,
+/obj/item/storage/box/matches,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "vsF" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40700,18 +41857,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "vzq" = (
-/obj/structure/table/wood/settler,
-/obj/item/seeds/tobacco,
-/obj/item/storage/bag/plants,
-/obj/item/seeds/apple,
-/obj/item/seeds/wheat,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/chair{
+	dir = 4;
+	icon_state = "chair";
+	tag = "icon-chair (EAST)"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "vzE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2";
+	tag = "icon-horizontalinnermain2 (WEST)"
 	},
 /area/f13/ncr)
 "vCX" = (
@@ -40721,11 +41878,25 @@
 	tag = "icon-verticalleftborderleft2top"
 	},
 /area/f13/wasteland)
+"vGo" = (
+/obj/structure/sink/well{
+	pixel_x = -15
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "vGO" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/random,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"vLH" = (
+/obj/structure/chair/stool,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/village)
 "vOI" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old";
@@ -40735,6 +41906,14 @@
 /obj/machinery/light/small/broken,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"vPH" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/bed/mattress/pregame,
+/obj/effect/landmark/start/f13/campfollower,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "wce" = (
 /obj/machinery/light/lampost{
 	dir = 1;
@@ -40749,18 +41928,68 @@
 /mob/living/simple_animal/hostile/retaliate/poison/snake,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"whz" = (
+/mob/living/simple_animal/hostile/handy,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
 "woN" = (
-/obj/structure/closet/crate/freezer/saline,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/restraints/handcuffs/cable/zipties,
+/obj/structure/closet,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"wsu" = (
+/obj/structure/table/wood/settler,
+/obj/item/shovel,
+/obj/item/shovel{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
+"wvn" = (
+/obj/structure/rack,
+/turf/open/floor/f13/wood,
+/area/f13/city)
+"wwv" = (
+/obj/structure/bed/mattress,
+/obj/effect/landmark/start/f13/vetlegionary,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"wsu" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress6"
+"wBy" = (
+/turf/open/floor/wood/f13/stage_r,
+/area/f13/wasteland)
+"wBE" = (
+/obj/structure/chair/office,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"wCS" = (
+/obj/structure/fence{
+	dir = 4;
+	icon_state = "straight";
+	tag = "icon-metal_fence3"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner";
+	tag = "icon-dirtcorner (NORTH)"
+	},
+/area/f13/wasteland)
+"wDY" = (
+/obj/structure/fence/corner{
+	dir = 6;
+	icon_state = "corner"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wIv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -40781,40 +42010,189 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wSA" = (
+/obj/structure/window/fulltile/house{
+	dir = 2;
+	icon_state = "housewindowbroken";
+	tag = "icon-housewindowbroken"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"wTT" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt";
+	tag = "icon-dirt (SOUTHWEST)"
+	},
+/area/f13/wasteland)
 "wZd" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13/wood,
 /area/f13/tunnel)
+"xbm" = (
+/obj/structure/sink/well,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/legion)
+"xbW" = (
+/obj/effect/landmark/start/f13/primedecanus,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "xdG" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "xhl" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull";
-	tag = "icon-reddirtyfull"
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "verticalinnermaintop";
+	tag = "icon-verticalinnermaintop (WEST)"
 	},
 /area/f13/ncr)
-"xCV" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress3"
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
-"xGK" = (
-/mob/living/simple_animal/hostile/wolf,
+"xjs" = (
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"xTN" = (
+"xkj" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt";
+	tag = "icon-dirt (EAST)"
+	},
+/area/f13/legion)
+"xnX" = (
 /obj/machinery/light/small,
-/obj/structure/closet/crate/footlocker/legion,
 /turf/open/floor/f13/wood,
 /area/f13/legion)
-"xUI" = (
-/obj/structure/reagent_dispensers/compostbin,
+"xrY" = (
+/obj/structure/chair/stool{
+	dir = 2;
+	icon_state = "bench";
+	tag = "icon-bench"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/building)
+"xsh" = (
+/obj/structure/table/wood/settler,
+/obj/item/kitchen/knife,
+/obj/item/screwdriver,
+/obj/item/wirecutters,
+/obj/item/kitchen/knife/butcher,
+/obj/item/crowbar,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"xCV" = (
+/obj/structure/table/wood/settler,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/poppy/broc,
+/obj/item/seeds/xander,
+/obj/item/seeds/xander,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2";
+	tag = "icon-housewood2"
+	},
+/area/f13/village)
+"xFQ" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
+"xGK" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/police,
+/obj/item/clothing/head/f13/police,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/suit/armor/vest,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"xIS" = (
+/obj/structure/bed/mattress/pregame,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"xIU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/chair/f13chair2{
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"xJU" = (
+/obj/structure/window/fulltile/house{
+	icon_state = "housewindowbrokenvertical";
+	tag = "icon-housewindowbrokenvertical (NORTHEAST)"
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/village)
+"xKT" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"xMN" = (
+/obj/item/storage/belt/military/assault/legion,
+/obj/item/storage/belt/military/assault/legion,
+/obj/item/storage/belt/military/assault/legion,
+/obj/item/storage/belt/military/assault/legion,
+/obj/item/storage/belt/military/assault/legion,
+/obj/structure/rack,
+/obj/item/storage/belt/military/assault/legion,
+/obj/item/storage/belt/military/assault/legion,
+/obj/item/storage/belt/military/assault/legion,
+/turf/open/floor/plasteel/f13{
+	icon_state = "plating"
+	},
+/area/f13/legion)
+"xSc" = (
+/obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xTN" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"xUI" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/f13/sheriff,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/random,
+/turf/open/floor/f13/wood,
+/area/f13/village)
+"xYe" = (
+/obj/structure/decoration/rag,
+/obj/structure/simple_door/wood,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
+"xZK" = (
+/mob/living/simple_animal/cow/brahmin,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"ykD" = (
+/turf/closed/wall/f13/wood/house/broken,
+/area/f13/legion)
 "ylT" = (
 /obj/item/pickaxe,
 /obj/structure/bed/mattress{
@@ -40892,13 +42270,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aab
+aac
+aac
+aac
+aac
+aac
+aab
 aaa
 aaa
 aaa
@@ -41121,21 +42499,6 @@ aae
 aae
 aae
 aae
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
 aae
 aae
 aae
@@ -41156,6 +42519,21 @@ aae
 aae
 aae
 aae
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aab
+awV
+axu
+aaf
+ayl
+ayF
+aab
 aae
 aae
 aae
@@ -41310,10 +42688,10 @@ aEl
 aEl
 aEl
 aEl
-aEl
-aEl
-aEl
-aEl
+aae
+aae
+aae
+bji
 bji
 bji
 bji
@@ -41349,6 +42727,12 @@ aae
 aae
 aae
 aae
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -41378,7 +42762,6 @@ aae
 aae
 aae
 aae
-aaa
 aae
 aae
 aae
@@ -41391,10 +42774,23 @@ aae
 aae
 aae
 aae
+bwH
+aat
+aat
+aat
+aat
+aat
+aat
 aae
-aaa
 aae
 aae
+aab
+awW
+axv
+aan
+aym
+ayG
+aab
 aae
 aae
 aae
@@ -41405,6 +42801,19 @@ aae
 aae
 aae
 aae
+aat
+sub
+aat
+aat
+aaQ
+aaQ
+aLD
+aaQ
+aaQ
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -41412,37 +42821,6 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
 aae
 aae
 aae
@@ -41567,15 +42945,15 @@ aTY
 aQH
 aQE
 aEl
-bnq
-aKF
-aOY
-aEl
+aae
+aae
+aae
+bji
 blE
 btp
-blI
+hCM
 bnt
-blI
+hCM
 bji
 bnJ
 bpV
@@ -41605,6 +42983,19 @@ aaa
 aae
 aae
 aae
+aat
+aat
+aat
+aat
+aat
+aat
+any
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -41635,72 +43026,59 @@ aae
 aae
 aae
 aae
-aaa
 aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aab
+aab
+awX
+axv
+aan
+aym
+ayH
+aab
+aab
 aae
 aae
 aae
 aae
+aat
+aat
+aat
+aat
+aat
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+aBS
+acb
+aNO
+aaQ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
 aae
-bDY
-bDY
-bDY
-bDY
-bDY
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aaB
-aIM
 aae
 aae
 aae
@@ -41823,11 +43201,11 @@ bjx
 bjx
 bjx
 bjx
-bhi
-bjx
-bjx
-bjx
 aEl
+aae
+aae
+aae
+bji
 bkE
 bjx
 bjx
@@ -41861,6 +43239,25 @@ aad
 aaa
 aae
 aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -41886,78 +43283,59 @@ aae
 aae
 aae
 aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
+adH
+adY
+aeq
+ayn
+aeV
+ayW
+aat
+aat
 aae
 aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aaQ
+psn
+qaX
+aAf
+abf
+aEp
+aSr
+fyo
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
-aae
-aae
-aaa
-aae
-aae
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-cpz
-cqk
-crb
-bDY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-pAB
-geV
-aaB
-aaB
 aae
 aae
 aae
@@ -42081,14 +43459,14 @@ aLK
 aLK
 bhi
 aEl
-aPe
-aKH
-aKI
-aEl
+aae
+aae
+aae
+bji
 bmb
 bjx
 blN
-bjx
+uku
 blN
 bji
 bnK
@@ -42118,104 +43496,104 @@ aad
 aaa
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aae
-aae
-bDY
-bln
-blZ
-bmD
-byH
-bzb
-bGF
-bDY
-cpA
-aJN
-aJL
-bDY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
+adH
+adY
+aeC
+aeC
+aeV
+ayW
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aaQ
+abf
+qtR
+aAf
+sgn
+aCr
+sWl
+aaQ
+aat
+aat
+ady
+aat
+ady
+ady
+ady
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -42338,10 +43716,10 @@ aPh
 aRa
 bjx
 aEl
-aEl
-aEl
-aEl
-aEl
+aae
+aae
+aae
+bji
 blE
 bjx
 blN
@@ -42375,106 +43753,106 @@ aaa
 aaa
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-bDY
-bDY
-bDY
-bDY
-bDY
-aJN
-aJN
-aJN
-aJN
-aJN
-aJN
-bDY
-cpB
-aJN
-aJL
-bDY
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aIM
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
+adH
+adY
+aer
+ayn
+aeV
+ayW
+aat
+aat
+bxr
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+aaQ
+abv
+aAf
+aAf
+aAf
+abv
+aAf
+aaQ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ayt
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -42595,17 +43973,17 @@ bjx
 bjx
 bjx
 aEl
-blI
-bjx
-bjx
-bmF
+aae
+aae
+aae
+bji
 bmF
 bkd
 bmF
 bmF
 bmF
 bmF
-bnL
+ntx
 bnO
 bji
 aae
@@ -42628,113 +44006,113 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
 aat
-bDY
-aJv
-aJL
-aJN
-bDY
-aJH
-bma
-aJN
-aJN
-aJL
-aAJ
-alD
-bDY
-bkT
-bDY
-bDY
-bDY
-aqF
-aDt
-acm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
+adH
+aec
+abT
+bxk
+aeV
 ayW
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-xCV
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+sub
+bxv
+bxv
+bxv
+dXJ
+ady
+ady
+bxr
+aat
+aaQ
+acb
+acb
+aAf
+acb
+acb
+acb
+aaQ
+aat
+aii
+acO
+acO
+acO
+acO
+acO
+afL
+aat
+aat
+aat
+aat
+sub
+aat
+aat
+aii
+acu
+acv
 aae
 aae
 aae
@@ -42852,11 +44230,11 @@ bgz
 aEl
 bhi
 aEl
-blJ
-bjx
-bjx
-bkd
-bjx
+aEl
+aEl
+aEl
+aEl
+uku
 bjx
 bjx
 bjx
@@ -42885,113 +44263,113 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+cql
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+cql
 aat
 aat
 aat
 aat
 aat
 aat
-bDY
-aJH
-aJN
-aJL
-bDY
-aJN
-aJN
-aJN
-aJN
-aJN
-aJN
-cpl
-aJN
-aJN
-aJN
-crD
-bDY
-acm
-acm
-acm
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
+adI
+aec
+abT
+ayn
+aeW
 ayW
 aat
 aat
+sub
+bxv
+cnS
+cpT
+cqk
+fFq
+aat
+agz
+aat
+aQU
+acb
+acb
+abv
+aCr
+sOk
+aAq
+aKk
+aat
+ach
+acv
+apN
+acv
+apN
+acv
+ads
 aat
 aat
 aat
 aat
+sub
 aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aae
+aii
+acu
+acv
+acv
 aae
 aae
 aae
@@ -43110,9 +44488,9 @@ btp
 bjx
 aEl
 blK
-bjx
-bjx
-bmF
+tCa
+hSX
+aEl
 bjx
 bjx
 bnm
@@ -43142,32 +44520,51 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+cql
+bDO
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
-aae
 aat
 aat
 aat
@@ -43176,81 +44573,62 @@ aat
 aat
 aat
 aat
-bDY
-aJI
-aJN
-aJN
-bkT
-aJN
-aJL
-aJN
-aJN
-aJN
-aJN
-aJL
-aJN
-aJL
-aJN
-aJN
-bkT
-acm
-acm
-acm
-ayW
 aat
 aat
 aat
-ayJ
+aat
+aat
+aat
 ayt
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+ekc
+adJ
+aea
+abT
+ayn
+aeT
+ayW
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+sub
+bxv
+aEE
+cpU
+epP
+esz
+gpq
+jgK
+aat
+aKk
+bbi
+acb
+aAf
+bau
+acb
+tfq
+aKk
+aat
+ach
+acv
+apN
+acv
+apN
+acv
+ael
+afL
+xZK
+aat
+aat
+sub
+aii
+acu
+adC
+acv
+acv
+acv
+acv
 aae
 aae
 aae
@@ -43366,10 +44744,10 @@ bjx
 bjx
 bqQ
 aEl
-blM
 bjx
-bmo
-bmF
+bjx
+bjx
+aEl
 bmM
 bjx
 bnn
@@ -43398,10 +44776,52 @@ aaa
 aae
 aae
 aae
+aae
+cql
+bDO
+cql
+acf
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+bst
 aat
 aat
 aat
-ayJ
 aat
 aat
 aat
@@ -43412,53 +44832,67 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-ahF
-aat
+aib
 aat
 aat
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-ahF
-aat
-aat
-bDY
-aJK
-aKq
-bek
-bDY
-bDY
-aJH
-aJN
-aJN
-aJL
-bma
-aJN
-aJN
-aJL
-aJN
-bDY
-bDY
-acm
-acm
-acm
+aww
+ekc
+axd
+adY
+aer
+aer
+aeU
 ayW
 aat
 aat
+sub
+bxv
+cpl
+cqj
+aat
+fHx
+sub
+aat
+aat
+aaQ
+pAB
+qDJ
+aAf
+acb
+aEp
+tGl
+aaQ
+aii
+acu
+acv
+acv
+acv
+acv
+acv
+acv
+ael
+afL
 aat
 aat
 aat
+ach
+acv
+acv
+acv
+acv
+acv
+adr
+afj
+aae
+aae
+aae
+aae
+aae
+aae
 aat
 aat
 aat
@@ -43469,62 +44903,6 @@ aae
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-bNC
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -43581,7 +44959,7 @@ aat
 aat
 aat
 aat
-bcT
+agk
 aat
 aat
 agl
@@ -43623,10 +45001,10 @@ bjp
 joT
 joT
 aEl
-blN
+wvn
 bjx
-blN
-bmF
+tow
+aEl
 blo
 bjx
 bno
@@ -43654,7 +45032,50 @@ aaa
 aaa
 aae
 aae
-aab
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+heY
+heY
+alv
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+alv
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+alv
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+alv
+heY
+heY
+heY
+cqn
 aat
 aat
 aat
@@ -43676,50 +45097,58 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayJ
-aat
-aat
-aat
-aat
-aat
-bDY
-bDY
-aRu
-bDY
-bDY
-bDY
-bmf
-bsr
-bmf
-bzr
-bIm
-bzr
-bmf
-bsr
-bmf
-bDY
-acm
-aqB
-acm
-acm
+ekc
+adK
+adY
+abS
+aeq
+aeV
 ayW
 aat
 aat
+sub
+bxv
+cpq
+cqk
+aat
+fFq
+sub
+aat
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+azK
+aaQ
+aaQ
+aaQ
+anl
+aaQ
+uJo
+aaQ
+aaQ
+ueP
+aaQ
+aaQ
+acv
+ads
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+acv
+adr
+afj
 aat
 aat
 aat
 aat
 aat
 aat
-awE
 aat
 aat
 aat
@@ -43732,57 +45161,6 @@ aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -43879,17 +45257,17 @@ acv
 acv
 ads
 aat
-aLK
-aLK
-bju
-bju
-aLK
+aEl
+aEl
+bhi
+aEl
+aEl
 aLK
 bjd
 bju
 bju
 aLK
-aat
+aae
 aat
 aat
 aat
@@ -43908,66 +45286,66 @@ bji
 aaa
 "}
 (13,1,1) = {"
-aab
-aab
-aab
-aab
-ahQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-abQ
-ahQ
-bDY
-bDY
-aRu
-aRu
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
 bDY
 bDY
-aRu
-aRu
 bDY
 bDY
-acm
-acm
-acm
-acm
-azr
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+acz
+acz
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+heY
+cqn
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
+abQ
 abQ
 abQ
 abQ
@@ -43977,12 +45355,51 @@ abQ
 abQ
 abQ
 crN
-abQ
-abQ
-abQ
-abQ
-aBO
-aJR
+adH
+adY
+aeq
+ayn
+aeU
+ayW
+aat
+aat
+sub
+bxv
+aHe
+cqu
+esz
+aat
+sub
+aat
+aou
+aat
+aat
+acw
+acv
+acv
+acv
+adr
+aat
+anl
+aaQ
+crb
+byM
+acb
+acb
+qNp
+aaQ
+acv
+ads
+aat
+aat
+aib
+ach
+acv
+acv
+acv
+adr
+afj
+ahE
 aat
 aat
 aat
@@ -43991,56 +45408,17 @@ aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aaB
-aIM
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -44165,83 +45543,118 @@ bji
 aaa
 "}
 (14,1,1) = {"
-aac
-acj
-acj
-acj
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
+adD
+adD
+adD
+adD
+adD
+anM
+bDY
+aqe
+arD
+aqx
+awF
+arD
+bDY
+heY
+heY
+aJM
+aLH
+aOY
+bbW
+bkC
+bme
+bDY
+bqu
+brm
+brt
+bsk
+bsA
+btI
+anM
+buU
+bvb
+bvo
+bvw
+bDY
+heY
+cqn
+agn
+adW
+aeQ
 acG
 acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-agJ
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-agJ
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-acG
-agJ
+adW
+adW
+aeQ
 anR
-anf
+adW
+adW
 anf
 aeQ
 acG
 anR
+adW
+adW
+anf
+aeQ
+acG
+acG
 awA
 cse
-anf
-aeQ
-agJ
-ahK
+adY
+aeC
+aeC
+aeV
 ayW
 aat
 aat
+sub
+bxv
+bxv
+bxv
+ady
+ady
+aQW
+aat
+aat
+aib
+aat
+ach
+acv
+acv
+acv
+ads
+aii
+acu
+aaQ
+cqD
+byM
+byM
+aRo
+uIj
+aaQ
+acv
+ael
+aat
+aat
+aat
+ach
+acv
+acv
+adC
+bhV
 aat
 aat
 aat
@@ -44251,53 +45664,18 @@ aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -44382,7 +45760,7 @@ acO
 acu
 acv
 acv
-aMa
+acv
 adN
 aTa
 bsS
@@ -44422,70 +45800,70 @@ bji
 aaa
 "}
 (15,1,1) = {"
-aac
-adD
-adD
-adD
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+act
+bDY
+adP
+alw
+alw
+amb
+alw
+anM
+bDY
+ait
+arY
+atT
+ait
+ait
+bDY
+heY
+heY
+aKj
+aLI
+aLI
+aMa
+aLI
+bmo
+bDY
+bqw
+anM
+bru
+anM
+anM
+anM
+anM
+anM
+anM
+anM
+anM
+bDY
+heY
+cqn
+adH
+adX
+aeo
+aeo
+ajo
 aeo
 aeo
 aeo
 aeo
+ajo
+afl
+akh
 aeo
 aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
-aeo
+ajo
+afl
+akh
 aeo
 aeo
 aeo
@@ -44494,68 +45872,68 @@ afl
 ajo
 abS
 aer
-aQu
+abT
 aeV
 ayW
 aat
+bgK
+bxs
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bss
+aat
+aat
+ach
+acv
+acv
+acv
+ads
+anl
+acv
+ueP
+acb
+byM
+byM
+acb
+abG
+aaQ
+ueP
+aaQ
+aaQ
+aat
+aat
+ach
+acv
+acv
+acv
+bhV
 aat
 aat
 aat
-abz
+bqC
 aat
 aat
 aat
 aat
 aat
+aaQ
+aaQ
+aLi
+aaQ
+aaQ
+aaQ
+aaQ
+aLD
+aaQ
+aaQ
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aaB
-aaB
-aaB
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -44597,13 +45975,13 @@ aae
 aae
 aae
 aae
-beG
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
+agk
+agk
+agk
+agk
+agk
+agk
+agk
 aat
 agy
 aat
@@ -44639,7 +46017,7 @@ acv
 acv
 acv
 acv
-aMa
+acv
 agy
 ach
 apd
@@ -44679,70 +46057,70 @@ bji
 aaa
 "}
 (16,1,1) = {"
-aac
-adP
-adP
-adP
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+anN
+bDY
+aqx
+ass
+aqx
+atT
+ass
+bDY
+aIw
+aJf
+aKF
+aMa
+aLI
+bcH
+bkD
+bmD
+bDY
+bqy
+anM
+anM
+anM
+anM
+anM
+anM
+anM
+anM
+anM
+anM
+bDY
+heY
+cqn
+adH
+adY
+aha
+amx
+ahB
+ahb
+ahb
+aha
+ahb
+aje
+ajp
 ahb
 ahb
 ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-ahb
-aeq
-ahb
-ahb
+ajp
+ahB
+ajp
 akG
 ahb
 aha
@@ -44754,6 +46132,43 @@ csz
 ahb
 aeV
 ayW
+ajt
+anl
+aaQ
+aaQ
+aaQ
+aLi
+aLD
+aaQ
+aaQ
+aaQ
+bhV
+aat
+aat
+ach
+acv
+acv
+acv
+ael
+acu
+acv
+aaQ
+aAf
+byM
+uJo
+aAf
+aAf
+aAf
+byM
+kdj
+uVY
+aat
+sub
+ach
+acv
+acv
+acv
+bhV
 aat
 aat
 aat
@@ -44763,56 +46178,19 @@ aat
 aat
 aat
 aat
-aat
-aat
-bqC
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
+aaQ
+mXv
+aRo
+aAL
+eWt
+aAf
+aNO
+rYJ
+aSr
+aaQ
 aat
 aat
 aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -44860,7 +46238,7 @@ acG
 acG
 acG
 acG
-bcT
+agk
 aat
 agy
 cox
@@ -44896,14 +46274,14 @@ acv
 acv
 acv
 acv
-aMa
+acv
 agy
 ach
 acv
 acv
 aYr
 biN
-aLH
+ach
 acv
 acv
 acv
@@ -44936,10 +46314,57 @@ bji
 aaa
 "}
 (17,1,1) = {"
-aac
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
 adT
 adT
 adT
+bDY
+ana
+anm
+aon
+anm
+anm
+anP
+anm
+anP
+aIb
+cpg
+heY
+aKF
+aLI
+aMa
+aMa
+aMa
+aMa
+bDY
+bqz
+brn
+anM
+bsl
+bsM
+anM
+anM
+anM
+bvb
+bvr
+bvw
+bDY
+heY
+cqn
+adH
+adY
+abT
+abT
 agC
 agC
 agC
@@ -44950,56 +46375,9 @@ agC
 agC
 agC
 agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-agC
-afO
 ajq
-agC
+afO
+age
 agC
 agC
 ajq
@@ -45012,63 +46390,63 @@ abT
 aeT
 ayW
 aat
-aii
-acO
-acO
-afL
+anl
+bxt
+byH
+byM
+cqD
+byM
+acb
+gCv
+aaQ
+bhV
 aat
 aat
-ahF
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+aaQ
+acb
+byM
+byM
+byM
+byM
+byM
+byM
+acb
+aaQ
+aat
+sub
+ach
+acv
+acv
+acv
+bhV
 aat
 aat
 aat
 aat
 aat
-akJ
 aat
 aat
 aat
 aat
+jyr
+acb
+aAq
+acb
+cWx
+aAf
+bUW
+acb
+bAz
+jyr
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -45117,7 +46495,7 @@ adX
 aeo
 aeo
 coo
-bcT
+agk
 aat
 agy
 aat
@@ -45153,7 +46531,7 @@ acv
 acv
 acv
 acv
-aMa
+acv
 adN
 aKd
 app
@@ -45173,7 +46551,7 @@ bpz
 bmc
 bmr
 aLK
-aLH
+ach
 acv
 ads
 aat
@@ -45193,70 +46571,70 @@ bji
 aaa
 "}
 (18,1,1) = {"
-aac
-ahi
-ahi
-ahi
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
+ait
+amQ
+amQ
+bDY
+anc
+anm
+aoo
+anP
+anm
+anm
+anm
+anm
+aIb
+heY
+cpg
+aKH
+aLI
+aMa
+aLI
+aLI
+aMa
+bDY
+bDY
+bDY
+brv
+brv
+atW
+aIs
+atW
+brv
+brv
+bDY
+bDY
+bDY
+aJy
+cqn
+adH
+adY
+abS
+aiv
+ayQ
 axb
 axb
 axb
+axn
+ahb
+ahb
+ahb
+aeS
 axb
-axb
-agL
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-agL
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-agL
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
-axb
+afP
+aya
+aya
 aMG
 aMG
 aya
@@ -45269,63 +46647,63 @@ aer
 aeU
 ayW
 aat
+anl
+bxt
+byM
+cpu
+crb
+byM
+fJF
+abG
+aaQ
+bhV
+aat
+aat
+ach
+adC
+acv
+acv
+acv
+acv
+acv
+usm
+acb
+uOe
+byM
+byM
+acb
+aAf
+acb
+qNp
+aaQ
+aat
+sub
 ach
 acv
 acv
-hlw
-bss
-aat
-aat
-aat
-aat
-aii
-acO
-acO
-afL
+acv
+uTu
+ady
+ady
+ady
 aat
 aat
 aat
 aat
 aat
 aat
+aaQ
+aAs
+acb
+acb
+eWt
+aAf
+acb
+vLH
+aEG
+aaQ
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -45374,7 +46752,7 @@ adY
 aPK
 abS
 aiv
-bcT
+agk
 aat
 agy
 akd
@@ -45430,7 +46808,7 @@ bgM
 bgM
 blO
 aLK
-aLH
+ach
 acv
 ads
 aat
@@ -45450,97 +46828,120 @@ bji
 aaa
 "}
 (19,1,1) = {"
-aab
-aab
-aab
-aab
-ahR
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-bgy
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-acm
-aiq
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-adf
-akO
+aaa
+aae
+aae
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
+ahi
+amQ
+ait
+amc
+anm
+anP
+bDY
+aqx
+ass
+aqx
+aqx
+ass
+bDY
+cpg
+heY
+aKF
+aMa
+aLI
+bcO
+bkR
+bnk
+bDY
+cps
+cqH
+brx
+cpp
+cpp
+cpp
+cpp
+cpp
+arB
+ayZ
+bvz
+bDY
+heY
+cqn
+adI
+aeb
+abT
+aiv
+aeV
+agn
+acG
+acG
+axj
+ahb
+ahb
+ahb
+aeX
+acG
+adW
+ahK
+afF
 bDY
 bDY
 crF
 crF
-bDY
-fZN
+crF
+adK
 adY
 abS
 aeq
 aeV
 ayW
 aat
+anl
+aaQ
+bza
+byM
+crA
+byM
+byM
+aaQ
+aaQ
+bhV
+aat
+aat
 ach
 acv
 acv
 acv
-ads
+adr
+acP
+acw
+aaQ
+byM
+byM
+aAq
+woN
+aEG
+aAf
+acb
+byM
+elx
 aat
 aat
-aat
-aii
-bgs
+ach
 acv
 acv
-hlw
-acO
-bss
+acv
+bhV
+aat
+abd
 aat
 aat
 aat
@@ -45548,42 +46949,19 @@ aat
 aat
 aat
 aat
+aaQ
+aAf
+abv
+aAf
+aAf
+aAf
+abv
+aAf
+aAf
+aaQ
 aat
 aat
-aii
-acO
-acO
-acO
-bss
 aat
-aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -45631,7 +47009,7 @@ adY
 abS
 abS
 aiv
-bcT
+agk
 aat
 agy
 aiH
@@ -45660,11 +47038,11 @@ aTw
 aTw
 aTw
 aat
-aLH
-aMa
+ach
 acv
-aMb
-aNi
+acv
+bhV
+aat
 aat
 ach
 acv
@@ -45710,68 +47088,68 @@ aaa
 aaa
 aae
 aae
-aab
-bDY
-aVT
-aVT
-aVT
+aae
+aae
+cql
+bDO
+cql
 cqn
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
-aVT
+heY
+bDY
+amQ
+ait
+amQ
+bDY
+anp
+anP
+bkZ
+ait
+amQ
+atT
+ait
+amQ
+bDY
+aII
+aIw
+aKF
+aLI
+aLI
+aMa
+aLI
+bnq
+bDY
+cps
+cqH
+azb
+bsu
+aqT
+aqT
+aqT
+aqT
+aqT
+aqT
+bvh
+bkZ
+heY
 cqn
-aVT
-bcT
-aat
-aat
+adK
+adY
+aer
+aer
+aeV
+adH
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+aeV
+afF
 bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-acm
-acm
-ayW
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aii
-bgA
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-krJ
 crB
 crG
 crK
@@ -45783,63 +47161,63 @@ ayn
 aeV
 ayW
 aat
+anl
+aaQ
+bzb
+cpz
+aaQ
+byM
+byM
+gWz
+bsq
+bgL
+aat
+aou
 ach
 acv
 acv
 acv
 ads
 aat
+afw
+aaQ
+aaQ
+ueP
+ueP
+aaQ
+aaQ
+aaQ
+jrS
+aaQ
+aaQ
 aat
-aat
+abd
 ach
 acv
 acv
 acv
-acv
-acv
-ads
+bhV
 aat
 aat
 aat
 aat
+bqC
 aat
 aat
 aat
 aat
+fyo
+mWX
+acb
+acb
+aCr
+aFR
+acb
+acb
+lRM
+jyr
 aat
-ach
-acv
-acv
-acv
-ads
 aat
-aat
-ayJ
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -45888,7 +47266,7 @@ adY
 afx
 abT
 aiv
-bcT
+agk
 aat
 agy
 abA
@@ -45944,7 +47322,7 @@ aPF
 anL
 bmR
 aLK
-boj
+ach
 acv
 ads
 aat
@@ -45968,69 +47346,69 @@ aaa
 aae
 aae
 aae
+aae
 cql
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
+bDO
+cql
+cqn
+heY
+bDY
+ahQ
+ahQ
+ahQ
+bDY
+anm
+anm
+bDY
+aqz
+ast
+aqx
+awG
+azu
+bDY
+heY
+aIw
+bDY
+aMa
+aPe
+bdE
 aqk
-aat
-ayJ
+boj
 bDY
-axw
-akP
+cps
 cqH
+azb
+cqt
 amZ
-bDY
-cpt
-cpt
-awC
-acm
-aqB
-ayW
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-anl
-acv
-ads
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+btK
+buz
+buz
+btK
+bls
+azb
+acz
+heY
+cqn
+adH
+adY
+abS
+aiv
+aeV
+adH
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ajp
+ahb
+ajp
+aeV
+afF
 bDY
 crC
-crB
+bwb
 bmL
 crF
 adH
@@ -46040,17 +47418,19 @@ aeC
 aeV
 ayW
 aat
+anl
+aaQ
+aaQ
+aaQ
+aaQ
+byM
+byM
+byM
+bhV
+aat
+abd
+aat
 ach
-aAl
-acv
-bsq
-afj
-aat
-aat
-aat
-ach
-acv
-acv
 acv
 acv
 acv
@@ -46064,11 +47444,16 @@ aat
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aat
 ach
 acv
 acv
-bsq
-afj
+acv
+bhV
 aat
 aat
 aat
@@ -46076,28 +47461,21 @@ aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+jyr
+aAs
+acb
+acb
+acb
+mtr
+acb
+aCr
+oLV
+fyo
+aat
+aat
+aat
 aae
 aae
 aae
@@ -46145,7 +47523,7 @@ adY
 afx
 ahB
 aiv
-bcT
+agk
 aat
 agy
 bdW
@@ -46201,7 +47579,7 @@ aLK
 aLK
 aLK
 aLK
-aLH
+ach
 acv
 ads
 aat
@@ -46225,57 +47603,93 @@ aaa
 aae
 aae
 aae
-afF
-afF
-aBP
-aqF
-aBP
-aDt
-akb
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-akb
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-aqk
-aat
-aat
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-axR
-ayo
-akP
+bDY
+bDY
+bDY
+atW
+ant
+aog
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+acz
+acz
+bDY
+bDY
+bkZ
+bDY
+bkZ
+bDY
+bDY
+cps
+cqH
+azb
+cqt
 asX
+btX
+btY
+buV
+btX
+asX
+brF
 bDY
-bzi
-cpt
-awC
-acm
-acm
+heY
+cqn
+adH
+adY
+abS
+aiv
+aeV
+adI
+crv
+crv
+crv
+ahb
+ajp
+ajp
+crv
+crv
+crv
+aeV
+afF
+bDY
+bwU
+bDY
+bDY
+bDY
+adI
+aec
+abT
+ayn
+aeW
 ayW
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayJ
 anl
+aaQ
+aUf
+acb
+crD
+byM
+byM
+crD
+hlw
+bss
+aat
+aat
+ach
+acv
+acv
 acv
 ads
 aat
@@ -46284,77 +47698,41 @@ aat
 aat
 aat
 aat
-blD
-bDY
-alD
-crF
-crF
-bDY
-tFI
-aec
-abT
-ayn
-aeW
-ayW
-aii
-bgs
-acv
-aCL
-afj
-aat
-aat
 ayt
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 ach
 acv
 acv
 acv
-bsq
-acP
-afj
-aat
-aat
-ayJ
-aat
-aat
-aat
-aat
-aat
-ayt
-afw
-acP
-acP
-afj
+bhV
 aat
 aat
 aat
 aat
 aat
 aat
-aHF
-aHF
-aHF
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aaQ
+aaQ
+aLi
+aaQ
+azK
+aaQ
+aAf
+abv
+aAf
+aaQ
+aat
+aat
+aat
 aae
 aae
 aae
@@ -46402,13 +47780,13 @@ adY
 aeY
 afx
 aiv
-bcT
+agk
 aat
 agy
 aat
 ibj
 aae
-bcT
+agk
 aat
 aat
 agl
@@ -46481,71 +47859,71 @@ aaa
 aaa
 aae
 aae
-afF
-afF
-afF
-aqF
-agM
-apt
-abO
-afF
-coy
+aae
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
+ahR
+alx
+alG
+akb
+ajW
+akb
+ajW
+ajW
+ayZ
+alG
+axa
+axa
+bDY
+heY
+heY
+bDY
+aMb
+awC
+beh
+bgO
+bpg
+bDY
+cps
+cqH
+azb
+cqt
+atw
+btY
+buC
+buF
+buV
+buz
+aPz
+bDY
+heY
+cqn
+adH
+aeb
+abT
+aiv
+aeV
+adK
+ahb
+ajp
+ahb
+ajp
+ahb
+ajp
+ahb
+ahb
+ahb
+aeV
 afF
 aqB
-aqF
+aqB
 aDt
-afF
-afF
-afF
-afF
-aqF
-aDt
-aHZ
-bDY
-bDY
-bDY
-bDY
-bDY
-awC
-bDY
-bDY
-bDY
-bDY
-bDY
-axT
-alE
-cqH
-atw
-bDY
-cpt
-cpt
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-aat
-aat
-aat
-aat
-aat
-aat
-anl
-acv
-hlw
-afL
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+adH
 ekc
 adJ
 aea
@@ -46553,64 +47931,64 @@ afx
 aha
 aeT
 ayW
-afw
-acP
-acP
-afj
 aat
-aat
-aat
+anl
+aKk
+aFq
+acb
+acb
+byM
+byM
+aHF
+aHF
+bhV
 aat
 aat
 ach
 acv
 acv
 acv
-ads
+hlw
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acu
+acv
+acv
+acv
+hlw
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+bgs
+acv
+acv
+acv
+acv
+aaQ
+aCy
+acb
+aDH
+aaQ
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
-aHF
-aat
-aat
-aat
-aat
-aHF
-aHF
-aHF
-aHF
-aHF
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -46659,7 +48037,7 @@ adY
 abT
 abT
 aiv
-bcT
+agk
 aat
 agy
 aat
@@ -46738,71 +48116,71 @@ aaa
 aaa
 aae
 aae
-afF
-afF
-afF
-aBP
-aiu
-aat
-aiH
-aDt
-afF
-afF
-afF
-aqB
-afF
-afF
-aqB
-afF
-afF
-afF
-afF
-afF
-bDY
-heY
-apH
-cpm
-cpt
-cpt
-cpt
-cpm
-arb
+aae
+aae
+cql
+bDO
+cql
+cqn
 heY
 bDY
-akP
-ayq
-akP
-cqH
+ahR
+alz
+alW
+ame
+ame
+aoh
+aph
+aqT
+aqT
+avb
+aqT
+azv
+bDY
+heY
+cpg
 bDY
 cpt
-cpe
-cpt
-cpt
+aQz
 bzi
-blp
-cpt
-cpt
+aQz
+arb
+atU
+cps
+cqH
+azb
+cqt
+atw
+bua
+buD
+cpe
+buF
+buV
+brO
 bDY
-aat
-aat
-aat
-aat
-aat
-aii
-acu
-acv
-acv
-ads
-aat
-aat
-ayJ
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+heY
+cqn
+adH
+adY
+aer
+aer
+aeV
+adH
+ahb
+ahb
+aha
+ahb
+ahb
+ajp
+ahb
+ahb
+ahb
+aeV
+agn
+acG
+acG
+acG
+axj
 ekc
 axd
 adY
@@ -46811,63 +48189,63 @@ aer
 aeU
 ayW
 aat
-aat
-aat
-aat
-aat
-aat
-aat
+anl
+aKk
+aCw
+aCr
+acb
+acb
+byM
+ijo
+aHF
+bhV
 aat
 aat
 ach
 acv
 acv
 acv
-ads
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+aaQ
+abf
+acb
+fLm
+fyo
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-fWz
-bgA
-bgA
-bgA
-aSK
-aat
-aHF
-aHF
-mWX
-acf
-usm
-aHF
-aHF
-aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -46916,7 +48294,7 @@ adY
 cok
 abT
 ayy
-bcT
+agk
 aat
 agy
 aae
@@ -46997,65 +48375,65 @@ aae
 aae
 aae
 aae
-afF
-afF
-agN
-aoD
-ahc
-afF
-agn
-akx
-acG
-acG
-acG
-akx
-ahK
-afF
-afF
-coy
-afF
-afF
+cql
+bDO
+cql
+cqn
+act
 bDY
-anK
+ajW
+alA
+amQ
+amQ
+anv
+ait
+amQ
+aqW
+aqW
+aqW
+aqW
+azb
+aIc
+heY
 cpg
-cqb
-cpt
-cpt
+bDY
 bzi
-cqb
-cqd
+bzi
+bzi
+bzi
+bzi
 atU
-bDY
+cps
 cqH
-akP
-akP
+brF
+cqt
 atx
+bua
+buF
+buY
+bvc
+xhl
+brO
 bDY
-bzi
-cpt
-cpt
-cpt
-cpt
-bzi
-cpt
-bzi
-bDY
-aat
-aat
-aii
-acO
-acO
-acu
-acv
-acv
-acv
-hlw
-acO
-afL
-aat
-aat
-aat
-aat
+heY
+cqn
+bwl
+adY
+abS
+aeq
+aeV
+adH
+crv
+crv
+bwC
+aqm
+ajp
+ajp
+crv
+crv
+crv
+aeV
+adH
 aat
 aat
 aat
@@ -47068,63 +48446,63 @@ aeq
 aeV
 ayW
 aat
+anl
+aaQ
+bzr
+acb
+acb
+aaQ
+fKC
+aHF
+aHF
+bhV
 aat
 aat
-ahF
-aat
-aat
-aat
-aat
-ahF
-afw
-brV
-acv
-acv
-ads
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aJJ
 ach
-apN
+adC
 acv
-apN
-ads
-aHF
-aHF
-aKC
-aKC
-fHx
-aKC
-aKC
-aHF
-aHF
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+bsq
+bvT
+bvT
+bvT
+aaQ
+uwO
+acb
+aCb
+aaQ
 aat
 aat
-aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -47173,7 +48551,7 @@ adY
 abT
 abT
 aiv
-bcT
+agk
 aat
 agy
 aae
@@ -47254,67 +48632,67 @@ aae
 aae
 aae
 aae
-afF
-afF
-afF
-aqB
-aDt
-afF
+cql
+bDO
+cql
+cqn
+heY
+bDY
 blY
+alA
+ait
+amQ
+amQ
+ait
+ait
+aqW
+asv
+aqW
+axU
+azb
 bDY
-amb
-akU
-akU
-bDY
-ame
-afF
-afF
-afF
-afF
-afF
-bDY
-bDY
-bDY
+cpg
+heY
 bDY
 apV
-bzi
+aSK
+ber
+bkX
 apV
 bDY
-bDY
-bDY
-bDY
-bDY
-alY
-alD
-bDY
-bDY
-cpt
-bDY
-alD
+bqD
+bro
+aPz
+cqt
+atw
+bub
+buG
+buZ
 cps
-cps
+xhl
+bvA
 bDY
-cpt
-cpt
-bDY
+heY
+cqn
+cqt
+amZ
+bwo
+bwt
+cpD
+adH
+ahb
+ajp
+bwD
+bwG
+aha
+ahb
+bwJ
+aWS
+bwL
+aeV
+adH
 aat
-ahF
-anl
-acv
-apN
-acv
-apN
-acv
-apN
-acv
-apN
-ads
 aat
-aat
-aat
-aat
-aat
-ahF
 aat
 aat
 ekc
@@ -47325,63 +48703,63 @@ ayn
 aeV
 ayW
 aat
-aat
-aat
-aat
-aat
-aAm
-aat
-aat
+anl
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+bzx
+acv
+bsq
+bgL
 aat
 aat
 ach
 acv
 acv
-ads
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ach
-jkN
 acv
-bsj
-ads
-aHF
-eHM
-bbW
-aIw
-aIw
-aIw
-aJf
-aKC
-aHF
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+adC
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+bhV
 aat
 aat
+ady
+aaQ
+aaQ
+aLD
+aaQ
+aaQ
 aat
 aat
-aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
 aae
 aae
 aae
@@ -47430,7 +48808,7 @@ adY
 abS
 abS
 aiv
-bcT
+agk
 aat
 agy
 aae
@@ -47475,11 +48853,11 @@ bsj
 ads
 bji
 baX
-bwd
+krc
 bjx
 bji
 bjx
-bvy
+uvY
 bcd
 bmI
 acP
@@ -47511,65 +48889,65 @@ aae
 aae
 aae
 aae
-afF
-aqB
-aDt
-afF
-afF
-afF
-adH
-cqt
-akB
-akC
-akC
-akC
-amt
-afF
-afF
-afF
-afF
-afF
-bDY
+cql
+bDO
+cql
+cqn
 heY
-cqd
-cpm
-cpt
-cpt
-cpt
-asa
-cpt
-cpt
-cpt
-cpt
-bzi
-bzi
-bzi
-cpt
-cpt
-cpt
 bDY
-xhl
-xhl
+akb
+cqt
+ait
+amQ
+ait
+amQ
+ait
+aqW
+aqW
+aqW
+aqW
+azb
+cqb
+heY
+heY
+bDY
+bDY
+bDY
+aIs
+bDY
+bDY
+bDY
+bqF
+axY
+aPz
+cqt
+atw
+bue
+buv
+bua
 cps
-bzi
-cpt
+xhl
 bDY
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-aat
+bDY
+bDY
+btZ
+cqt
+amZ
+bwp
+bwv
+cpD
+adH
+ahb
+ahb
+bwD
+bwG
+ahb
+bwI
+ahb
+ahb
+ahb
+aeV
+adH
 aat
 aat
 aat
@@ -47582,64 +48960,64 @@ ayn
 aeV
 ayW
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-acP
-acP
-afj
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ahF
-aat
-aat
-aat
-aHF
-ach
-apN
+anl
+aaQ
+bzv
+bzx
+bzx
+eHM
+bzx
 acv
-apN
-ads
-aHF
-aJM
-jgK
-aIw
-aIw
-aIw
-jgK
-aJM
-aHF
+bhV
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+adr
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+brV
+acv
+bsq
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bgL
 aat
 aat
 aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -47687,7 +49065,7 @@ agK
 bfT
 abS
 aht
-bcT
+agk
 aat
 agy
 aat
@@ -47731,13 +49109,13 @@ acv
 acv
 ads
 bji
-bxA
+rBU
 bjx
 bjx
 bji
 bjx
 bjx
-bxA
+rBU
 bmI
 aat
 aat
@@ -47768,65 +49146,65 @@ aae
 aae
 aae
 aae
-afF
-afF
-afF
-afF
-afF
-afF
-adH
-aky
-akC
-akC
-akB
-akC
-amu
-afF
-afF
-afF
-aqF
-afF
+cql
+bDO
+cql
+cqn
+heY
 bDY
+ayZ
+cqt
+ait
+ait
+ait
+ait
+ait
+aqW
+asy
+aqW
+asy
+aAl
+atW
 npx
-cqd
+aJy
 cqb
-cpt
-cpt
-cpt
-asa
-cpt
+aMN
 bzi
-cpt
-cpt
-cpt
-aBQ
 bzi
-cpt
 bzi
-cpt
+bpB
+atW
+bqG
+brp
+azp
+cqt
+bsT
+but
+btY
+buC
 cps
 xhl
 vzE
-cps
-cpt
-cpt
-bDY
-aat
-aat
-anl
-acv
-apN
+bvM
+aqT
+aqT
+bwm
+bls
+bwq
+buz
+cpD
+adH
 crv
-apN
-acv
-apN
-acv
-apN
-ads
-aat
-aat
-aat
-aat
+bwB
+bwE
+aPT
+ajp
+ajp
+crv
+bwK
+bwR
+aeV
+adH
 aat
 aat
 aat
@@ -47839,64 +49217,64 @@ ayn
 aeT
 ayW
 aat
+anl
+aaQ
+bzx
+cpA
+acv
+bzx
+bzx
+acv
+hlw
+bss
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-abz
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
 ach
 acv
 acv
-aVu
+acv
 ads
-aHF
-feF
-aJf
-aIw
-aIw
-aIw
-aJf
-aKC
-aHF
 aat
 aat
 aat
 aat
-ahF
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+anl
+acv
+bhV
+aat
+aat
+aat
+aat
+aat
+abd
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ayt
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -47944,7 +49322,7 @@ axn
 adY
 aiv
 aeS
-bcT
+agk
 aat
 agy
 aat
@@ -48025,65 +49403,65 @@ aae
 aae
 aae
 aae
-aae
-afF
-aBP
-aqF
-aDt
-afF
-blY
-bDY
+cql
+bDO
+cql
+cqn
+heY
+acz
+ayZ
+alC
 amQ
+ait
+ait
 amQ
-amQ
-bDY
-amv
-afF
-afF
-afF
-afF
-afF
-bDY
-bDY
-bDY
-bDY
-apV
+ait
+aqW
+asy
+aqW
+asy
+azb
+acz
+cpg
+cpg
+cpm
 bzi
-apT
-bDY
-bDY
-bDY
-bDY
-bDY
-ayr
-bDY
-bDY
-bDY
-cpt
-cpt
+bzi
+bzi
+bzi
+bzi
+bqg
+bqH
+ayZ
+ayZ
+cqt
+bsY
+buv
+bua
 cps
+buD
 bkn
-bkU
-bDY
-bDY
-bkx
-bDY
-aat
+vzE
+bls
+bvU
+bvU
+bvU
+bls
 cqw
-cqw
+bww
 cpD
-cqw
-cqw
-xUI
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-aat
+adH
+ahb
+ajp
+ajp
+ahb
+ajp
+ahb
+ahb
+ahb
+ajp
+aeV
+adH
 aat
 aat
 aat
@@ -48096,64 +49474,64 @@ aer
 aeU
 ayW
 aat
-aat
-aat
-ayt
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-ach
-apN
+aci
+bxu
+brV
 acv
-apN
-ael
-aHF
-aHF
-aKC
-aKC
-aKC
-aLI
-aKC
-aHF
-aHF
+acv
+acv
+acv
+acv
+aaQ
+bhV
+aou
 aat
-aHF
-aat
-aat
+ach
+acv
+acv
+acv
+ads
 aat
 aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+anl
+acv
+bhV
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+gpq
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+aat
+ady
+ady
+ady
+aat
 aae
 aae
 aae
@@ -48201,7 +49579,7 @@ axr
 adY
 col
 aeV
-bcT
+agk
 aat
 agy
 aat
@@ -48282,65 +49660,65 @@ aae
 aae
 aae
 aae
-aae
-afF
-afF
-aqB
-aDt
-afF
-aqY
-cqv
-axb
-axb
-axb
-cqv
-amw
-afF
-afF
-aqB
-afF
-afF
-bDY
-heY
-cqd
-cpm
-cpt
-cpt
-cpt
-cpm
-cqd
+cql
+bDO
+cql
+cqn
 heY
 bDY
-axX
+ayZ
+cqv
+amQ
+ait
+ait
+ait
+amQ
+aqW
+asy
+aqW
+asy
+azb
+acz
+heY
+heY
+cpm
+bzi
+bzi
+bzi
+bzi
+bzi
+bqg
+bqH
 ayZ
 ayZ
+cqt
 atX
-bDY
-cpt
-cpt
-bDY
-bkv
+but
+bua
+buD
+bkn
+vzE
 vzE
 bls
-xhl
-xhl
-bDY
-aat
-cqw
+bvW
+bvW
+bvW
+bvW
+bwr
 asQ
-akP
-akP
-alY
-acv
-acv
-bsj
-acv
-bmp
-ads
-aat
-aat
-aat
-aat
+cpD
+adH
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ahb
+ajp
+aeV
+adH
 aat
 aat
 aat
@@ -48354,63 +49732,63 @@ aeV
 ayW
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-abz
-ahF
-aii
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+sub
+aci
+bvT
+bvT
+brV
+aaQ
+aaQ
+aaQ
+bhV
 aat
 aat
 ach
 acv
 acv
 acv
-acv
-xUI
-aHF
-aHF
-aKC
-aKC
-aKC
-aHF
-aHF
+ads
 aat
-aat
-aHF
-aHF
+abz
 aat
 aat
 aat
+aaQ
+aLi
+aLi
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+azK
+aaQ
+aaQ
 aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+sub
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -48458,7 +49836,7 @@ adH
 adY
 aiv
 aeV
-bcT
+agk
 aat
 agy
 aat
@@ -48539,65 +49917,65 @@ aae
 aae
 aae
 aae
-aae
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
+cql
+bDO
+cql
+cqn
+heY
 bDY
-npx
-cpg
-cqb
-cpt
-cpt
-cpt
-cqb
-cqd
+akt
+cqt
+ait
+ait
+amQ
+amQ
+ait
+aqW
+asy
+aqW
+asy
+aAl
 atW
+heY
+aJJ
 bDY
+aNi
+bzi
+bzi
+bzi
+bzi
+atW
+bqI
 axY
 azb
-ayZ
+cqt
 aEn
-bDY
-cpt
-cpt
-bDY
-bDY
-bDY
-alD
+btY
+buC
 xhl
 vzE
-bDY
-aat
-cqw
+cpn
+vzE
+bvN
+bvZ
+bwg
 cpp
-cqH
-akP
-cqw
-crR
-bsj
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-aat
+cpp
+cpp
+cpp
+bwy
+agp
+axb
+axb
+axb
+axb
+axb
+axb
+axb
+axb
+axb
+ayp
+adH
 aat
 aat
 aat
@@ -48611,63 +49989,63 @@ aeV
 ayW
 aat
 aat
+sub
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+eTT
+bvT
+bvT
+bvT
+bgL
 aat
 aat
 ach
+acv
+acv
 acv
 ads
 aat
 aat
-ahF
+aat
+aat
+aat
+aaQ
+bbi
+bbi
+aCy
+aAf
+tiC
+bbi
+aAf
+fNW
+aCr
+acb
+acb
+aaQ
 aat
 aat
 aat
 aat
 aat
+aib
+aat
+aat
+sub
 aat
 aat
 aat
-aHF
+bqC
 aat
-ach
-bsj
-bme
-acv
-acv
-acv
-aIc
-aHF
-fMj
-aJy
-fMj
-aHF
+aat
+aat
+aat
+ayt
 aat
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aii
-acO
-bss
-aat
-aat
-aat
-aae
-aae
-aae
 aae
 aae
 aae
@@ -48715,7 +50093,7 @@ adH
 adY
 aiv
 aeV
-bcT
+agk
 aat
 agy
 aat
@@ -48796,65 +50174,65 @@ aae
 aae
 aae
 aae
-bDY
+cql
 bDO
-cpv
-cpV
-cpV
-cpv
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-cpv
-cpV
-cpV
-cpv
-afF
+cql
+cqn
+heY
 bDY
-bDY
-bDY
-bDY
-apV
-cpt
-arW
-bDY
-bDY
-bDY
-bDY
-axX
-azb
-ayZ
-axX
-bDY
-cpt
-bzi
-cpt
-bDY
+akt
+alA
+amQ
+ait
+ait
+ait
+ait
+aqZ
+asO
+awz
+cpp
+arB
+cqb
+cpg
+heY
 bkZ
-xhl
-xhl
-bst
 bDY
-aat
-cqw
-cqH
+bDY
+aIs
+bDY
+bDY
+bDY
+brg
+brp
+azb
+cqt
+atw
+bua
+cps
+xhl
+vzE
+bvt
+bkZ
+bvP
+bwa
+bst
 anu
-cqu
-cqw
+anu
+bws
+anu
+anu
+acG
 dIH
-acv
-acv
-crv
-acv
-ads
-aat
-aat
-aat
-aat
+dIH
+acG
+acG
+acG
+acG
+acG
+acG
+acG
+acG
+axj
 aat
 aat
 aat
@@ -48864,12 +50242,11 @@ adH
 adY
 abT
 aeC
-nLp
+aeV
 ayW
 aat
 aat
-aat
-aat
+sub
 aat
 aat
 aat
@@ -48882,49 +50259,50 @@ aat
 aat
 ach
 acv
-hlw
-acO
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aat
-vaC
 acv
 acv
-acv
-vzq
-dXJ
-qDJ
-qDJ
-acv
-acv
-cwe
 ads
 aat
 aat
-aHF
-aHF
-aHF
-aHF
-aat
-aat
-ach
-acv
-hlw
-bss
 aat
 aat
 aat
-aae
-aae
+aaQ
+acb
+acb
+acb
+aAf
+aCr
+acb
+aAf
+aBT
+mtr
+acb
+acb
+aaQ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+sub
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -48972,7 +50350,7 @@ adH
 adY
 aiv
 aeV
-bcT
+agk
 aat
 agy
 aat
@@ -49054,65 +50432,65 @@ aae
 aae
 aae
 cql
-afF
-cpv
-cpV
-cpV
-cpv
-afF
-afF
-aqB
-afF
-afF
-afF
-afF
-anq
-cpV
-ajF
-cpv
-afF
-bDY
+bDO
+cql
+cqn
 heY
-cqd
-cpm
-cpt
-cpt
-cpt
-cpm
+bDY
+aku
+cqt
+amQ
+ait
+amQ
+amQ
+amQ
+ara
+asP
+ajF
+ayZ
+aAJ
+bDY
 cpg
 heY
 bDY
-bDY
-bDY
-ayr
-bDY
-bDY
-aIK
-cpt
 bzi
+aVu
+bzi
+bzi
+bpF
 bDY
-aPz
+bqD
+brq
+azb
+cqt
+atx
+bua
+cps
+xhl
 vzE
-vzE
-aPz
+bls
 bDY
-aat
-cqw
-alY
-azv
-cqw
-cqw
-cqw
-alY
-cqw
-cqw
-ozC
-afj
+bvQ
+bwb
+cqn
 aat
 aat
 aat
 aat
-ayJ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -49125,6 +50503,7 @@ aeV
 ayW
 aat
 aat
+sub
 aat
 aat
 aat
@@ -49134,13 +50513,10 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
+ayt
 ach
 acv
 acv
-hKE
 acv
 ads
 aat
@@ -49148,37 +50524,39 @@ aat
 aat
 aat
 aat
+aaQ
+aCr
+acb
+aDH
+aAf
+acb
+nHC
+aAf
+aAf
+aAf
+aAf
+acb
+aaQ
 aat
 aat
 aat
 aat
 aat
+aat
+aat
+aat
+sub
+aat
+aaQ
+aaQ
+xJU
+aaQ
+qPQ
+aaQ
 aHF
-aKC
-aKC
-aKC
-aHF
-qDJ
-sUB
-acv
-acv
-acv
-acv
-ael
-bgA
-bgA
-aHF
-aQz
-gCv
-aHF
-aat
-aat
-ach
-acv
-acv
-ads
-aat
-aat
+aaQ
+dRL
+dRL
 aat
 aat
 aae
@@ -49229,7 +50607,7 @@ cog
 adY
 aiv
 aeV
-bcT
+agk
 aat
 agy
 bcS
@@ -49310,63 +50688,63 @@ aae
 aae
 aae
 aae
-afF
-afF
-anq
-cpV
-cpV
-cpv
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-cpv
-cpV
-cpV
-anq
-afF
+cql
+bDO
+cql
+cqn
+heY
 bDY
-npx
-cqd
-cqb
+akB
+cqt
+ait
+ait
+amQ
+ait
+amQ
+azb
+asP
+akb
+ayZ
+aCl
+bDY
+heY
+heY
+bDY
 bzi
-cpt
-cpt
-cqb
-cqd
-atW
+bzi
+beL
+bgO
+bzi
+atU
+cps
+cqH
+brF
+cqt
+atw
+bua
+cps
+buF
+buV
+bls
 bDY
-bDY
-cpt
-cpt
-cpt
-cpt
-cpt
-cpt
-cpt
-bDY
-blm
-xhl
-xhl
-aPz
-bDY
-aat
-cqw
-akP
-alE
-alE
-crA
-alE
-akP
-amZ
-cqw
+aII
+heY
+cqn
 aat
 aat
 aat
-ayJ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -49382,24 +50760,7 @@ aeV
 ayW
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-bqC
-aat
-aat
-aat
-aat
-aat
-afw
-acP
-acP
-brV
-acv
-ads
+sub
 aat
 aat
 aat
@@ -49408,34 +50769,51 @@ aat
 aat
 aat
 aat
-aat
-aHF
-aHF
-aKC
-aKC
-aKC
-aHF
-aHF
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-aJy
-act
-iWS
-aHF
 aat
 aat
 ach
 acv
 acv
+acv
 ads
 aat
 aat
+aat
+aat
+aat
+aaQ
+bUW
+gld
+aMg
+aAf
+acb
+gQe
+aAf
+aZz
+lBN
+aBS
+acb
+aaQ
+aat
+aat
+aat
+aat
+aii
+acO
+acO
+acO
+acO
+acO
+aaQ
+xIS
+acb
+wBE
+gZC
+sKc
+aaQ
+acb
+aIi
+bhV
 aat
 aat
 aae
@@ -49486,7 +50864,7 @@ cog
 adY
 aiv
 aeV
-bcT
+agk
 aVT
 aXr
 abQ
@@ -49567,59 +50945,59 @@ aae
 aae
 aae
 aae
-afF
-afF
-cpv
-cpV
-cpV
-cpv
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-cpv
-cpV
-cpV
-cpv
-aHZ
+cql
+bDO
+cql
+cqn
+heY
 bDY
+ayZ
+cqt
+ait
+ait
+anw
+ait
+ait
+ara
+akR
+akR
+alx
+aCL
 bDY
-bDY
-bDY
-apV
-cpt
-apT
-bDY
-bDY
-bDY
-bDY
+cpg
+heY
 bDY
 bzi
+aYs
+bfL
+blg
 bzi
-cpt
-cpt
-cpt
-bzi
-cpt
-bkx
-xhl
-xhl
-xhl
-btw
+atU
+cps
+cqH
+brO
+bsw
+btj
+bub
+buR
+buR
+bkn
+bls
 bDY
+bDY
+bvR
+cqn
 aat
-cqw
-akP
-cqH
-akP
-akP
-akP
-akP
-cqH
-cpD
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -49638,63 +51016,63 @@ ayn
 aeW
 ayW
 aat
-ahF
+aat
+azh
+azh
+azh
+azh
+azh
+azh
+azh
+azh
+azh
+aat
+aat
+ach
+acv
+acv
+acv
+ads
 aat
 aat
 aat
 aat
 aat
-aat
-aat
-aii
-bss
-aat
-aat
+aaQ
+acb
+aHL
+rSv
+aAf
+abv
+aAf
+aAf
+aKC
+acb
+acb
+acb
+aaQ
 aat
 aat
 aat
 aat
 ach
-bsq
-afj
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-jJI
-aKC
-aLI
-aKC
-ajW
-fMj
 acv
 acv
+adC
 acv
-cJV
 acv
-bsq
-bvT
-bvT
-aHF
-aHF
-aHF
-aHF
+jfn
+hJn
+acb
+aCr
+byM
+acb
+abv
+acb
+utI
+bhV
 aat
-aat
-afw
-bvT
-bvT
-afj
-aat
-aat
-aat
-aat
+aae
 aae
 aae
 aae
@@ -49732,7 +51110,7 @@ acC
 bhf
 blj
 aiL
-bcT
+agk
 agk
 agk
 beg
@@ -49743,7 +51121,7 @@ bfh
 adY
 aiv
 bfr
-bcT
+agk
 com
 acG
 bfE
@@ -49824,64 +51202,64 @@ aae
 aae
 aae
 aae
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-aqF
-aDt
-afF
-afF
-afF
-afF
-afF
-afF
-aqB
-afF
-bDY
-heY
-cqd
-cpm
-cpt
-cpt
-cpt
-cpm
-cqd
+cql
+bDO
+cql
+cqn
 heY
 bDY
+akQ
+alF
+alX
+amt
+cpp
+cpp
+api
+arB
+alx
+alx
+ayZ
+aCT
 bDY
-cpt
-cpt
+heY
+cpg
 bDY
-cpm
-cpm
-cqb
-cpm
+aNt
+bzi
+bgO
+bln
+bpG
 bDY
-aPz
-xhl
-xhl
-aPz
-bDY
-aat
-cqw
-akP
-akP
-akP
-akP
+cps
 cqH
-akP
-uOe
-cpD
+aPz
+cqt
+btn
+buy
+vzE
+vzE
+buy
+bvt
+aPz
+cqb
+heY
+cqn
 aat
 aat
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aib
 aat
 aat
 aat
@@ -49896,60 +51274,60 @@ aeT
 ayW
 aat
 aat
-aAm
+azh
+acb
+aDv
+bcN
+azh
+fMj
+azh
+fMj
+azh
 aat
 aat
-ahF
-aat
-aii
-bgA
-bgs
+ach
+acv
+acv
+acv
 ads
-aat
-ahF
-aat
-aat
-aat
-aat
-afw
-afj
+abd
 aat
 aat
 aat
 aat
-aAm
-aat
-aat
-aat
-aat
-aat
-aHF
+aaQ
+abv
+aAf
+aAf
+aAf
+acb
+acb
 lmA
-okh
-aKC
-aKC
-aKC
-aJy
+aCr
+acb
+nHC
+nHC
+aaQ
+aat
+aat
+aat
+aat
+ach
 acv
 acv
 acv
 acv
 acv
-ads
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayt
-aat
-ayJ
+aaQ
+jMn
+acb
+acb
+acb
+pJA
+aaQ
+bCu
+hBB
+bmh
 aat
 aat
 aae
@@ -50080,71 +51458,71 @@ aaa
 aae
 aae
 aae
-aeS
-axb
-axb
-axb
-ajE
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-aqF
-afF
-afF
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-npx
-cpg
-cqb
-cpt
-cpt
-cpt
-cqb
-cpg
-atW
+akR
+ayZ
+alZ
+amu
+anx
+alx
+ayZ
+ayZ
+ayZ
+anx
+ayc
+aED
 bDY
-alD
-cpt
-cpt
+acz
+acz
 bDY
-cpn
-cqd
-cqd
-cpn
 bDY
+bDY
+bkZ
+bDY
+bDY
+bDY
+cps
+cqH
 blm
-xhl
+cqt
+btF
+cpn
 vzE
-aPz
+cpn
+cpn
+bls
+blm
 bDY
+aII
+cqn
 aat
-cqw
-cpq
-cpF
-cqD
-cqw
-ijo
-lRH
-sgn
-cqw
 aat
-ahF
-ayJ
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-agk
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
 axd
 adY
 aer
@@ -50153,42 +51531,18 @@ aeU
 ayW
 aat
 aat
+azh
+bAp
+cpB
+crR
+azh
+aNU
+azh
+aNU
+azh
 aat
 aat
-aat
-aat
-aii
-bgs
-aeL
-adq
-bqY
-uEx
-ady
-aat
-aat
-ady
-aNb
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-esz
-aKC
-aLI
-aKC
-aII
-fMj
-acv
-acv
+ach
 acv
 acv
 acv
@@ -50198,15 +51552,39 @@ aat
 aat
 aat
 aat
+aaQ
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+aIh
+hyl
+aRV
+aaQ
 aat
-aHF
 aat
 aat
 aat
-aat
-aat
-aat
-aat
+ach
+acv
+acv
+acv
+acv
+acv
+aaQ
+aaQ
+aaQ
+aaQ
+abv
+aaQ
+aaQ
+cpA
+ddk
+bhV
 aat
 aat
 aat
@@ -50337,71 +51715,71 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-bAq
-afF
-adH
-afF
-akt
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
 bDY
 bDY
-bDY
-apV
-bzi
-apV
-bDY
+atW
+amv
+atW
 bDY
 bDY
+atW
+amc
+atW
 bDY
 bDY
+cqb
+aIM
+heY
+bDY
+asV
+bax
+bhO
+bax
+asV
+bDY
+cps
+cqH
 azp
-cpt
-bDY
+cqt
+btF
+bls
 cpn
-cqd
-cpg
-cpn
+bva
+bvg
+bvu
+azp
 bDY
-aPz
-xhl
-xhl
-blm
-bDY
+heY
+cqn
 aat
-cqw
-cqw
-cqw
-cqw
-cqw
-cqw
-cqw
-cqw
-cqw
 aat
-aae
-aae
-aae
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
 adK
 adY
 abS
@@ -50410,60 +51788,60 @@ aeV
 ayW
 aat
 aat
+azh
+bEc
+aDE
+cwe
+azh
+acb
+ixM
+jkN
+azh
 aat
 aat
-aat
-aOX
 ach
 acv
-acR
 acv
-bsb
-aat
-aat
-aat
-aat
-aat
-agy
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
-kid
-kid
-aJM
-aHF
-aHF
-fFq
-bvT
-bvT
-acw
 acv
-ael
-bgA
+ads
+aat
+aat
+aat
+aat
+aat
+aaQ
+aAf
+aGa
+aAf
+aAf
+aaQ
+azK
+aLi
+aLi
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+adC
+acv
 aHF
-aHF
-aHF
-aHF
-aat
-aHF
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+adC
+acv
+gKP
+acb
+acb
+aaQ
+xSc
+acv
+bhV
 aat
 aat
 aat
@@ -50594,71 +51972,71 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-afF
-afF
-adH
-afF
-aqF
-afF
-afF
-afF
-akW
-aly
-afF
-afF
-afF
-afF
-afF
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+act
 bDY
+akS
+aHZ
+aHZ
+aHZ
+aly
+aHZ
+apE
+bDY
+ait
+awB
+aza
+aFE
+bkZ
 heY
 cpg
-aqT
-cpt
-cpt
-cpt
-cpm
-cqd
+bDY
+asU
+arE
+arE
+asU
+asU
+bDY
+cps
+cqH
+azb
+bsx
+btG
+cpp
+cpp
+cpp
+cpp
+cpp
+arB
+bDY
 heY
-bDY
-bDY
-cpt
-bzi
-bDY
-cpn
-aIN
-anK
-cpn
-bDY
-aPz
-vzE
-xhl
-aPz
-bDY
-aat
-aat
-aat
-aat
-ahF
+cqn
 aat
 aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
 adH
 adY
 afx
@@ -50667,63 +52045,63 @@ aeV
 ayW
 aat
 aat
-aat
-aat
-aat
-aii
-aCl
-acv
-acR
-acv
-ads
-aat
-gpq
-aat
-aat
-aat
-agy
-aat
-aFQ
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
-aHF
-aHF
-aHF
-aat
-aat
+azh
+bGB
+aCb
+cJV
+azh
+aNU
+azh
+azh
+azh
 aat
 aat
 ach
 acv
 acv
 acv
-aJy
-act
-aNt
+ads
+aat
+aat
+aat
+aat
+aat
+aKk
+aUF
+acb
+azE
+azE
+aaQ
+aii
+acu
+acv
+acv
+afL
+azK
+qtR
+aaQ
+aat
+aat
+aat
+ach
+acv
+acv
+adr
+acP
+acP
 aHF
+lXI
+acv
+jqC
+aAq
+qNp
+aHF
+aHF
+aaQ
+aaQ
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+aae
 aae
 aae
 aae
@@ -50851,50 +52229,49 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-afF
-afF
-adH
-afF
-akt
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
+akT
 aHZ
-bDY
-alD
-bDY
+aHZ
+aHZ
+aHZ
+aoi
 amd
-amd
 bDY
+ait
+ait
+ait
+ait
+awB
+cpg
+heY
 bDY
+arE
+arE
+apB
+asU
+bpX
 bDY
-afF
+cps
+cqH
+brX
+bsy
+anu
+aqT
+aqT
+aqT
+bvh
+ayZ
+ayZ
 bDY
-anK
-arx
-cqb
-cpt
-cpt
-cpt
-cqb
-arx
-anK
-bDY
-bDY
-cpt
-cpt
-bDY
-bDY
-alD
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
+heY
+cqn
 aat
 aat
 aat
@@ -50902,20 +52279,21 @@ aat
 aat
 aat
 aat
-aae
 aat
 aae
-aae
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aib
+aat
+aat
+aat
+bqC
+aat
+aat
+ekc
 adH
 adY
 afx
@@ -50924,63 +52302,63 @@ aeV
 ayW
 aat
 aat
+azh
+bGF
+azh
+azh
+azh
+acb
+aSt
+azh
 aat
-aat
+abd
 aat
 ach
 acv
 acv
-acR
 acv
 ads
 aat
-aGP
-aat
-aEx
-aat
-agy
 aat
 aat
 aat
 aat
+aaQ
+bbY
+acb
+azE
+azE
+azn
+anl
+acv
+acv
+vGo
+hlw
+aaQ
+aaQ
+aaQ
 aat
 aat
+abz
+ach
+acv
+acv
+ads
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
 aat
 afw
-bvT
-bvT
-fFq
+mwM
+lXI
+acv
+acv
+abJ
 aHF
-wsu
-aQz
-aHF
+bsq
+acP
+afj
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+aae
 aae
 aae
 aae
@@ -51017,18 +52395,18 @@ aiL
 aiL
 aiL
 aiL
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
-bcT
+agk
+agk
+agk
+agk
+agk
+agk
+agk
+agk
+agk
+agk
+agk
+agk
 adf
 adf
 adf
@@ -51108,52 +52486,52 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-afF
-afF
-adH
-afF
-afF
-afF
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-alv
-ait
-ait
-ait
+akT
+aHZ
+aHZ
+aHZ
+bDY
+bDY
+bDY
+bDY
 amS
-anw
-bDY
-afF
-bDY
-bDY
-bDY
-bDY
-bDY
+ait
+ait
+ait
+awB
+heY
+cpg
+aKI
+arE
 apB
+apW
+apW
+arE
+bkZ
 bDY
 bDY
 bDY
 bDY
-bDY
-bDY
-awC
-awC
-bDY
+atW
 aIs
-aat
-ayJ
+atW
+bDY
 cpo
+ayZ
+ayZ
+bDY
+heY
+cqn
 aat
 aat
 aat
-aii
-acO
-aOD
-afL
-aat
 aat
 aat
 aat
@@ -51162,17 +52540,17 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
 adH
 adY
 aer
@@ -51181,63 +52559,63 @@ aeV
 ayW
 aat
 aat
+azh
+bGB
+aBW
+aCb
+acb
+abJ
+acb
+azh
+bjB
 aat
 aat
-aih
 ach
 acv
 acv
 acv
-bsq
-afj
-aat
-aTL
-aat
-aat
-aat
-agy
+ads
 aat
 aat
 aat
 aat
 aat
+aaQ
+wsu
+acb
+acb
+ggv
+aaQ
+afw
+ecb
+acv
+acv
+acv
+azK
+jwt
+aaQ
 aat
 aat
 aat
-aat
-ahF
-aat
-aat
-aat
-aat
+ach
+acv
+acv
+ads
 aat
 aat
-aat
-aat
-aat
-aat
-aHF
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
-aHF
-aHF
+abd
+afw
+kcv
+adC
+acv
+acv
+wSA
+ads
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-abz
-aat
-aat
+aae
+aae
 aae
 aae
 aae
@@ -51365,55 +52743,53 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-aqF
-aqB
-adH
-afF
-aku
-aqB
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-alw
-amS
+akY
+aHZ
+aHZ
+amU
+bDY
 ait
-ait
+apF
+bDY
 amS
 amY
-bDY
-afF
-afF
-bDY
-ary
-ary
-aqR
+ait
+ait
+aId
+heY
+cpg
+aKI
+asU
 apC
 apW
-ary
-ary
+blp
+bqa
 bDY
+bzi
+brr
+brY
+brr
+brY
+bzi
+bzi
+bDY
+azb
+ayZ
+ayZ
+bDY
+aII
+cqn
 aat
-ach
-acv
-acv
-acv
-hlw
-acO
-acO
-acO
-acO
-acO
-acO
-bgs
-acv
-bDY
-bDY
-bDY
-bDY
-bDY
-bzv
+aat
+aat
+aat
 aae
 aae
 aae
@@ -51422,14 +52798,16 @@ aae
 aae
 aae
 aae
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ekc
 adH
 adY
 abS
@@ -51438,63 +52816,63 @@ aeV
 ayW
 aat
 aat
+azh
+bIm
+cpF
+djA
+fbV
+fbV
+fbV
+jAZ
 aat
 aat
-aii
-bgs
+aat
+ach
 acv
-bsq
-acP
-afj
+acv
+acv
+ads
 aat
 aat
 aat
 aat
 aat
+aaQ
+xCV
+fxk
+tOJ
+jGA
+aaQ
 aat
-agy
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+afw
+acw
+acv
+acv
+aaQ
+aaQ
+aaQ
 aat
 aat
 aat
+ach
+acv
+acv
+ads
 aat
 aat
 aat
-aat
-aat
-aHF
-aHF
-aHF
-aat
-aat
-aat
-aat
-aat
+abd
+xFQ
+kcv
+mwM
+aaQ
+aaQ
+bgL
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+aae
+aae
 aae
 aae
 aae
@@ -51622,55 +53000,53 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-afF
-afF
-adH
-afF
-afF
-afF
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-alx
-ait
-amd
-amd
-ait
-ait
-amP
-afF
-afF
+akZ
+aHZ
 bDY
-apI
-apW
-aqS
+bDY
+bDY
+aoj
+ait
+arC
+ait
+ait
+ait
+aHY
+bDY
+aIM
+heY
+bDY
+asU
 arE
-aqU
-aqR
+apB
+blM
 asU
 bDY
+brh
+bgO
+bgO
+bgO
+bgO
+bzi
+buS
+bkZ
+bDY
+bDY
+bvB
+bDY
+heY
+cqn
 aat
-ach
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-byM
-bwP
-awz
-bAp
-bDY
-bDY
+aat
+aat
+aat
 aae
 aae
 aae
@@ -51679,14 +53055,16 @@ aae
 aae
 aae
 aae
-aaa
 aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+bxa
 axg
 axx
 aqm
@@ -51695,50 +53073,48 @@ ayI
 aoI
 aat
 aat
-cnS
-aat
-afw
-acP
-acP
-afj
-aat
-aat
-bsM
-aat
+azh
+bUW
+cpG
+cpz
+aFR
+abJ
+acb
+azh
 aat
 aat
 aat
-aat
-agy
-aat
-aat
-aat
-aat
-ahF
+ach
+acv
+acv
+acv
+ads
 aat
 aat
 aat
 aat
 aat
+aaQ
+aLi
+aLi
+aLi
+aaQ
+aaQ
+afL
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+sub
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+ach
+acv
+acv
+ads
 aat
 aat
 aat
@@ -51751,7 +53127,9 @@ aat
 aat
 aat
 aat
-aat
+aae
+aae
+aae
 aae
 aae
 aae
@@ -51813,7 +53191,7 @@ adH
 aFV
 aer
 ayw
-aeV
+qJh
 ayW
 aat
 aat
@@ -51879,55 +53257,53 @@ aaa
 aae
 aae
 aae
-aeV
-ais
-afF
-afF
-adH
-afF
-aku
+aae
+cql
+bDO
+cql
+cqn
+heY
+bDY
 akc
-akz
-akz
+aHZ
 bDY
-alz
+amV
 ait
-amd
-amd
 ait
-anx
+ait
 bDY
-afF
-afF
+ait
+ait
+ait
+awB
 bDY
-aqh
-aqU
-apD
-apD
-apD
-aqS
+cpg
+heY
+bDY
+asV
+bbL
+bhO
+blZ
 asV
 bDY
-aat
-ach
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-byM
-bwQ
-bwP
-bwP
-cpG
+bri
+bgO
+bgO
+bgO
+bgO
+bzi
+bzi
 bDY
+bDY
+heY
+heY
+heY
+heY
+cqn
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -51936,14 +53312,16 @@ aae
 aae
 aae
 aae
-aaa
 aae
 aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+bxd
 aat
 aat
 aqn
@@ -51952,52 +53330,48 @@ aat
 aat
 aat
 aat
+azh
+acb
+aAq
+acb
+acb
+cpS
+aEA
+aBh
+abd
+aat
+aat
+ach
+acv
+acv
+acv
+ads
 aat
 aat
 aat
 aat
 aat
+uQK
+apN
+apN
+acv
+apN
+apN
+hlw
+afL
+sub
 aat
-agy
+xZK
 aat
-aHm
-aat
-aat
-aat
-aat
-aat
-agy
-aat
-aat
-aat
-aat
-aat
+sub
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-ayt
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aii
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-ayt
+ach
+acv
+adC
+ads
 aat
 aat
 aat
@@ -52009,6 +53383,10 @@ aat
 aat
 aat
 aat
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -52136,64 +53514,52 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-afF
-afF
-adH
-afF
-afF
-aiN
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-alA
+alu
+aHZ
+bDY
+amV
 ait
-amd
-amd
 ait
-aza
+ait
 bDY
-afF
-afF
+asT
+ait
+azt
+awB
 bDY
-aqh
-aqW
+heY
+heY
 bDY
 bDY
+bkZ
 bDY
-asb
-asV
+bkZ
 bDY
+bDY
+bzi
+brs
+bsb
+bsb
+btH
+bzi
+bzi
+bDY
+bDY
+heY
+bDY
+bvR
+bDY
+cqn
 aat
-ach
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-byM
-bwP
-bwQ
-bwP
-cpS
-bDY
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aat
+aat
 aae
 aae
 aae
@@ -52201,6 +53567,18 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aat
+aat
+aat
+bxe
 axh
 axy
 aat
@@ -52209,44 +53587,46 @@ aat
 aat
 aat
 aat
+azh
+aCr
+aCr
+acb
+acb
+acb
+acb
+jJI
 aat
 aat
 aat
-aYc
+ach
+acv
+acv
+acv
+ads
 aat
-aat
-agy
-aat
-aat
-aii
-bgA
-bss
-aat
-aat
-agy
+ayt
 aat
 aat
 aat
+uQK
+acv
+acv
+acv
+acv
+acv
+acv
+hlw
+oCT
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+xZK
+sub
 aat
 aat
 aat
 aat
-abz
-aat
-aat
-aii
-acO
-acu
+ach
+acv
 acv
 ads
 aat
@@ -52257,8 +53637,6 @@ aat
 aat
 aat
 aat
-aat
-ahF
 aat
 aat
 aat
@@ -52393,58 +53771,51 @@ aaa
 aae
 aae
 aae
-aeV
-afF
-aWs
-afF
-adH
-afF
-afF
-aiN
-afF
-afF
+aae
+cql
+bDO
+cql
+cqn
+heY
 bDY
-amS
-ait
-ait
-ait
-amS
-any
 bDY
-afF
-afF
 bDY
-aqh
-apW
-ary
-ary
-arY
-aqR
-asV
 bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+acz
+acz
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+bDY
+heY
+bvG
+anM
+bwe
+cqn
 aat
-ach
-acv
-acv
-acv
-acv
-bsq
-bvT
-bvT
-bvT
-bvT
-brV
-acv
-acv
-bDY
-bzx
-bwP
-bwP
-cpT
-bDY
-aae
-aae
-aaa
+aat
 aae
 aae
 aae
@@ -52458,6 +53829,13 @@ aae
 aae
 aae
 aae
+aae
+ady
+ady
+ady
+ady
+ady
+bxf
 axi
 axz
 axy
@@ -52466,43 +53844,45 @@ ayJ
 aat
 aat
 aat
+azh
+aDy
+aDA
+acb
+acb
+fWz
+iWS
+azh
 aat
 aat
 aat
-aat
-aih
-aat
-aHF
-aHF
-aHF
-aHF
-bky
-aHF
-aHF
-aHF
-aHF
-aat
-aAm
-aat
-aat
-aat
-aat
-aat
-aii
-acO
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aii
-acu
+ach
+adC
 acv
+acv
+ads
+aat
+aat
+aat
+aat
+aat
+uQK
+apN
+apN
+acv
+apN
+apN
+apN
+acv
+cXL
+aat
+xZK
+aat
+sub
+aat
+aat
+aat
+aat
+ach
 acv
 acv
 ads
@@ -52512,13 +53892,11 @@ aat
 aat
 aat
 aat
-aii
-acO
-acO
-acO
-bss
 aat
-aAm
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -52580,7 +53958,7 @@ aae
 aae
 aat
 agl
-adH
+thR
 adY
 abS
 aiv
@@ -52650,70 +54028,70 @@ aaa
 aae
 aae
 aae
-aeX
-acG
-akx
-acG
-ajT
-afF
-afF
-bdp
-afF
-afF
-bDY
-alB
-alH
-ait
-and
-ans
-anI
-bDY
-afF
-afF
-bDY
-aqi
-aqU
-aqR
-arF
-apW
-aqS
-asW
-bDY
-awD
-ach
-acv
-acv
-acv
-acv
-bhV
+aae
+cql
+bDO
+cql
+cqn
+heY
+heY
+heY
+heY
+heY
+amX
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+amX
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+amX
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+heY
+amX
+heY
+heY
+bvI
+brn
+bwf
+cqn
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aat
 aat
 aat
 aat
-ach
-acv
-acv
-bDY
-bAp
-bwP
-bwQ
-bqg
-bDY
-aae
-aae
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
 agl
 adH
 adY
@@ -52723,49 +54101,14 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-bnk
-buV
-aAf
-azJ
-aAf
-rnb
-epP
-aHF
-aat
-aat
-aat
-aat
-aat
-ayJ
-aat
-ach
-acv
-acv
-hlw
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-acv
-qaX
-acv
-ads
-aat
-aat
-aat
+azh
+acb
+acb
+acb
+acb
+acb
+acb
+aBh
 aat
 aat
 aat
@@ -52774,6 +54117,41 @@ acv
 acv
 acv
 ads
+aat
+aat
+aat
+aat
+aat
+uQK
+acv
+acv
+acv
+acv
+acv
+acv
+bsq
+wCS
+aat
+xZK
+xZK
+sub
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+ads
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -52907,58 +54285,50 @@ aaa
 aae
 aae
 aae
-bDY
-bDY
-bDY
-bDY
-bDY
-ajY
-bDY
-bDY
-adf
-akO
-bDY
-bDY
-bDY
-amP
-bDY
-bDY
-bDY
-bDY
-aol
-aTo
-bDY
-apD
-aqX
-aqS
-arH
-aqU
-apD
-apD
-bDY
-aat
-ach
-acv
-acv
-acv
-acv
-bhV
-aat
-aat
-aat
-aat
+aae
+cql
+bDO
+cql
+acj
 blt
-bDY
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
+blt
 btZ
-bDY
-bEc
-bwQ
-bwP
-cpU
-bDY
-aae
-aae
-aaa
+aat
 aae
 aae
 aae
@@ -52970,9 +54340,17 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aat
 aat
 agl
-qSr
+adH
 adY
 abS
 axz
@@ -52980,25 +54358,14 @@ ayK
 anQ
 aat
 aat
-aat
-aat
-aat
-abz
-aat
-aat
-bcO
-aCn
-bvA
-azn
-aJr
-azn
+azh
+aDR
+cpS
 acb
 acb
-aQU
-aat
-aat
-aat
-aat
+bdJ
+aDv
+jJI
 aat
 aat
 aat
@@ -53012,26 +54379,37 @@ aat
 aat
 aat
 aat
+vaC
+buf
+buf
+buf
+buf
+buf
+buf
+gfl
+jgK
+ady
+ady
+ady
+wDY
 aat
 aat
-afw
-acw
-acv
+aat
+aat
+ach
 acv
 acv
 ads
 aat
 aat
 aat
-ayJ
 aat
 aat
-ach
-acv
-acv
-bsq
-afj
 aat
+aat
+aat
+aat
+bqC
 aat
 aat
 aat
@@ -53164,58 +54542,58 @@ aaa
 aae
 aae
 aae
-bDY
-aiG
-ajl
-ajb
-ajb
-ajb
+aae
+cql
+bDO
 bFy
-bDY
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
 aat
-aat
-akX
-bDY
-akD
-ait
-ann
-ait
-anJ
-bDY
-acO
-acO
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-aql
-ach
-acv
-acv
-acv
-acv
-bhV
-aat
-aat
-aat
-ayJ
-blD
-bDY
-bwP
-aoo
-bwP
-bwP
-bwP
-cqj
-bDY
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -53235,6 +54613,24 @@ abS
 aiv
 aeV
 aiu
+bxl
+ady
+azh
+azh
+azh
+azh
+azh
+azh
+azh
+azh
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+ads
 aat
 aat
 aat
@@ -53243,54 +54639,36 @@ aat
 aat
 aat
 aat
-aHF
-aHf
-aCX
-aAf
-azE
-aAf
-aNP
-aJr
-aHF
-aat
-psn
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-bvT
-bvT
-afj
-aat
-aat
-aat
-aat
-aat
-aAm
-aat
-aat
-afw
-bvT
-bvT
-bvT
-afj
 aat
 aat
 aat
 aat
 aat
 aat
-afw
-bvT
-bvT
-afj
 aat
 aat
 aat
-ayJ
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+ads
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -53353,7 +54731,7 @@ aat
 agl
 adH
 aec
-abS
+mMB
 aiv
 jwd
 ayW
@@ -53421,58 +54799,58 @@ aaa
 aae
 aae
 aae
-bDY
-aYC
-ajb
-ajb
-ajU
-ajZ
-akw
-bDY
-akA
-akA
+aae
+cql
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+bDO
+cql
 aat
-bDY
-ait
-ait
-ait
-ait
-ait
-bDY
-acv
-acv
-hlw
-acO
-acO
-acO
-acO
-acO
-acO
-acO
-acO
-acO
-bgs
-acv
-acv
-acv
-bsq
-bgL
-aat
-aat
-aat
-aat
-aat
-bDY
-bwQ
-bwP
-bwQ
-bwP
-cpu
-alD
-bDY
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -53492,7 +54870,7 @@ abT
 aiv
 aeV
 agN
-anQ
+bxm
 aat
 aat
 aat
@@ -53500,21 +54878,16 @@ aat
 aat
 aat
 aat
-aHF
-aAf
-aAf
-aAf
-aGa
-aAf
-acb
-aHy
-aHF
-aat
-aat
-pNB
 aat
 aat
 aat
+aat
+abz
+ach
+acv
+acv
+acv
+ads
 aat
 aat
 aat
@@ -53536,6 +54909,11 @@ aat
 aat
 aat
 aat
+aat
+ach
+acv
+acv
+ads
 aat
 aat
 aat
@@ -53678,58 +55056,58 @@ aaa
 aae
 aae
 aae
-bDY
-bDY
-bAV
-ajD
-ajV
-aka
-bDY
-bDY
-ady
-ady
-ady
-bDY
-bDY
-bDY
-ano
-ano
-ano
-bDY
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-bgL
-aat
-aat
-aat
-aat
-aat
 aae
-bDY
-bys
-bza
-bGB
-bUW
-bDY
-bDY
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+bFy
+aat
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -53750,6 +55128,49 @@ aer
 aeX
 aeQ
 azs
+aii
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+jSS
+bgA
+bgA
+bgA
+bgs
+acv
+acv
+acv
+ael
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+acO
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgs
+acv
+acv
+ads
 aat
 aat
 aat
@@ -53757,50 +55178,7 @@ aat
 aat
 aat
 aat
-aHF
-abw
-bvW
-sOk
-azE
-aAf
-aJr
-acb
-aHF
 aat
-aat
-aat
-aat
-ahF
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayJ
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-abz
 aat
 aat
 aat
@@ -53936,57 +55314,57 @@ aae
 aae
 aae
 aae
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
+aae
+aae
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aat
 aat
 aat
 aat
 aat
 aat
-bDY
-bDY
-bDY
-bDY
-bDY
-acw
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ads
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aKZ
 aat
 aat
 aat
 aae
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
 aae
 aae
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -54007,49 +55385,49 @@ abS
 afl
 akh
 aEa
-aat
-aat
-aat
-aii
-bss
-aat
-aii
-bgO
-acb
-azE
-aHN
-azE
-aAf
-aHy
-acb
-aHF
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayt
-aat
-aat
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+adC
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+ads
 aat
 aat
 aat
@@ -54194,6 +55572,26 @@ aae
 aae
 aae
 aae
+aae
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aat
 aat
 aat
@@ -54203,29 +55601,6 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-acw
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-adr
-bvT
-bgL
 aat
 aat
 aat
@@ -54239,9 +55614,12 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -54264,51 +55642,51 @@ abS
 ajp
 ahb
 aEa
-aii
-bss
-aat
-afw
-afj
-aat
 ach
-bky
-acb
-abJ
-azE
-aJr
-aAf
-acb
-acb
-aHF
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+adC
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+ads
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aii
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ahF
 aat
 aat
 aat
@@ -54453,34 +55831,29 @@ aae
 aae
 aae
 aae
+aaB
+aaB
+aaB
 aae
 aae
 aae
 aae
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-acw
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-adr
-bgL
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aat
 aat
 aat
@@ -54494,9 +55867,14 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -54504,13 +55882,13 @@ aae
 acv
 arI
 acv
-asz
+buw
 aat
 aat
 ang
 alc
 abP
-alc
+bhs
 alc
 aps
 arL
@@ -54521,33 +55899,56 @@ abS
 agC
 agC
 aEa
-afw
-afj
-aat
-aat
-aat
-aat
-afw
-aHF
-aHr
-azE
-aJa
-azE
-aAf
-dpr
-xGK
-aHF
-aat
-ayt
-aat
-aat
-aat
-aat
-aat
-aat
 ach
 acv
-hlw
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+iYe
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+adC
+acv
+acv
+ads
+aat
+aat
+aat
+aii
+acO
+acO
+acO
 bss
 aat
 aat
@@ -54555,29 +55956,6 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayt
 aat
 aat
 aae
@@ -54711,57 +56089,57 @@ aae
 aae
 aae
 aae
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-acw
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 acv
 acv
 acv
-adr
-bvT
-bvT
-bgL
-aat
-aat
-aat
-aat
-aat
-aat
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aae
-aae
-aae
-aae
 acv
-acv
-acv
-acv
-asz
+buw
 aat
 abP
 abP
@@ -54778,57 +56156,57 @@ aiv
 aeS
 axb
 apr
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
-aat
-aat
-aat
-aat
-aat
+aci
+bvT
+bvT
+bvT
+bvT
+feF
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+brV
+acv
+adr
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bvT
+bgL
 aat
 aat
 aat
 ach
 acv
 acv
+acv
 ads
-aat
-aat
-aat
-aat
-aii
-acO
-acO
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
 aat
 aat
 aat
@@ -54968,41 +56346,41 @@ aae
 aae
 aae
 aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
-bDY
-akP
-akY
-akP
-akP
-anm
-bDY
-aat
-ahF
-ayJ
-aat
-aat
-aat
-aat
-anM
-ach
-acv
-acv
-acv
-atT
-aat
-aat
-aat
-aat
-aat
-ahF
-aat
-aat
-aat
 aae
 aae
-aaa
+aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -55018,7 +56396,7 @@ acv
 ard
 acv
 acv
-asz
+buw
 aat
 abP
 aua
@@ -55026,7 +56404,7 @@ alc
 aul
 alc
 alc
-aub
+bwV
 abP
 adH
 aec
@@ -55034,12 +56412,7 @@ abT
 aes
 aeV
 acB
-aiu
-aat
-aat
-aat
-aat
-aAm
+bxn
 aat
 aat
 aat
@@ -55054,38 +56427,43 @@ aat
 aat
 aat
 aat
+ayt
 aat
 aat
 aat
 aat
 aat
-afw
-bvT
-bvT
-afj
 aat
-ahF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+ach
+acv
+ads
+aat
+aat
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 ach
 acv
 acv
 acv
-hlw
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
+ads
 aat
 aat
 aat
@@ -55227,46 +56605,46 @@ aae
 aae
 aae
 aae
-aae
-bDY
-akQ
-akP
-akP
-alW
-amV
-bDY
-aat
-anM
-aat
-aat
-aat
-aat
-aql
-bDY
-bDY
-alY
-bDY
-ass
-bDY
-aql
-aat
-aat
-aat
-aat
-anM
-aat
+aaB
+aaB
+aaB
+aaB
+aaB
 aae
 aae
 aae
 aae
-aaa
+aaB
+aaB
+aaB
+aae
+aae
+aaB
+aaB
 aae
 aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aat
-aoR
+bwx
 acv
 acv
 acv
@@ -55275,7 +56653,7 @@ acv
 acv
 acv
 acv
-asz
+buw
 aat
 abP
 aub
@@ -55291,7 +56669,39 @@ abT
 ayn
 aeV
 acm
-aiu
+bxp
+ady
+ady
+ady
+aat
+aat
+aat
+aat
+aat
+aat
+ady
+ady
+ady
+aat
+aat
+aat
+aat
+ady
+ady
+ady
+uEx
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+azK
+aaQ
+aaQ
 aat
 aat
 aat
@@ -55306,44 +56716,12 @@ aat
 aat
 aat
 aat
+afw
+bvT
+bvT
+bvT
+afj
 aat
-aat
-aat
-aat
-aii
-acO
-acO
-acO
-acO
-bss
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-aat
-aat
-aii
-acO
-acO
-bss
-aat
-aat
-aat
-aii
-bss
 aat
 aat
 aat
@@ -55485,38 +56863,38 @@ aae
 aae
 aae
 aae
-bDY
-akR
-akP
-akP
-alX
-amX
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-ara
-akP
-akP
-akP
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aaB
+aaB
 aae
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aae
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -55548,7 +56926,39 @@ abT
 aes
 aeV
 acB
-aiu
+bxn
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+bqC
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+sub
+aat
+aaQ
+vcy
+xGK
+acb
+aRf
+aaQ
+bky
+acb
+acb
+hjY
+aaQ
 aat
 aat
 aat
@@ -55567,40 +56977,8 @@ aat
 aat
 aat
 aat
-ach
-acv
-hKE
-acv
-acv
-ads
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-acv
-ads
-aat
-aat
-aat
-aci
-afj
 aat
 aat
 aat
@@ -55742,38 +57120,38 @@ aae
 aae
 aae
 aae
-bDY
-akP
-akP
-cqH
-alX
-amV
-bDY
-ant
-anN
-amU
-bDY
-ant
-anN
-amU
-bDY
-arB
-akP
-akP
-ast
-bDY
-akP
-aph
-akP
-aph
-akP
-aph
-bDY
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aaB
+aaB
+aaB
 aae
 aae
 aae
 aae
-aaa
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -55803,9 +57181,9 @@ adH
 aec
 abT
 ayn
-nLp
+aeV
 agM
-aoI
+bxq
 aat
 aat
 aat
@@ -55824,12 +57202,20 @@ aat
 aat
 aat
 aat
-afw
-acw
-acv
-acv
-acv
-ads
+abd
+aat
+aat
+aaQ
+acb
+acb
+acb
+aDE
+aaQ
+mEF
+acb
+acb
+acb
+aaQ
 aat
 aat
 aat
@@ -55838,21 +57224,13 @@ aat
 aat
 aat
 aat
-ach
-acv
-acv
-acv
-acv
-ads
 aat
 aat
 aat
 aat
 aat
-ach
-acv
-acv
-ads
+aat
+aat
 aat
 aat
 aat
@@ -55999,38 +57377,38 @@ aae
 aae
 aae
 aae
-bDY
-akS
-akZ
-akP
-alW
-amV
-bDY
-akP
-akP
-aoh
-bDY
-akP
-akP
-aqx
-bDY
-amU
-akP
-akP
-akP
-alY
-akP
-awF
-akP
-azt
-akP
-aED
-bDY
 aae
-aaa
-aaa
-aaa
-aaa
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
 aae
 abN
 acB
@@ -56065,6 +57443,36 @@ aiu
 aat
 aat
 aat
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aLD
+aLD
+aaQ
+aLi
+aLD
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aat
+aat
+aat
+aat
+aaQ
+vzq
+acb
+acb
+krJ
+aaQ
+gyK
+acb
+acb
+acb
+aaQ
 aat
 aat
 aat
@@ -56082,34 +57490,6 @@ aat
 aat
 aat
 aat
-ach
-acv
-acv
-bsq
-afj
-aat
-aat
-aat
-aat
-ahF
-aat
-aat
-aat
-afw
-bvT
-bvT
-bvT
-bvT
-afj
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-acv
-ads
 aat
 aat
 aat
@@ -56119,8 +57499,6 @@ aat
 aat
 aat
 aat
-aat
-ayJ
 aat
 aat
 aat
@@ -56256,39 +57634,39 @@ aae
 aae
 aae
 aae
-bDY
-akT
-alu
-akP
-akP
-amU
-bDY
-anu
-akP
-cqH
-bDY
-apE
-akP
-cqH
-bDY
-arC
-cqH
-akP
-akP
-bDY
-avb
-cqH
-ayc
-akP
-akP
-akP
-bDY
-aae
-aaa
 aae
 aae
 aae
 aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+acB
 acB
 abN
 abN
@@ -56319,6 +57697,39 @@ abS
 aeq
 aeV
 aiu
+sub
+aat
+aat
+aaQ
+aUf
+aCw
+aaQ
+aCb
+aCb
+aCb
+lRH
+gdO
+aWc
+aAs
+aaQ
+shs
+gdO
+aaQ
+aat
+aat
+aat
+aat
+aaQ
+aGW
+xTN
+aaQ
+aaQ
+aaQ
+aCb
+mWX
+aCb
+qNp
+aaQ
 aat
 aat
 aat
@@ -56326,23 +57737,6 @@ aat
 aat
 aat
 aat
-abz
-aat
-aat
-aat
-aii
-acO
-acO
-afL
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-bvT
-afj
 aat
 aat
 aat
@@ -56351,22 +57745,6 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-bvT
-afj
 aat
 aat
 aat
@@ -56513,35 +57891,35 @@ aae
 aae
 aae
 aae
-bDY
-bDY
-bDY
-bDY
-alY
-bDY
-bDY
-bDY
-alY
-bDY
-bDY
-bDY
-alY
-bDY
-bDY
-akP
-akP
-akP
-asy
-alD
-akP
-aph
-akP
-aph
-cqH
-aph
-bDY
 aae
-aaa
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aaB
+aaB
+aaB
+aaB
+aae
 aae
 aae
 abN
@@ -56576,6 +57954,42 @@ aeq
 ayn
 aeV
 aiu
+sub
+aat
+aat
+aKk
+acb
+acb
+aaQ
+fZN
+acb
+acb
+acb
+acb
+acb
+acb
+aaQ
+acb
+acb
+aKk
+aat
+aat
+sub
+aat
+aaQ
+acb
+acb
+abv
+acb
+abv
+acb
+pgI
+xTN
+acb
+aaQ
+aat
+aat
+aat
 aat
 aat
 aat
@@ -56587,10 +58001,8 @@ aat
 aat
 aat
 aii
-bgs
-acv
-acv
-hlw
+acO
+acO
 acO
 bss
 aat
@@ -56601,40 +58013,6 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aAm
 aat
 aat
 aat
@@ -56772,33 +58150,33 @@ aae
 aae
 aae
 aae
-bDY
-akP
-akP
-akP
-anp
-akP
-cqH
-akP
-anp
-akP
-akP
-akP
-aqZ
-akP
-akP
-cqH
-asO
-bDY
-cqH
-awG
-akP
-aog
-akP
-aHY
-bDY
-aaa
-aaa
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aaB
+aaB
+aae
+aae
 aae
 abN
 abN
@@ -56836,16 +58214,50 @@ agN
 anQ
 aat
 aat
+aaQ
+abf
+aAt
+abv
+acb
+aCr
+acb
+acb
+acb
+acb
+acb
+abv
+dpr
+acb
+azK
+aat
+aat
+agz
+aat
+aaQ
+aAt
+acb
+aaQ
+acb
+aaQ
+acb
+aAt
+acb
+acb
+aaQ
 aat
 aat
 aat
-ahF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aii
-bgA
-bgs
-acv
-acv
+acu
 acv
 acv
 acv
@@ -56854,40 +58266,6 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayt
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ayJ
-aat
-aHF
-azE
-azE
-aAc
-azE
-aHF
-aii
-acO
-acO
-acO
-bss
 aat
 aat
 aat
@@ -57029,38 +58407,38 @@ aae
 aae
 aae
 aae
-bDY
-cqH
-cqH
-akP
-akP
-akP
-akP
-akP
-aon
-akP
-cqH
-akP
-akP
-akP
-akP
-akP
-asP
-bDY
-akP
-akP
-akP
-akP
-akP
-akP
-bDY
-aaa
 aae
 aae
+aae
+aae
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+agn
 adW
 amf
 adW
-bmm
+anf
 acG
 anR
 adW
@@ -57078,7 +58456,7 @@ acG
 acG
 acG
 acG
-vCX
+anR
 adW
 adW
 anf
@@ -57093,58 +58471,58 @@ acm
 aiu
 aat
 aat
-ahF
-aat
-aat
-aHm
-aii
-bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aih
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aii
-bss
-aat
+aQU
+acb
+dpr
+aaQ
+gdO
+acb
+kid
+acb
+okh
+acb
+gdO
+aaQ
+aCr
+acb
+aQU
 aat
 aat
 sub
-azE
-azI
-aKj
-vcy
-aHF
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+abv
+aaQ
+aaQ
+aaQ
+abv
+aaQ
+aaQ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 ach
 acv
 acv
-acv
-ads
+bsq
+acP
+afj
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -57273,47 +58651,47 @@ aaa
 "}
 (65,1,1) = {"
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bDY
-bDY
-alY
-bDY
-bDY
-bDY
-alY
-bDY
-alD
-bDY
-bDY
-bDY
-alD
-bDY
-alY
-bDY
-bDY
-alD
-akP
-anP
-akP
-anP
-akP
-aph
-bDY
-aaa
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aiH
+adH
 adX
 aeo
 aeo
@@ -57350,56 +58728,50 @@ acm
 aiu
 aat
 aat
+aaQ
+aDR
+aDv
+aaQ
+abf
+acb
+aCb
+acb
+aCb
+acb
+qNp
+aaQ
+szl
+sUB
+aaQ
+aat
+aou
+aat
+aat
+aat
+aaQ
+xUI
+hjY
+acb
+aaQ
+acb
+acb
+acb
+aaQ
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
 aat
 ach
 acv
-acv
-acv
-acv
-acv
-acv
-bsq
-acP
-afj
-aat
-aat
-aOX
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aii
-acO
-acO
-acO
-bss
-aat
-aat
-aat
-aat
-aci
-bgL
-aat
-aat
-aat
-sub
-azE
-aAf
-aAf
-aAf
-aHF
-ach
-acv
-hKE
 acv
 ads
 aat
@@ -57408,6 +58780,12 @@ aat
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aat
+bqC
 aat
 aat
 aat
@@ -57542,35 +58920,35 @@ aae
 aae
 aae
 aae
-aaa
-bDY
-alC
-akP
-amZ
-bDY
-anv
-akP
-akP
-akP
-cqH
-apF
-akP
-akP
-akP
-cqH
-apF
-asQ
-bDY
-akP
-awF
-akP
-aog
-akP
-aIb
-bDY
-aaa
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+akd
+ahc
+adH
 adY
 amg
 amx
@@ -57607,58 +58985,58 @@ acm
 aiu
 aat
 aat
-aat
-aib
-aat
-aii
-aCl
-acv
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-ahF
-aat
-aat
+aaQ
+aaQ
+aaQ
+aaQ
+aCb
+acb
+kid
+aAt
+kid
+acb
+aCb
+aaQ
+aaQ
+aaQ
+aaQ
 aat
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-hKE
-acv
-ads
-aat
-aat
-ahF
+aaQ
+acb
+acb
+acb
+aaQ
+rEx
+aEG
+qNp
+aaQ
 aat
 aat
 aat
 aat
 aat
 aat
-aHF
-azE
-bky
-azE
-aHh
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 afw
-bvT
-bvT
-bvT
+acP
+acP
 afj
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -57799,35 +59177,35 @@ aae
 aae
 aae
 aae
-aaa
-alD
-alZ
-alZ
-akP
-bDY
-akP
-anP
-akP
-aph
-akP
-aph
-cqH
-aph
-akP
-aph
-cqH
-asT
-bDY
-akP
-cqH
-akP
-akP
-akP
-akP
-bDY
-aaa
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaB
+aaB
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aat
+aiH
+acB
+adH
 agK
 agC
 agC
@@ -57867,35 +59245,35 @@ aat
 aat
 aat
 aat
-ach
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ads
+aaQ
+aEG
+acb
+cpG
+acb
+mWX
+acb
+abL
+aaQ
 aat
 aat
 aat
 aat
+bqC
 aat
 aat
 aat
+aaQ
+acb
+aCr
+acb
+aaQ
+gij
+xTN
+acb
+aaQ
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-ach
-acv
-acv
-acv
-ads
 aat
 aat
 aat
@@ -57905,12 +59283,12 @@ aat
 aat
 aat
 bqC
-aHF
-azE
-aAf
-szl
-azE
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -58056,33 +59434,33 @@ aae
 aae
 aae
 aae
-aaa
-bDY
-alE
-alE
-ana
-bDY
-akP
-aog
-akP
-aog
-akP
-aog
-cqH
-aog
-cqH
-aog
-akP
-amU
-bDY
-avb
-aph
-akP
-anP
-akP
-aph
-bDY
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aya
@@ -58120,26 +59498,19 @@ aeU
 acm
 aiu
 aat
+ayt
 aat
 aat
 aat
-aih
-ach
-acv
-acv
-acv
-bsq
-brV
-acv
-acv
-ads
-aat
-aat
-aii
-acO
-acO
-acO
-bss
+aKk
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+aQU
 aat
 aat
 aat
@@ -58148,11 +59519,15 @@ aat
 aat
 aat
 aat
-afw
-acw
-acv
-acv
-ads
+aaQ
+khX
+aCb
+acb
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
 aat
 aat
 aat
@@ -58162,12 +59537,15 @@ aat
 aat
 aat
 aat
-aHF
-bky
-aHF
-aAf
-gWz
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -58313,33 +59691,33 @@ aae
 aae
 aae
 aae
-aaa
-bDY
-alF
-akP
-akP
-bDY
-cqH
-anP
-akP
-api
-akP
-aph
-akP
-aph
-akP
-aph
-akP
-akP
-alY
-akP
-awF
-akP
-azu
-aCT
-azu
-bDY
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 afz
 afz
 afz
@@ -58380,36 +59758,33 @@ aat
 aat
 aat
 aat
-aii
-bgs
-acv
-bsq
-acP
-afj
-ach
-acv
-acv
-ads
 aat
-aat
-ach
-acv
-acv
-acv
-ads
+aaQ
+geV
+acb
+krJ
+mWX
+aRg
+acb
+rnb
+aaQ
 aat
 aat
 aat
 aat
 aat
-ayJ
 aat
 aat
 aat
-afw
-bvT
-bvT
-afj
+aaQ
+aJg
+aCb
+acb
+xjs
+acb
+qaX
+acb
+aaQ
 aat
 aat
 aat
@@ -58421,10 +59796,13 @@ aat
 aat
 aat
 aat
-aHF
-aDj
-aCn
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 ahF
@@ -58570,33 +59948,33 @@ aae
 aae
 aae
 aae
-aaa
-bDY
-alG
-amc
-anc
-bDY
-akP
-aog
-aoi
-aog
-cqH
-aog
-akP
-aog
-arD
-aog
-cqH
-akP
-bDY
-awB
-akP
-akP
-akP
-cqH
-aId
-bDY
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 afz
 ala
 alJ
@@ -58637,36 +60015,33 @@ aat
 aat
 aat
 aat
-aYs
-acP
-acP
-afj
 aat
+fyo
+acb
+acb
+cpG
+nTp
+dpr
+acb
+acb
+aKk
 aat
-afw
-acP
-acP
-afj
-aat
-aat
-afw
-acP
-acP
-acP
-afj
-aat
-aat
-aHF
-sub
-aHF
-aHF
-aHF
-aHF
-aHF
+aib
 aat
 aat
 aat
 aat
+aat
+aat
+aaQ
+aBW
+xTN
+acb
+aaQ
+pYQ
+xjs
+pYQ
+aaQ
 aat
 aat
 aat
@@ -58678,10 +60053,13 @@ aat
 aat
 aat
 aat
-aHF
-aDF
-djA
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -58827,33 +60205,33 @@ aae
 aae
 aae
 aae
-aaa
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-amU
-anP
-akP
-anP
-akP
-aph
-bDY
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 afz
 alb
 alK
@@ -58894,33 +60272,33 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-ahF
-aat
-aat
-aat
-aat
-aat
-aat
-bqC
-aat
-aat
-aat
+aib
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+abv
+aaQ
+aaQ
 aat
 aat
 aat
 aat
 aat
-aHF
-azE
-aoj
-aAf
-azE
-azE
-aHF
+abz
 aat
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
+acb
+acb
+acb
+aaQ
 aat
 aat
 aat
@@ -58935,10 +60313,10 @@ aat
 aii
 acO
 acO
-aHF
-aHF
-aHF
-aHF
+acO
+bss
+aat
+aat
 aat
 aat
 aat
@@ -59084,33 +60462,33 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bDY
-asQ
-axa
-cqH
-azu
-akP
-azu
-bDY
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 afz
 alc
 alc
@@ -59153,6 +60531,13 @@ aat
 aat
 aat
 aat
+aaQ
+aCr
+acb
+abv
+acb
+acb
+aaQ
 aat
 aat
 aat
@@ -59160,24 +60545,17 @@ aat
 aat
 aat
 aat
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
-aHF
 aat
 aat
 aat
-aHF
-ixM
-vcy
-aAf
-eTT
-aHh
-aHF
 aat
+aat
+aat
+aaQ
+acb
+acb
+qNp
+aaQ
 aat
 aat
 aat
@@ -59358,16 +60736,16 @@ aae
 aae
 aae
 aae
-aaa
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-bDY
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 afz
 ald
 alc
@@ -59410,31 +60788,31 @@ aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aHF
-fKC
 fyo
-aAf
-azE
-gdO
-aHF
+acb
+acb
+aaQ
+acb
+acb
+aKk
 aat
 aat
 aat
-aHF
-azE
-azE
-aAf
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aaQ
 bky
-aAf
-aHF
-aat
+acb
+bky
+aaQ
 aat
 aat
 aat
@@ -59615,16 +60993,16 @@ aae
 aae
 aae
 aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 afz
 alc
 alc
@@ -59664,34 +61042,34 @@ aiu
 aat
 aat
 aat
+aat
+aat
+aat
+aaQ
+acb
+kwf
+aaQ
+ozC
+aDv
+aaQ
+aat
+aat
+aat
+aat
 ayt
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
 sub
-aBD
-azE
-aMP
-azE
-tGl
-aHF
 aat
-aCK
 aat
-aHF
-azE
-azE
-bky
-azE
-azE
-aHF
 aat
+aat
+aat
+aat
+aaQ
+prX
+fUZ
+dKM
+aaQ
 aat
 abz
 aat
@@ -59921,34 +61299,34 @@ aiu
 aat
 aat
 aat
+bqC
+aat
+aat
+aaQ
+abv
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
 aat
 aat
 aat
 aat
 aat
 aat
-aat
-aat
-aat
-aat
-aHF
-azL
-azE
-aAf
-aAf
-aAf
-aHF
-aat
-aat
-aat
-aHF
 sub
-aHF
-aHF
-bky
-aHF
-aHF
 aat
+aat
+aat
+aat
+aat
+aat
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
 aat
 aat
 aat
@@ -60181,19 +61559,19 @@ aat
 aat
 aat
 aat
-aii
-acO
-acO
-afL
 aat
 aat
 aat
-aHF
-azE
-eTT
-aMP
-azE
-fbV
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 sub
 aat
 aat
@@ -60201,7 +61579,7 @@ aat
 aat
 aat
 aat
-abz
+aat
 aat
 aat
 aat
@@ -60438,20 +61816,20 @@ aat
 aat
 aat
 aat
-ach
-acv
-acv
-hlw
-bss
 aat
 aat
-aHF
-aAf
-aAf
-aAf
-azE
-uJo
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+sub
 aat
 aat
 aat
@@ -60690,37 +62068,37 @@ aeV
 acm
 aiu
 aat
+ady
+ady
 aat
 aat
 aat
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+aat
+ady
+ady
+uIa
+ady
+ady
+ady
+ady
+ady
+ady
+ady
+ady
 aat
 aat
-ach
-acv
-acv
-acv
-ads
-aat
-aat
-sub
-aCn
-aFE
-aMP
-azE
-jSS
-aHF
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-ach
-acv
+gyA
+adq
 acv
 acv
 ads
@@ -60952,20 +62330,20 @@ aat
 aat
 aat
 aat
-ach
-acv
-acv
-acv
-ads
 aat
 aat
-aHF
-aDj
-ueP
-aAf
-azE
-tfq
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -61209,20 +62587,20 @@ aat
 aat
 aat
 aat
-ach
-aAl
-acv
-bsq
-afj
+aat
+aih
 aat
 aat
-aHF
-aHF
-aHF
-aHF
-bky
-aHF
-aHF
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 ayt
 aat
 aat
@@ -61465,21 +62843,21 @@ aat
 aat
 aat
 aat
-aii
-bgs
-acv
-bsq
-afj
-aat
-aat
-aat
-agy
 aat
 aat
 aat
 aat
 aat
-agy
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aat
 aat
 aat
@@ -61722,21 +63100,21 @@ aat
 aat
 aat
 aat
-afw
-bax
-acP
-afj
+aat
+aHm
+aat
+aat
 aat
 aat
 ahF
 aat
-agy
+aat
 aat
 aat
 aat
 aCK
 aat
-uIa
+ahF
 aat
 aat
 aat
@@ -61810,7 +63188,7 @@ aat
 aat
 bbI
 bds
-alc
+auF
 alc
 bcW
 adH
@@ -61993,7 +63371,7 @@ abz
 aat
 aat
 aat
-uQK
+aii
 acO
 acO
 acO
@@ -62078,7 +63456,7 @@ aeV
 ayW
 abP
 bca
-alc
+auF
 alc
 abP
 aat
@@ -62501,7 +63879,7 @@ aat
 aat
 aat
 aat
-agy
+aat
 aat
 aat
 aat
@@ -62758,7 +64136,7 @@ aat
 aat
 aat
 aat
-agy
+aat
 aat
 aat
 aat
@@ -62842,7 +64220,7 @@ alc
 aTs
 bdZ
 adH
-beh
+adY
 ahB
 aeC
 aeV
@@ -63020,8 +64398,8 @@ aat
 aat
 aat
 aat
-jAZ
-aXZ
+aat
+aat
 aat
 aat
 abz
@@ -63107,7 +64485,7 @@ ayW
 bbI
 aub
 bdu
-alc
+auF
 bcX
 bfQ
 abP
@@ -63347,7 +64725,7 @@ aat
 aat
 abP
 aZZ
-ahj
+ahZ
 aqQ
 bcC
 bcX
@@ -63366,9 +64744,9 @@ aub
 bfs
 alc
 bcX
-bfR
+pdZ
 abP
-ahj
+ahZ
 aZZ
 abP
 aat
@@ -64118,7 +65496,7 @@ aat
 aat
 apO
 alc
-alc
+auF
 alc
 alc
 ang
@@ -64129,7 +65507,7 @@ asf
 adH
 adY
 abS
-beL
+aiv
 aeV
 ayW
 asf
@@ -64139,7 +65517,7 @@ alc
 ang
 alc
 alc
-alc
+auF
 alc
 abP
 aat
@@ -64379,7 +65757,7 @@ bbS
 bcv
 bcD
 aqQ
-alc
+auF
 alc
 alc
 abP
@@ -64971,7 +66349,7 @@ aat
 aat
 aat
 aat
-aat
+bdh
 aat
 aat
 aat
@@ -65661,10 +67039,10 @@ aat
 aat
 abP
 aZZ
-asr
+ozT
 aqQ
 baU
-alc
+auF
 alc
 bdr
 bbI
@@ -66179,7 +67557,7 @@ aat
 abP
 avc
 bdu
-alc
+auF
 alc
 abP
 adH
@@ -67207,7 +68585,7 @@ aat
 bcF
 alc
 alc
-alc
+auF
 bcW
 agl
 adH
@@ -67285,7 +68663,7 @@ bgL
 aat
 aat
 aat
-bhO
+aat
 aat
 aat
 aat
@@ -67463,7 +68841,7 @@ aat
 aat
 abP
 alc
-alc
+auF
 asF
 bbI
 agl
@@ -68037,7 +69415,7 @@ bhs
 bqr
 alc
 alc
-bsk
+bhY
 alc
 bpW
 aat
@@ -68748,7 +70126,7 @@ bbU
 bcx
 aqQ
 auh
-alc
+aoX
 alc
 bcD
 bcW
@@ -69065,7 +70443,7 @@ bhs
 bqt
 acl
 alc
-bsl
+bit
 alc
 bpW
 ach
@@ -69264,7 +70642,7 @@ aqQ
 bdc
 alc
 alc
-bcv
+nFT
 bbI
 adH
 aec
@@ -69924,7 +71302,7 @@ apO
 arj
 alc
 arj
-aoX
+biD
 atf
 alc
 aul
@@ -70030,11 +71408,11 @@ aub
 awh
 ang
 aCj
-alc
+aoX
 ang
 alc
 aCj
-alc
+aoX
 arQ
 abP
 adH
@@ -70282,7 +71660,7 @@ abP
 alc
 aVA
 aVA
-alc
+aoX
 aVA
 alc
 aqQ
@@ -70441,7 +71819,7 @@ alc
 alc
 alc
 alc
-alc
+biD
 alc
 avj
 abP
@@ -71833,7 +73211,7 @@ afO
 afO
 bdd
 afO
-bdE
+age
 agC
 agC
 ajq
@@ -72344,10 +73722,10 @@ adf
 adf
 adf
 adf
-bcH
 adf
 adf
-bcH
+adf
+adf
 adf
 adf
 adf
@@ -73683,7 +75061,7 @@ bhV
 agk
 afS
 afS
-afS
+whz
 afS
 agk
 aat
@@ -74350,7 +75728,7 @@ aGR
 aJl
 aBe
 aLG
-aLw
+tmW
 acb
 aBe
 acm
@@ -75751,7 +77129,7 @@ aat
 agk
 aqJ
 avR
-aoH
+sYQ
 bsp
 bjT
 agk
@@ -75995,7 +77373,7 @@ acP
 bgL
 aat
 aat
-aou
+aat
 aat
 aat
 aat
@@ -76007,7 +77385,7 @@ aat
 aat
 arK
 alc
-alc
+qLa
 alc
 alc
 alc
@@ -76145,7 +77523,7 @@ aHt
 aLw
 aAL
 aJx
-aHL
+aHt
 aHa
 aAf
 aNS
@@ -76211,7 +77589,7 @@ aat
 aat
 aat
 aat
-aat
+bdh
 ahF
 aat
 agl
@@ -76492,11 +77870,11 @@ aat
 abP
 bhK
 ahj
-ahZ
+ahj
 alc
 alc
 alc
-alc
+qLa
 alc
 alc
 aTg
@@ -76754,7 +78132,7 @@ ahj
 alc
 alc
 alc
-auF
+alc
 bjT
 abP
 aat
@@ -78578,7 +79956,7 @@ alc
 bsQ
 aYk
 bhT
-biD
+alc
 bgX
 buL
 agk
@@ -79488,7 +80866,7 @@ aaQ
 aHf
 aCX
 aAf
-azE
+sHF
 aAf
 aOf
 azE
@@ -79590,7 +80968,7 @@ aat
 aat
 aat
 aat
-aat
+frt
 aat
 aat
 aat
@@ -80261,7 +81639,7 @@ aMM
 aNf
 azI
 aHz
-azE
+mbI
 azE
 aCN
 acB
@@ -80348,7 +81726,7 @@ bhp
 alc
 alc
 big
-biD
+qLa
 alc
 abP
 bjB
@@ -80517,7 +81895,7 @@ azE
 aHy
 aNg
 aNx
-aIx
+azE
 azE
 aOt
 aCN
@@ -80771,7 +82149,7 @@ aeq
 aeV
 aCN
 azJ
-aMN
+aHy
 aNh
 aHy
 azE
@@ -81028,7 +82406,7 @@ ayn
 aeV
 aaQ
 aMl
-azE
+sHF
 acb
 azE
 aHy
@@ -81902,14 +83280,14 @@ bkL
 bld
 bkN
 bkN
-bkN
+tyg
 bkN
 bkN
 bkN
 bkh
 boc
 bkN
-blf
+bkN
 bkq
 aat
 aat
@@ -82148,7 +83526,7 @@ alc
 bhS
 aqQ
 aoH
-biD
+alc
 abP
 aat
 aat
@@ -82935,7 +84313,7 @@ bkN
 bkN
 bkN
 bnA
-bkN
+blf
 bnA
 bkN
 bkN
@@ -83184,7 +84562,7 @@ aat
 bkh
 bkh
 bkh
-blg
+bkN
 bkh
 bkh
 blU
@@ -83479,7 +84857,7 @@ aae
 aae
 aae
 boU
-bxH
+boU
 boU
 aae
 aae
@@ -83991,7 +85369,7 @@ aae
 aae
 aae
 aae
-boU
+imi
 boU
 boU
 aae
@@ -84508,7 +85886,7 @@ boU
 boU
 boU
 boU
-bxH
+boU
 aae
 aae
 aaa
@@ -85014,7 +86392,7 @@ aae
 aae
 bwN
 boU
-bxH
+boU
 boU
 byp
 bpQ
@@ -88825,14 +90203,6 @@ axb
 aya
 aya
 aya
-agL
-axb
-axb
-axb
-axb
-aya
-aya
-axb
 axb
 axb
 axb
@@ -88840,6 +90210,14 @@ axb
 axb
 aya
 aya
+axb
+axb
+axb
+axb
+axb
+axb
+aya
+aya
 aya
 axb
 axb
@@ -88855,7 +90233,7 @@ axb
 axb
 axb
 axb
-eWl
+aMG
 apr
 aat
 aat
@@ -89336,7 +90714,7 @@ aeV
 ayW
 aat
 aat
-aKU
+kmy
 agk
 agk
 agk
@@ -89591,7 +90969,7 @@ abS
 abS
 aeV
 ayW
-aKU
+kmy
 aBO
 aHW
 agk
@@ -89648,7 +91026,7 @@ aat
 aat
 aat
 aat
-aae
+aaB
 aae
 aae
 aaa
@@ -89880,32 +91258,32 @@ aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
 aat
 aat
 aat
 aat
 aat
 aat
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aaB
+aaB
 aae
 aae
 aaa
@@ -90085,7 +91463,7 @@ abS
 aiv
 aeV
 agk
-ber
+aiZ
 afS
 beQ
 afS
@@ -90132,37 +91510,37 @@ aat
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+eEx
+oFn
 aae
 aae
 aaa
@@ -90360,7 +91738,7 @@ abS
 abS
 abS
 abS
-nLp
+aeV
 ayW
 agl
 afF
@@ -90380,7 +91758,7 @@ beR
 afS
 beQ
 afS
-afS
+efb
 agk
 aWT
 aat
@@ -90389,39 +91767,39 @@ aat
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
 aae
+amH
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 "}
 (194,1,1) = {"
@@ -90639,45 +92017,45 @@ boy
 afS
 boy
 agk
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+abd
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
 aae
 aae
 aae
+adg
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-bhh
-bhw
-bhw
-bhh
-bhh
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+adg
 aae
 aaa
 "}
@@ -90896,42 +92274,42 @@ agk
 agk
 agk
 agk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bhh
-bvg
-bvt
-bvg
-bhw
-aaa
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
 aae
 aae
+aae
+aae
+adg
 aae
 aae
 aae
@@ -91149,11 +92527,38 @@ afS
 afC
 afS
 agk
-aaa
-aaa
-aaa
-aaa
-aaa
+aat
+aat
+aat
+aae
+aae
+aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -91161,34 +92566,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-bhh
-aaI
-aaI
-aaI
-bhw
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
+adg
 aae
 aae
 aae
@@ -91406,7 +92784,37 @@ bki
 agk
 afR
 agk
-aaa
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aae
+aat
 aae
 aae
 aae
@@ -91418,37 +92826,7 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-bhw
-bvh
-aaI
-bvw
-bhh
-bhh
-bhw
-bhw
-bhw
-aaa
-aae
-aae
-aae
-aae
+adg
 aae
 aaa
 "}
@@ -91663,7 +93041,23 @@ afS
 agk
 agk
 agk
-aaa
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+aat
 aae
 aae
 aae
@@ -91686,26 +93080,10 @@ aae
 aae
 aae
 aae
+adg
 aae
 aae
-aae
-aae
-aae
-aae
-bhw
-bhh
-bvu
-bhh
-bhh
-bvI
-aaI
-bwe
-bhh
-aaa
-aae
-aae
-aae
-aae
+adg
 aae
 aaa
 "}
@@ -91918,51 +93296,51 @@ afC
 agk
 afC
 agk
-aaa
-aaa
-aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-bro
-nTp
-bhw
 aat
 aat
 aat
-anl
-acv
-acv
-acv
-acv
-acv
-bsA
-aaI
-buu
-bqF
-bhh
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aae
 aae
 aae
 aae
+aae
+adg
+aae
+aae
+adg
 aae
 aaa
 "}
@@ -91980,7 +93358,7 @@ aae
 aae
 aae
 acl
-acz
+acV
 acV
 agw
 acl
@@ -92175,51 +93553,51 @@ afS
 agk
 afS
 agk
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-bhw
-bhw
-brt
-brs
-nTp
-aaI
-brn
 bhh
-aat
-aat
-aat
-anl
-acT
-acv
-acv
-acv
-acv
 bhh
-bvB
-aaI
-bwf
-bhw
-aaa
-aaa
-aaa
+bhh
+bhh
+bhh
 aaa
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+adg
 aae
 aaa
 "}
@@ -92420,7 +93798,7 @@ aeV
 ayW
 aat
 aat
-bbZ
+ftK
 agk
 agk
 agk
@@ -92432,6 +93810,41 @@ bjb
 agk
 afS
 agk
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+bhh
+bhw
+jyn
+bvO
+bhh
 aaa
 aae
 aae
@@ -92440,43 +93853,8 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-bhw
-nTp
-aaI
-nTp
-brn
-aaI
-nTp
-bhh
-aaI
-aaI
-aaI
-aaI
-nTp
-bhh
-aat
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-bhh
-bhw
-bhh
-bhh
-bhh
-bhw
-bhh
-bhh
-bhh
-aaa
-aae
+aaB
+adg
 aae
 aaa
 "}
@@ -92689,51 +94067,51 @@ afS
 afS
 afS
 agk
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+bhh
+bvC
+aaI
+omC
+bhh
 aaa
 aae
 aae
 aae
 aae
 aae
-aae
-nTp
-bqu
-bqy
-bqA
-nTp
-bhw
-bqA
-aaI
-aaI
-aaI
-aaI
-brs
-bhh
-aaI
-brt
-qNp
-bro
-bhw
-bhw
-aat
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-bhh
-bvw
-buu
-bvR
-bhw
-bwe
-bwC
-bwe
-bhh
-aaa
-aae
+adg
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -92940,57 +94318,57 @@ bgy
 bec
 afF
 bhx
-bgE
+ehJ
 afS
 afS
 bki
 afS
 agk
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bhh
+bwX
+aaI
+aaI
+bhh
+aaa
+aaa
+aaa
 aaa
 aae
 aae
-aae
-aae
-aae
-bpF
-aaI
-bqa
-aaI
-aaI
-bqF
-bhh
-bhw
-shs
-bqa
-aaI
-aaI
-xTN
-bhw
-aaI
-aaI
-bhh
-bhh
-bhw
-bgT
-aat
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-bvu
-aaI
-aaI
-bqF
-bhw
-buu
-aaI
-buu
-bhh
-aaa
-aae
+adg
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -93198,57 +94576,57 @@ adf
 adf
 agk
 aiZ
-ajB
+xrY
 bjn
-afS
+hYd
 bkz
 agk
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
 aae
 aae
 aae
-bhw
-aaI
-aaI
-aaI
-aaI
-bqA
-bqa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bhh
-brg
-aaI
-bro
-aaI
-brt
-bhw
-bqB
-bhw
 bhh
-aat
-aat
-aat
-aat
-aat
-bgK
-bgs
-acv
-acv
-acv
-acv
 bhh
-bvB
-aaI
-bvU
 bhh
-bvI
-aaI
-bvI
-bhw
+arz
+bhh
+bhh
+bhh
+bhh
+bhh
 aaa
-aaa
-aaa
+aae
+aae
+aae
+aaB
+aaB
+adg
+aae
 aaa
 "}
 (205,1,1) = {"
@@ -93444,7 +94822,7 @@ abS
 abS
 abS
 abS
-nLp
+aeV
 ayW
 aat
 aat
@@ -93460,52 +94838,52 @@ bjo
 agk
 agk
 agk
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
 aae
 aae
-aat
+aae
+aae
+aae
 bhh
-shs
-aaI
-bqu
-aaI
-aaI
-aaI
-bhw
-bqu
-aaI
-aaI
-aaI
+bwW
 bhh
-bhh
-acv
-ael
-afL
-aat
-aat
-aaV
-bgK
-acO
-bgs
-acv
-acv
-acv
-acv
-acv
-bhh
-bhw
-bhw
+bwW
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bhh
 bhh
+bwX
+bwX
 bhh
-bsA
-bhw
-bhw
+bvv
+bvi
+bhh
+bwX
+bwX
 bhh
 bhh
-bhh
+aae
+aae
+adg
+aaB
+aaB
+aae
+aae
 aaa
 "}
 (206,1,1) = {"
@@ -93715,54 +95093,54 @@ acv
 acv
 bhV
 aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-aat
-aat
-aat
+aae
+aae
+aae
+aae
 bhh
-bqa
-aaI
-aaI
-aaI
-bqa
-aaI
-bhw
-nTp
-aaI
+bwW
 bqA
 bhw
-bhw
-anl
-acv
-acv
-ads
-aat
-bgK
-acO
-bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acT
-acv
-acv
-acv
 bhh
-bvI
+bhh
+bhh
+bwW
+bhh
+aae
+aae
+aae
+aae
+bhh
+tnF
 aaI
-bwe
+aaI
+arz
+bvv
+bvv
+arz
+aaI
+aaI
+svh
 bhh
+aae
+aae
+adg
+aaB
+aaB
+aae
+aae
 aaa
 "}
 (207,1,1) = {"
@@ -93967,59 +95345,59 @@ aat
 bgK
 bgs
 acv
-acv
+lKr
 acv
 acv
 bhV
 aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
-aaa
 aae
 aae
-aat
-aat
-aat
-bhw
-bhw
-bqw
-nTp
+aae
+aae
+aae
+aae
+bhh
+bwX
 aaI
 aaI
-bqI
+bhh
+bwW
+xIU
 bhh
 bhh
-bqB
+aae
+aae
+aae
+aae
 bhh
-bhh
-bgT
-anl
-acv
-acv
-ael
-acO
-bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bvu
+tnF
 aaI
-buu
-bqF
+xnX
 bhh
+bvv
+bvv
+bhh
+bvC
+aaI
+svh
+bhh
+aae
+aae
+adg
+aaB
+aaB
+adg
+aae
 aaa
 "}
 (208,1,1) = {"
@@ -94219,64 +95597,64 @@ aeV
 ayW
 aat
 aii
-bgA
+mzX
 bgA
 bgs
 acv
 acv
 acv
-acv
+ndH
 adr
 bgL
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-aat
-aat
-aat
-aat
-amE
-bhw
+aae
+aae
+aae
+aae
+bwW
+fkW
+gME
+aaI
 bhh
+ezE
+aaI
+cMw
 bhh
-bqB
-bhw
-bhw
-bhw
-brV
-acv
-ads
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
+aae
+aae
+aae
+aae
 bhh
-bvw
-buu
-bwf
-bhw
+tnF
+aaI
+bwX
+bhh
+bvv
+bvv
+bhh
+bwX
+xbW
+svh
+bhh
+aae
+aae
+adg
+agT
+aaB
+adg
+aaa
 aaa
 "}
 (209,1,1) = {"
@@ -94479,61 +95857,61 @@ anl
 acv
 acv
 acv
-acv
+cYt
 acv
 acv
 adr
 bgL
 aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
-aaa
 aae
 aae
-aat
-aat
-aat
-adN
-amE
-bgT
-aat
-anl
-acv
-ads
-aat
-aat
-anl
-acv
-ael
-acO
-bhy
-bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-arz
-arz
-arz
-buW
-arz
-arz
-arz
-arz
-arz
-arz
-arz
-arz
+aae
+aae
+aae
+aae
+bwW
+gky
+aaI
+aaI
+bvx
+aaI
+aaI
+aaI
+bhh
+bhh
+bwW
+bwW
+bwW
 bhh
 bhh
 bhh
+bhh
+bhh
+bvv
+bvv
+bhh
+bhh
+bhh
+bhh
+bhh
+aae
+aae
+aae
+aaB
+aaB
+adg
+aae
 aaa
 "}
 (210,1,1) = {"
@@ -94600,7 +95978,7 @@ aat
 aqO
 acV
 acV
-acV
+bwS
 acV
 acV
 arT
@@ -94700,7 +96078,7 @@ agS
 aZj
 aZj
 bbB
-bbL
+aZj
 aZD
 aaD
 aae
@@ -94734,62 +96112,62 @@ ayW
 aii
 acu
 acv
+rbp
 acv
 acv
 acv
-acv
-acv
+rbp
 bhV
 aat
 ayt
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
 aae
 aae
 aae
-aat
-aat
-aat
-adN
-adp
-aat
-aaV
-anl
-acv
-ael
-acO
-acO
-bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-buX
-arz
-aaI
-aaI
-aaI
-aaI
-aaI
-buu
-buw
-aaI
-bwC
-aaI
-arz
 aae
 aae
+aae
+bhh
+bhh
+bhh
+bhh
+bhh
+aaI
+aaI
+jDu
+bhh
+hHj
+ivc
+fRv
+bvO
+bhh
+wwv
+aaI
+bwX
+bhh
+bvv
+bvv
+bhh
+bwX
+aaI
+sbH
+bhh
+aae
+aae
+aae
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -94956,7 +96334,7 @@ aaD
 agS
 aZj
 aZj
-aZj
+rlW
 aZk
 agQ
 aaD
@@ -94989,64 +96367,64 @@ abS
 aeV
 ayW
 ach
+akj
 acv
 acv
-acv
-acv
+nyj
 acv
 acv
 acv
 bhV
 aat
 aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
 aae
 aae
 aae
-aat
-aat
-aat
-adp
-adp
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bkj
-ads
-aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bhh
 arz
-bvi
-buu
+bwW
+bhh
+bhh
 aaI
+aaI
+aaI
+aaI
+bhh
+wwv
+aaI
+xnX
+bhh
+bvi
+bvv
+bhh
 bvC
-bvC
-buB
-arz
-bvw
-bwD
-bwG
-arz
+aaI
+sbH
+bhh
 aae
 aae
+aae
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -95104,7 +96482,7 @@ acv
 acv
 acv
 ads
-aqe
+aat
 aat
 aat
 aat
@@ -95256,54 +96634,54 @@ acv
 bhV
 aat
 aat
-aQW
-aQW
-adN
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aat
-bgK
-acO
-acO
-afL
-amE
-amE
-aat
-aat
-afw
-bvT
-brV
+mfG
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-bvT
-afj
-aat
-arz
-bvj
-buu
+acT
+bhV
+bhh
+uub
+cXZ
+nAB
 aaI
-bvC
-bvC
-buu
+bhh
+wwv
+aaI
+aaI
 arz
+bvv
+bvv
 arz
-arz
-arz
-arz
+aaI
+aaI
+sbH
+bhh
 aae
 aae
+aae
+agT
+aaB
+adg
 aae
 aaa
 "}
@@ -95372,7 +96750,7 @@ ats
 atS
 auA
 aqQ
-avu
+acV
 avO
 abP
 agy
@@ -95504,63 +96882,63 @@ aeV
 ayW
 ach
 acv
-acv
+lKr
 acv
 afd
 adr
-acP
+hPw
 acP
 bgL
 aat
-amE
-aQW
-adp
 aat
-bgK
-bgs
-acT
-acv
-ads
-aat
-amE
-aat
-aat
-aat
-aat
-afw
-bvT
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-afj
-aat
-aat
-aat
-arz
-aaI
-aaI
-aaI
-bvC
-bvC
-aaI
-buw
-aaI
-brQ
-buu
-arz
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+afL
+aat
+ach
+acv
+acv
+hlw
+bhh
+bwW
+bwW
+bhh
+arz
+bhh
+bhh
+bwX
+bwX
+bhh
+bvv
+bvv
+bhh
+bwX
+bwX
+bhh
+bhh
+aae
+aae
+aae
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -95768,25 +97146,30 @@ bgL
 aat
 aat
 aat
-amE
-adp
-adN
-adN
 aat
-anl
-acv
-acv
-acv
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+aae
+brd
+brd
+brd
+brd
 ads
 aat
-adp
-adp
-aat
-aat
-aat
-aat
-aaV
-anl
+ach
 acv
 acv
 acv
@@ -95796,27 +97179,22 @@ acv
 acv
 acv
 acv
-bkj
-bsq
-bvT
-afj
-aat
-aat
-aat
-aat
-arz
-bvk
-aaI
-aaI
-bvG
-bvC
-aaI
-arz
-bwo
-buz
-bwH
-arz
+bhh
+bhh
+bhh
+bhh
+bvv
+bvv
+bhh
+bhh
+bhh
+bhh
+bgA
+bgA
 aae
+aae
+aaB
+aaB
 aae
 aae
 aaa
@@ -96024,56 +97402,56 @@ bgL
 aat
 aat
 aat
-bvS
-amE
-adp
-aQW
 aat
-bgK
-bgs
-bkj
-acv
-acv
-ads
-aat
-bpG
-adp
-adN
-amE
-aat
-adp
+aii
+acO
+bhh
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+aae
 brd
-anl
-acv
-acv
-acv
-acv
-acv
-acv
+bwY
+dCz
+bhh
+ael
+bgA
+bgs
 acv
 acv
 bsq
-bvT
-afj
-aat
-aat
-aat
-aat
-aat
-aat
-arz
-bvi
-aaI
-buu
-aaI
-aaI
-buB
-arz
-arz
-arz
-arz
-arz
+acP
+acP
+acP
+acP
+fIF
+acv
+acv
+acT
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acT
 aae
+aaB
+aaB
 aae
 aae
 aaa
@@ -96281,57 +97659,57 @@ aat
 aat
 aat
 aat
-aat
-aQW
-adp
-aat
-aat
-anl
-acv
-acv
-acv
-acv
-ael
-acO
+aii
 bgs
-adN
-adN
-adN
-amE
-adN
+bhh
+tku
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+bhh
 bre
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-bvT
-afj
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-arz
+riv
 aaI
-buu
-aaI
-buu
-aaI
-aaI
-bwg
-bwp
-bwE
-arz
-asv
-aae
-aae
+bhh
+brd
+bvv
+acv
+acv
+acv
+bhV
+aat
+aat
+aat
+ayt
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+aWn
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -96394,7 +97772,7 @@ aat
 aqO
 acV
 acV
-acV
+avu
 aoy
 acV
 acV
@@ -96434,7 +97812,7 @@ abP
 acV
 acV
 acV
-aHD
+acV
 acV
 acV
 acV
@@ -96442,7 +97820,7 @@ aoJ
 acV
 acV
 acV
-acV
+rGh
 abP
 aat
 aat
@@ -96481,7 +97859,7 @@ aat
 aat
 aat
 aat
-aat
+anY
 aat
 ahF
 aii
@@ -96537,58 +97915,58 @@ aat
 aat
 bqC
 aat
-aat
-amE
-adp
-adN
-bgK
-acO
+aii
 bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-boz
-adp
+bhh
+bhh
+kcv
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+bhh
 brf
-anl
-acv
-acv
-acv
-acv
-acv
-bsq
-bqD
-aat
-aat
-aat
-aat
-arz
-arz
-arz
-arz
-arz
-arz
-arz
-arz
-arz
 aaI
 aaI
-arz
-arz
-arz
-arz
-arz
-arz
-arz
-aae
-aae
+bwX
+brd
+bvv
+acv
+acv
+acv
+bhV
+aat
+aat
+aat
+aat
+ach
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+opz
+aaB
+aaB
+adg
 aae
 aaa
 "}
@@ -96793,59 +98171,59 @@ acO
 afL
 aat
 aat
-aat
-aat
-aQW
-adp
-adN
-anl
-acT
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-acO
-acO
+aii
 bgs
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-aat
-aat
-arz
-btF
-but
-buz
-buS
-buu
-bvc
-arz
-buf
-aaI
-buB
-arz
-buT
-aaI
-aaI
-aaI
-bwI
-arz
+tbs
+tbs
+amE
+amE
+pOW
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+bhh
+bhw
+aaI
+aaI
+aaI
+arz
+bvv
+acv
+acv
+acv
+bhV
+aat
+aat
+aGP
+aat
+ach
+acv
+acv
+acv
+bsq
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+ggy
+aae
+aae
+adg
+adg
 aae
 aaa
 "}
@@ -97042,65 +98420,65 @@ abS
 abS
 abS
 abS
-nLp
+aeV
 ayW
+ach
+lKr
+nyj
+ads
+aat
+aii
+bgs
+bhh
+tbs
+aat
+vdP
+aat
+qlE
+cWu
+aae
+aae
+aae
+aae
+aae
+aaa
+aaa
+aaa
+aae
+aae
+aae
+bhh
+pxN
+nAB
+hNx
+aaI
+bhh
+bvv
+acT
+acv
+acv
+bhV
+aat
+aat
+aat
+aat
 ach
 acv
 acv
-ads
-aat
-aat
-aat
-amE
-adp
-aat
-aat
-anl
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bkj
 ads
 aat
 aat
 aat
 aat
 aat
-arz
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-arz
-buf
-aaI
-aaI
-arz
-buT
-buu
-bwq
-aaI
-bwJ
-arz
+aat
+aat
+aat
+aat
+aat
+aae
+aae
 aae
 aae
 aae
@@ -97305,62 +98683,62 @@ ach
 acv
 adr
 afj
-aaV
+aii
+bgs
+tbs
+tbs
 aat
 aat
-adN
-aQW
 aat
 aat
-anl
+oxj
+cWu
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+aae
+aae
+aae
+brd
+bhh
+bhh
+bhh
+brd
+bvv
 acv
 acv
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-bvT
-bvT
-bvT
-brV
-acv
-acv
-acv
+bhV
+aat
+aat
+bqC
+aat
+ach
 acv
 acv
 acv
 ads
-aat
-aat
-aat
-aat
-aat
-arz
-btG
-buu
-buB
-arz
-arz
 bvd
-arz
-buf
-buu
-aaI
-buW
-aaI
-buu
-bwr
-buu
-bwK
-arz
-arz
-arz
-arz
+bkm
+bkm
+bkm
+bkm
+bkm
+eKF
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (221,1,1) = {"
@@ -97465,7 +98843,7 @@ acV
 acV
 acV
 acV
-aHD
+acV
 acV
 acV
 acX
@@ -97520,7 +98898,7 @@ aat
 aat
 aat
 aat
-aat
+anY
 aat
 aat
 aat
@@ -97562,62 +98940,62 @@ afw
 acP
 afj
 aat
+ach
+bhh
+tbs
 aat
 aat
-amE
-adN
-aat
-aat
-bgK
+aii
+sKT
+afL
+afw
+fFu
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+aae
+aae
+bwW
+bhh
+bwW
+bhh
+aae
+acP
+acP
+acP
+acP
+acw
+acv
+acv
+hlw
+bgA
+bgA
+bgA
+bgA
 bgs
 acv
 acv
 acv
+ads
+bvf
+jbB
+acv
+jbB
 acv
 acv
-acv
-acv
-bsq
-bvT
-bvT
-afj
+bvX
 aat
 aat
-adp
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-acO
-acO
-acO
-acO
-acO
-arz
-aaI
-buu
-aaI
-arz
-buY
-bve
-arz
-buf
-buu
-aaI
-arz
-aaI
-buu
-bws
-aaI
-bwL
-arz
-brF
-bxp
-arz
+aat
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (222,1,1) = {"
@@ -97817,64 +99195,64 @@ aeV
 ayW
 aat
 aat
-aat
-aat
-aat
+aii
+acO
+bhh
 bgT
-aQW
-adp
+aSG
 aat
 aat
 anl
-bkj
 acv
+ael
+afL
+ach
 acv
-acv
-acv
-bsq
-bvT
-bvT
-afj
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+bhh
+gmY
+tQJ
+bhh
 aat
 aat
 aat
 aat
 aat
-amE
-anl
-acv
-acv
-acv
-acT
-acv
-bru
+ach
 acv
 acv
 acv
 acv
 acv
 acv
-arz
-btH
-buv
-aaI
-arz
-buZ
+acv
+acv
+acv
+acv
+acv
+hlw
 bvf
-arz
-buf
-buu
-aaI
-arz
-bvV
-aaI
-aaI
-buu
-aaI
-bxd
-bxk
-bxq
-arz
+acv
+acv
+acv
+acv
+bte
+bvX
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (223,1,1) = {"
@@ -98032,7 +99410,7 @@ aat
 aat
 aat
 aat
-ajt
+aat
 aat
 aat
 aat
@@ -98074,64 +99452,64 @@ aeV
 ayW
 aat
 aat
-aat
-aat
-aat
-aat
-adp
-adp
-aat
-bgK
-bgs
-acv
-acv
-acv
-acv
-bsq
-afj
-adp
+kFm
+bhh
+bhh
 bgT
 aat
-aaV
 aat
-bgK
-acO
-acO
-acO
-bgs
+alh
+anl
+acv
+acv
+ads
+afw
+acw
+aae
+aae
+aae
+aae
+bqd
+aae
+bqd
+aae
+bhh
+bIy
+xKT
+fvW
+aat
+aat
+ayJ
+aat
+bqC
+ach
+acv
+dPg
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+brV
+acv
+acv
+buj
 acv
 acv
 acv
 acv
-acv
-brv
-adq
-adq
-adq
-adq
-adq
-bsy
-arz
-arz
-arz
-buw
-arz
-arz
-arz
-arz
-buf
-aaI
-buB
-arz
-buT
-aaI
-bwt
-aaI
-bwR
-arz
-bxl
-bxr
-arz
+bte
+bvX
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (224,1,1) = {"
@@ -98328,67 +99706,67 @@ abS
 abT
 abS
 aeV
-aqz
+ayW
 aat
-aat
-aat
-aat
-bvS
-aat
-aQW
-bhy
-acO
+aii
 bgs
-acv
-acv
-acv
+tbs
+pYk
+bgL
+aat
+aat
+aat
+ktT
 acv
 acv
 ads
-adp
-adp
-bpg
-bpw
-bpw
-bqb
+aat
+afw
+bqd
+aae
+aae
+aae
+bqd
+aae
+bqd
+aae
+bhh
+bwW
+bwW
+bhh
+aat
+aat
+aat
+aat
+ayJ
+ach
+acv
+bhV
+efS
+bsS
+bsS
+rcg
+bsS
+bsS
+tUZ
 anl
 acv
+bsq
+wTT
 acv
 acv
 acv
 acv
-acv
-acv
-acv
-acv
-buj
-acv
-acv
-acv
-acv
-acv
-acv
-arz
-btI
-aaI
-aaI
-buu
-aaI
-aaI
-arz
-buf
-aaI
-aaI
-arz
+bte
 bvX
-aaI
-bwv
-aaI
-bwv
-arz
-arz
-arz
-arz
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 "}
 (225,1,1) = {"
@@ -98584,65 +99962,65 @@ abS
 abS
 abS
 ayb
-ayS
+aeV
 ayW
 aat
+jgC
+tbs
+tbs
 aat
 aat
-bgK
-acO
-acO
-bgs
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ads
-amE
 aat
-bpi
-bpy
-bpI
+aaV
+aat
+afw
+acP
+ozn
+afj
+aat
+aaV
 bqd
-anl
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bhh
+aat
+aat
+aat
+aat
+ach
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acR
-acv
-acv
-acv
+bhV
+bwx
 acv
 acv
 acv
 bsX
-btK
-aaI
-aaI
-aaI
-buu
-aaI
+acv
 buw
-buu
-aaI
-aaI
-bvJ
-aaI
-buu
-buu
-aaI
-aaI
-arz
+anl
+acv
+ads
+bvf
+jbB
+acv
+jbB
+acv
+acv
+bvX
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -98843,63 +100221,63 @@ abS
 ayb
 aeV
 ayW
-bgK
+aat
+afw
+afj
+aat
+aii
+acO
+acO
+afL
+aat
+aat
+aat
+aat
+aat
+aat
+aat
+anl
+bqx
+gED
+bqx
+bqx
+bqx
+gED
+bqx
+bqx
+bqx
+gED
+bqx
+bqx
+acO
+dVv
 acO
 acO
 bgs
 acv
+bhV
+bwx
 acv
 acv
 acv
 acv
 acv
-acv
-acv
-acv
-acv
-acv
-ads
-adN
-aat
-bpj
-bpy
-bpy
-bqd
+buw
 anl
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-brq
-acR
-brX
-acv
-acv
-acv
-acv
-acv
-bsY
-aaI
-buu
-buu
-aaI
-aaI
+ads
 buB
-arz
 buf
-aaI
-aaI
-bvJ
-aaI
-aaI
-bww
-buu
-bwS
-arz
+buf
+buf
+pxa
+bwW
+bwW
+bwW
+bhh
+bhh
+bhh
+aae
 aae
 aae
 aae
@@ -99100,63 +100478,63 @@ abS
 abS
 aeV
 ayW
+aat
+aat
+aat
+aat
 anl
 acv
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-aez
-adN
-amE
-bpi
-bpy
-bpH
-bqd
+ads
+aii
+acO
+acO
+afL
+aat
+aat
+aat
 anl
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
 acv
 acv
 acv
 acv
 acv
 acv
-acv
-acv
-brr
-acR
-brX
-acv
-acv
-acv
-acv
-acv
-bsY
-btX
-aaI
-aaI
-buT
-bva
-aaI
-arz
-buf
-aaI
-buu
-bvK
-aaI
-aaI
+bhV
 bwx
+acv
+acv
+acv
+acv
+acv
+buw
+anl
+acv
+ads
+aat
+aat
+aat
+aat
+ach
+bwW
+ook
 aaI
-bwU
-arz
+aaI
+bxc
+bhh
+aae
 aae
 aae
 aae
@@ -99357,63 +100735,63 @@ abS
 abS
 aeV
 ayW
+aat
+aat
+aat
+aat
 anl
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
+hBB
 acv
 ads
-adp
-adp
-bpj
-bpy
-bpy
-bqd
+anl
+cWu
+acv
+ads
+aat
+aat
+aii
+bgs
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+acv
+acv
+acv
+acv
+acv
+acv
+bhV
+bwx
+acv
+acv
+acv
+acv
+acv
+buw
 anl
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acR
-acv
-acv
-acv
-acv
-acv
-acv
-btj
-btY
+ads
+aat
+aat
+mxD
+aat
+ach
+bhh
+dgT
 aaI
-buC
-buT
-bvb
-buu
-arz
-buf
 aaI
-buu
-bvJ
-aaI
-buu
-bwy
-aaI
-bwV
-arz
+nsL
+bhh
+aae
 aae
 aae
 aae
@@ -99614,66 +100992,66 @@ abS
 abS
 aeV
 ayW
+aat
+aat
+aat
+aat
 anl
 acv
 acv
+ads
+anl
+cWu
+ouN
+ads
+aat
+aii
+acu
+acv
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
+bqx
 acv
 acv
 acv
 acv
 acv
 acv
+bhV
+bwx
+acv
+cKQ
 acv
 acv
 acv
-acv
-acv
-acv
-ael
-boz
-adp
-bpi
-bpy
-bpI
-bqd
+buw
 anl
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-buj
-acv
-acv
-acv
-acv
-acv
-acv
-arz
-bua
+ads
+aat
+oYM
+mWu
+cLJ
+ach
+bhh
+xsh
+nRU
 aaI
-buD
-buT
-aaI
-aaI
-arz
-buf
-aaI
-buB
-arz
-aaI
-aaI
-aaI
-aaI
-bwR
-arz
-arz
-arz
-arz
+bxc
+bhh
+aae
+aae
+aae
+aae
 aaa
 "}
 (230,1,1) = {"
@@ -99871,66 +101249,66 @@ abS
 ayb
 aeV
 ayW
+aat
+aii
+afL
+aat
 afw
-bvT
-bvT
-bvT
-bfL
-bvT
-aQW
-acT
+acP
+acP
+afj
+afw
+acP
+acP
+afj
+aat
+afw
+brV
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ads
-adp
-bpk
-bpA
-bpA
+bqx
 bqf
 bqx
+bqx
+bqx
+bqf
+bqx
+bqx
+bqx
+bqf
+bqx
+bqx
+acP
+ggy
+acP
+acP
+acP
+brV
+bhV
+bwx
+bsX
 acv
 acv
 acv
 acv
-acv
-acv
-acv
-acv
-acv
-brO
-adq
-adq
-adq
-adq
-adq
-bsy
-arz
-arz
 buw
-arz
-arz
-arz
-arz
-arz
-arz
-buu
+anl
+acv
+ads
+aat
+hYk
+tEU
+cvM
+ach
+bwW
+qSy
 aaI
-arz
-arz
-arz
-arz
-arz
-arz
-arz
-bxm
-bxs
-arz
+aaI
+bxc
+bhh
+aae
+aae
+aae
+aae
 aaa
 "}
 (231,1,1) = {"
@@ -100126,68 +101504,68 @@ abS
 abS
 abT
 ayb
-ayS
+aeV
 ayW
 aat
+jgC
+tbs
+tbs
 aat
 aat
 aat
-aat
-aat
-aQW
-adp
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-acO
-bpl
-afL
 aaV
 aat
-afw
-bvT
-bvT
-brV
-acv
-acv
-acv
-acv
-acT
-acv
-bru
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
+aat
+aat
+aat
+aPQ
+aat
+cwR
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bqd
+bhh
+qzw
+aat
+aat
+aat
+aat
+ach
+bhV
+eLz
+app
+app
+uMU
+app
+app
+mFu
+anl
 acv
 ads
-buU
-buU
-arz
+ayJ
 bvn
-bvn
+wBy
+oJK
+ach
+bwW
+hmD
 aaI
 aaI
-bvL
-arz
-bwh
-aaI
-buu
-aaI
-bxe
-bxm
-bxt
-arz
+bxc
+bhh
+aae
+aae
+aae
+aae
 aaa
 "}
 (232,1,1) = {"
@@ -100384,67 +101762,67 @@ abS
 abS
 abS
 aeV
-aqz
+ayW
 aat
-aat
-aat
-aat
-aat
-bgT
-amE
-adp
 afw
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
+acw
+tbs
+nUL
 afL
 aat
 aat
 aat
-aat
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
-afj
+aii
+acO
+acO
+afL
 aat
 aat
-arz
-bvo
-buT
-aaI
-aaI
-aaI
-arz
-bwh
-aaI
-buu
+bqd
+aae
+aae
+aae
+bqd
+aae
+bqd
+bhh
+fcy
+lbZ
+nmE
+xKT
+ykD
+tme
+bgA
+bgA
+bgA
+bgA
+bgs
+hlw
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+glq
+acv
+ads
+aat
+aat
+bvS
+aat
+ach
 bwW
-arz
-bxn
-bxu
-arz
+bwW
+bwW
+aaI
+aaI
+bwW
+bwW
+aae
+aae
+aae
 aaa
 "}
 (233,1,1) = {"
@@ -100644,64 +102022,64 @@ aeV
 ayW
 aat
 aat
+pim
+bhh
+bhh
+bgT
 aat
 aat
-aat
-aat
-amE
-adN
-aQW
-afw
-bvT
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-acO
-acO
-acO
-acO
-bgs
-acv
-acv
-acv
-acv
+alh
+anl
 acv
 acv
 ads
 aat
+ubX
+aae
+aae
+aae
+aae
+bqd
+aae
+bqd
+mlo
+xKT
+xKT
+xKT
+xKT
+ktI
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+acv
+hlw
+bgA
+afL
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-arz
-bvr
-bvr
-aaI
-buu
-bvM
-bvZ
-aaI
-aaI
+ayJ
+ach
+acv
+acv
+bhh
+bvC
 aaI
 bwX
-arz
-bxm
-bxv
-arz
+bwW
+aae
+aae
+aae
 aaa
 "}
 (234,1,1) = {"
@@ -100901,64 +102279,64 @@ aeV
 ayW
 aat
 aat
+afw
+acw
+bhh
+bgT
 aat
 aat
-aat
-aaV
-aat
-amE
-adN
-adp
 aat
 anl
-bkj
+hBB
 acv
+ads
+aat
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+bhh
+mVJ
+xKT
+xKT
+xKT
+uin
+brd
+bwW
+xKT
+xKT
+xKT
+brd
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
+bsq
+acP
+acP
+acP
+acP
+acP
+acP
+acP
+acw
 acv
 acv
 acv
 ads
 aat
 aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-arz
+ach
+acv
+acv
+bvx
 aaI
-buu
-aaI
-aaI
-bvM
-bwa
-aaI
-buu
 aaI
 bwY
-arz
-arz
-arz
-arz
+bwW
+aae
+aae
+aae
 aaa
 "}
 (235,1,1) = {"
@@ -101159,60 +102537,60 @@ ayW
 aat
 bqC
 aat
-aat
-aat
-aat
-aat
-aQW
-aQW
-adp
-aQW
 afw
-bvT
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-acO
-afL
+acw
+bhh
+tbs
+aSG
 aat
-bgK
-acO
-acO
-acO
-bub
+anl
+acv
+acv
+ads
+aat
+aae
+aae
+aae
+aae
+aae
+aaa
+aae
+bhh
+lCd
+xKT
+xKT
+xKT
+cKk
+brd
+bwW
+mwk
+xKT
+xKT
+xKT
+acv
+bhV
+aat
+ayt
 aat
 aat
+ayJ
 aat
 aat
-arz
-bvn
-bvn
+ach
+acv
+acv
+acv
+hlw
+bgA
+bgA
+acu
+acv
+acv
+bhh
 aaI
-aaI
-bvN
-bvZ
-buu
-buu
 aaI
 bwZ
-arz
+bhh
 aae
 aae
 aae
@@ -101417,59 +102795,59 @@ aat
 aat
 aat
 aat
+afw
+acw
+tbs
+tbs
 aat
-aat
-aat
-aQW
+afw
+acP
+acP
+afj
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
-aQW
-aat
-aat
-bkX
-bvT
-bvT
-brV
+bwW
+mVY
+xKT
+xKT
+xKT
+xMN
+bhh
+bwW
+xKT
+xKT
+xKT
+xKT
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-bkj
-ael
-acO
+hlw
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
+bgA
 bgs
 acv
 acv
 acv
-ael
-acO
-acO
-afL
-aat
-arz
-bvo
-buT
-aaI
-buu
-bvM
-bvZ
-aaI
-aaI
-buu
-bxa
-arz
+acv
+acv
+acv
+acv
+acv
+acT
+bhh
+bhh
+bhh
+bhh
+bhh
 aae
 aae
 aae
@@ -101675,20 +103053,41 @@ aat
 aat
 aat
 aat
+afw
+acw
+bhh
+tbs
+aat
+vdP
 aat
 aat
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
 aae
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-brV
+aae
+bhh
+eZU
+gQS
+xKT
+pwM
+bhh
+bwW
+uwd
+xKT
+xKT
+xKT
+acv
+acv
+acv
+acv
+acv
+acv
+acv
 acv
 acv
 acv
@@ -101701,32 +103100,11 @@ bvT
 brV
 acv
 acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-afL
-arz
-bvr
-bvr
-aaI
-aaI
-aaI
-arz
-aaI
+xYe
 aaI
 aaI
 bxb
-arz
+bwW
 aae
 aae
 aae
@@ -101933,57 +103311,57 @@ aat
 aat
 aat
 aat
-aat
+afw
+acw
+tbs
+tbs
+amE
+amE
+amE
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
 aae
 aae
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-anl
-acT
+aae
+bwW
+bhh
+aae
+bhh
+brd
+bhh
+lJP
+xKT
+ucI
+bhh
+bhh
+bwW
+bvO
+bvO
+bvO
+vpE
+bwW
+bwW
+adr
+acP
+acP
+acw
+acv
+ads
+aGP
+aii
+acu
 acv
 acv
-acv
-acv
-acv
-bqG
-adp
-adp
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-ael
-arz
-arz
-arz
-buW
-arz
-arz
-arz
-arz
-buW
-arz
-arz
-arz
+bwW
+aaI
+aaI
+jsS
+bwW
 aae
 aae
 aae
@@ -102191,56 +103569,56 @@ aat
 aat
 aat
 aat
+afw
+acw
+bhh
+bhh
+fHG
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
 aae
 aae
 aae
-aeS
-axn
-aeS
-axb
-axb
-axb
-axn
-acv
-acv
-acv
-acv
-acv
-acv
-bqH
-amE
-adN
-afw
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
 aae
+aae
+aae
+ajX
+bwW
+bhh
+bhh
+nDM
+bwW
+bwW
+tiY
+bwY
+aaI
+aaI
+unv
+aaI
+kra
+bhh
+sfA
+ady
+ady
+gyA
+kMK
+uTu
+ady
+gyA
+bhh
+bwW
+bwW
+bwW
+bvC
+aaI
+dZg
+bhh
 aae
 aae
 aae
@@ -102448,56 +103826,56 @@ acO
 acO
 afL
 aat
+aat
+afw
+acP
+bhh
+kcv
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aaa
-aaa
 aae
 aae
-bkC
-adH
-aeV
-afF
-bAq
-afF
-adH
-acv
-aTD
-aTD
-acv
-acv
-acv
-bqH
-amE
-amE
-bgT
+aae
+aae
+aae
+ajX
+byL
+djD
+qhU
 bpC
-acv
-acv
-acv
-acv
-acv
-acv
-bsq
-bvT
-bvT
-brV
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-acv
-aae
+rrE
+ajX
+bhh
+gKR
+aaI
+aaI
+aaI
+aaI
+aaI
+qTn
+bhh
+qPk
+npX
+rgf
+gpH
+bvv
+pHG
+ntt
+xbm
+bhh
+uAX
+aaI
+aaI
+aaI
+aaI
+aaI
+bwW
 aae
 aae
 aae
@@ -102705,56 +104083,56 @@ aVn
 acv
 ael
 afL
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-aeV
-adH
-aeV
-afF
-afF
-afF
-adH
-acv
-acv
-acv
-aTD
-aTD
-acv
-ads
-aat
-amE
-adp
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-afw
-brV
-acv
-acv
-acv
-acT
-bhh
-bhw
-bhh
-aaI
-aaI
-aaI
-bhh
-bhw
-bhw
-bhh
-bhh
 aae
+aae
+aae
+ajX
+koI
+rrE
+rrE
+rrE
+rrE
+ajX
+bhh
+bvO
+bvO
+hxV
+epC
+aaI
+aaI
+jXp
+bhh
+qPG
+mtC
+mtC
+shd
+bvv
+mwO
+xkj
+shd
+bhh
+uAX
+aaI
+aaI
+bwA
+bwA
+bwA
+bhh
 aae
 aae
 aae
@@ -102962,56 +104340,56 @@ acv
 acv
 bhb
 ads
+aat
+aat
+aat
+bqC
+aat
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-bkC
-adH
-aeV
-afF
-afF
-afF
-adH
-acv
-acv
-acv
-acv
-acv
-bsq
-afj
-aat
-adp
-aat
-anl
-acv
-acv
-acv
-acv
-acv
-acv
-aez
-aat
-aat
-aat
-anl
-acv
-acv
-acv
-acv
+aae
+aae
+aae
+ajX
+bzg
+rrE
+rrE
+rrE
+rrE
+ahz
+aae
 bhh
-bvs
+bwW
+bhh
+bhh
+bvC
+aaI
+aaI
+eqX
 bvv
+bvv
+bvv
+bvv
+bvv
+bvv
+bvv
+vca
+bhh
+poH
 aaI
 aaI
-aaI
-aaI
-bwl
-bwz
+bwA
 bwF
 bxc
-aae
+bwW
 aae
 aae
 aae
@@ -103214,61 +104592,61 @@ aeV
 ayW
 anl
 acv
-acv
+cnp
 acv
 afd
 acv
 ads
+aat
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-aeV
-adH
-aeV
-afF
-afF
-afF
-adH
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-adN
-aat
-brj
-acv
-acv
-bsq
-brV
-acv
-acv
-ads
-aat
-aat
-aat
-anl
-bkj
-acv
-acv
-acv
-aaI
-aaI
-aaI
-aaI
-buu
-aaI
-aaI
-aaI
-buu
-aaI
-buu
 aae
+aae
+aae
+ajX
+gPo
+bCL
+bCL
+brj
+ajX
+ajX
+aae
+aae
+aae
+aae
+bhh
+sQm
+fYc
+fYc
+bwW
+bkj
+bvv
+bvv
+bvv
+bvv
+bvv
+bvv
+bvv
+bwW
+vPH
+aaI
+aaI
+brW
+lEX
+nGh
+bhh
 aae
 aae
 aae
@@ -103467,65 +104845,65 @@ abS
 abS
 abS
 abS
-nLp
+aeV
 ayW
 anl
 acv
 acv
 acv
 acv
-acv
+nyj
 ads
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-bkD
-adH
-aeV
-afF
-afF
-afF
-adH
-acv
-acv
-acv
-acv
-acv
-ads
-aat
-aat
-adN
-bgK
-bgs
-acv
-acv
-ads
-anl
-acv
-acv
-ael
-aat
-bgT
-aat
-anl
-acv
-acv
-acv
-acv
+aae
+aae
+aae
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
+aae
+aae
+aae
+aae
+aae
+aae
+bwW
+bwW
+bhh
+bhh
+bvi
+bvv
+jEc
+bvv
+mjl
+bvv
+bvi
+bwW
+bwW
+uAX
 aaI
 aaI
-buu
-aaI
-aaI
-aaI
-buu
-aaI
-aaI
-aaI
-aaI
-aaI
+bwA
+bwA
+bwA
+bhh
 aae
 aae
 aae
@@ -103733,56 +105111,56 @@ acP
 acP
 acP
 afj
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-aeV
-adH
-aeV
-ais
-afF
-afF
-adH
-acv
-bpX
-acv
-acv
-acv
-ads
-aat
-aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 bhh
-bhh
-aaI
-aaI
-aaI
-bhw
-bhh
-aaI
-aaI
-aaI
-bhh
-bhh
-bhh
-bhh
-bhw
-bhw
-bhh
-acv
-bhh
-bpZ
-aaI
+buW
+bvv
+buW
+bvv
+buW
+bvv
+bvv
 bvx
-bhw
-brW
-bwb
-brW
-brW
-bhh
-buu
 aaI
+aaI
+aaI
+aaI
+brW
+rXw
+nJA
+bhh
 aae
 aae
 aae
@@ -103990,58 +105368,58 @@ ayt
 aat
 aat
 aat
+aat
+aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-bkD
-adH
-aeV
-afF
-afF
-afF
-adH
-bpB
-acv
-acv
-bpX
-acv
-ads
-aat
-aat
-bhh
-aaI
-aaI
-aaI
-aaI
-brQ
-aaI
-aaI
-aaI
-aaI
-aaI
-brQ
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 btk
-btl
-bux
-brQ
+btk
+nXn
 buW
-acv
-aaI
-aaI
-aaI
-bvz
-bvH
+bvv
+buW
+dxy
+buW
+bvv
+buW
+bhh
+bvO
 bvO
 bwc
-bwc
+nAB
 bwA
-bvH
-aaI
-aaI
-bqF
-bhh
+rXw
+bxc
+bwW
+aae
+aae
 aae
 aaa
 "}
@@ -104247,57 +105625,57 @@ aat
 aat
 aat
 aat
+aat
+aat
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
 aae
 aae
-bkR
-ajT
-aeV
-afF
-afF
-afF
-adH
-bpC
-acv
-acv
-acv
-bqz
-bqD
-aat
-aat
-bhw
-bpZ
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
-aaI
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+btl
+btl
+rTx
+nXn
 buW
-acv
-aaI
-aaI
-buu
-aaI
-brx
-axU
-bwc
-bwc
-bvQ
-brx
-aaI
-buu
-aaI
+bvv
+buW
+bvv
+buW
+bvv
+buW
+bhh
+bhh
+bhh
+bhh
+bhh
+bhh
+bhh
+bhh
+bwW
+aae
 aae
 aae
 aaa
@@ -104506,55 +105884,55 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
 aae
 aae
-aeV
-afF
-aWs
-afF
-adH
-anl
-acv
-acv
-acv
-ads
-aat
-aat
-aat
-bhh
-bhw
-bhh
-buw
-bhh
-bhw
-brh
-brm
-brh
-bhh
-bhh
-aaI
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+btl
+btl
 btl
 bud
-aaI
-buE
-bhh
-acv
-bhh
-buu
-aaI
-aaI
-bhw
-bvP
-bwc
-bwc
-bwB
-bvH
-aaI
-buu
-aaI
+btl
+bvv
+buW
+bvv
+buW
+bvv
+buW
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
@@ -104763,55 +106141,55 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
 aae
 aae
-aeX
-acG
-acG
-acG
-ajT
-afw
-bvT
-brV
-acv
-ads
-aat
-aat
-aat
-bhh
-woN
-aaI
-aaI
-kwf
-bhh
-aaI
-aaI
-aaI
-aaI
-bhw
-aaI
-aaI
-aaI
-aaI
-buF
-bhw
-adq
-bhh
-aaI
-buu
-aaI
-bvH
-bvQ
-bwc
-bwc
-bwB
-bhw
-aaI
-aaI
-aaI
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+rTx
+btl
+aae
+aae
+aae
+aae
+bvv
+buW
+bvv
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
@@ -105020,55 +106398,55 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
 aae
 aae
-aat
-aat
-aat
-aat
-aat
-aat
-aat
-afw
-bvT
-afj
-aat
-aat
-aat
-bhw
-qtR
-aaI
-aaI
-brp
-bhh
-aaI
-aaI
-aaI
-bsw
-bhh
-aaI
-btn
-bue
-buy
-buG
-bhw
-acv
-bhw
-bpZ
-aaI
-buu
-bvH
-axU
-axU
-bwm
-axU
-bhw
-aaI
-aaI
-aaI
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
@@ -105277,6 +106655,16 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
@@ -105290,42 +106678,32 @@ aae
 aae
 aae
 aae
-aat
-aat
-aat
-aat
-aat
-bhh
-bri
-fJF
-aaI
-sWl
-bhh
-brY
-aaI
-aaI
-asv
-bhw
-bsA
-bhw
-aaI
-aaI
-buR
-bhh
-acv
-bhw
-aaI
-aaI
-aaI
-bhw
-axU
-axU
-axU
-axU
-bhw
-aaI
-bxf
-bhh
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aaa
@@ -105534,6 +106912,16 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
@@ -105552,36 +106940,26 @@ aae
 aae
 aae
 aae
-ahz
-ahz
-ajX
-ajX
-ahz
-ajX
-ahz
-aae
-aae
-bhh
-brQ
-aaI
-bhh
-aaI
-aaI
-aaI
-asv
 aae
 aae
 aae
-bhh
-aaI
-bhh
-brW
-bwb
-brW
-brW
-bhh
-aaI
-aaI
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -105791,6 +107169,16 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
@@ -105818,27 +107206,17 @@ aae
 aae
 aae
 aae
-bhw
-bsx
-bsT
-bhw
-buf
-buf
-buf
-bhh
 aae
 aae
 aae
 aae
-aaI
-aaI
-aaI
-aaI
-buu
-aaI
-aaI
-bsu
-aaI
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aae
 aae
 aae
@@ -106048,6 +107426,16 @@ aae
 aae
 aae
 aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
 aae
 aae
@@ -106075,14 +107463,6 @@ aae
 aae
 aae
 aae
-bhh
-bhh
-asv
-bhh
-asv
-bhh
-asv
-asv
 aae
 aae
 aae
@@ -106093,8 +107473,6 @@ aae
 aae
 aae
 aae
-aae
-bhh
 aae
 aae
 aae
@@ -108007,7 +109385,7 @@ aae
 aae
 aae
 abP
-arj
+mhm
 bLA
 alc
 alc


### PR DESCRIPTION
Replaces the faction bases on Pahrump, brings back some old areas and updates mobs to make looting certain locations harder.

NCR base + Old town that was below it re-added to replace the empty void of tribal town.

https://i.imgur.com/pGQRF1n.png

https://i.imgur.com/wGd0jlh.png

Updated Prior Legion Camp

https://i.imgur.com/QK9yKN2.png

Made it so to access workbench you don't have to break into shop. Also, made it so settlers don't potentially spawn outside into hazardous weather.

https://i.imgur.com/cVqMToi.png

Buffed certain areas with mobs dependent on loot level.

Minor note: While unchanged, I noticed that radiation is actually something caused by area. 