### PR TITLE
Add oxygen tanks for Legion on Pahrump

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump.dmm
+++ b/_maps/map_files/Pahrump/Pahrump.dmm
@@ -40465,6 +40465,15 @@
 	tag = "icon-dirtcorner (EAST)"
 	},
 /area/f13/wasteland)
+"lNZ" = (
+/obj/structure/closet/cabinet,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/f13/wood,
+/area/f13/legion)
 "lRH" = (
 /obj/structure/decoration/clock/old{
 	pixel_x = -32
@@ -97937,7 +97946,7 @@ bhh
 brf
 aaI
 aaI
-bwX
+lNZ
 brd
 bvv
 acv


### PR DESCRIPTION
## Description
Oxygen tanks in Centurion's cabin

## Motivation and Context
So that the powerfist can work.
## How Has This Been Tested?
local machine.

## Changelog (necessary)
:cl:
add: Add oxygen tanks in Centurion cabin
/:cl:
